### PR TITLE
WIP: introduce communities and community_users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,7 +50,7 @@ class ApplicationController < ActionController::Base
     RequestContext.clear!
 
     host_name = request.raw_host_with_port   # include port to support multiple localhost instances
-    RequestContext.community = @community = Rails.cache.fetch("#{host_name}/community") do
+    RequestContext.community = @community = Rails.cache.fetch("#{host_name}/community", expires_in: 1.hour) do
       Community.find_by(host: host_name)
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,7 +50,7 @@ class ApplicationController < ActionController::Base
     RequestContext.clear!
 
     host_name = request.raw_host_with_port   # include port to support multiple localhost instances
-    RequestContext.community = @community = Rails.cache.fetch("#{host_name}/community", expires_in: 30.minutes) do
+    RequestContext.community = @community = Rails.cache.fetch("#{host_name}/community") do
       Community.find_by(host: host_name)
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,10 +47,19 @@ class ApplicationController < ActionController::Base
   private
 
   def set_globals
+    RequestContext.clear!
+
+    host_name = request.raw_host_with_port   # include port to support multiple localhost instances
+    RequestContext.community = @community = Rails.cache.fetch("#{host_name}/community", expires_in: 30.minutes) do
+      Community.find_by(host: host_name)
+    end
+
     if current_user.nil?
       Rails.logger.info 'No user signed in'
     else
       Rails.logger.info "User #{current_user.id} (#{current_user.username}) signed in"
+      RequestContext.user = current_user
+      current_user.ensure_community_user!
     end
 
     @hot_questions = Rails.cache.fetch("hot_questions", expires_in: 30.minutes) do

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ require 'net/http'
 class UsersController < ApplicationController
   before_action :authenticate_user!, only: [:edit_profile, :update_profile, :stack_redirect, :transfer_se_content]
   before_action :verify_moderator, only: [:mod, :destroy, :soft_delete]
-  before_action :set_user, only: [:mod, :destroy, :soft_delete, :posts]
+  before_action :set_user, only: [:show, :mod, :destroy, :soft_delete, :posts]
 
   def index
     sort_param = {reputation: :reputation, age: :created_at}[params[:sort]&.to_sym] || :reputation
@@ -15,7 +15,6 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = user_scope.find params[:id]
   end
 
   def posts
@@ -151,7 +150,8 @@ class UsersController < ApplicationController
   private
 
   def set_user
-    @user = user_scope.find params[:id]
+    @user = user_scope.find_by(id: params[:id])
+    not_found if @user.nil?
   end
 
   def user_scope

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,14 +8,14 @@ class UsersController < ApplicationController
   def index
     sort_param = {reputation: :reputation, age: :created_at}[params[:sort]&.to_sym] || :reputation
     @users = if params[:search].present?
-               User.where('username LIKE ?', "#{params[:search]}%")
+               user_scope.where('username LIKE ?', "#{params[:search]}%")
              else
-               User.all.order(sort_param => :desc)
+               user_scope.order(sort_param => :desc)
              end.list_includes.paginate(page: params[:page], per_page: 48)
   end
 
   def show
-    @user = User.find params[:id]
+    @user = user_scope.find params[:id]
   end
 
   def posts
@@ -130,7 +130,7 @@ class UsersController < ApplicationController
       redirect_to edit_user_profile_path and return
     end
 
-    auto_user = User.where(se_acct_id: current_user.se_acct_id).where.not(id: current_user.id).first
+    auto_user = user_scope.where(se_acct_id: current_user.se_acct_id).where.not(id: current_user.id).first
     if auto_user.nil?
       flash[:warning] = "There doesn't appear to be any of your content here."
       redirect_to edit_user_profile_path and return
@@ -151,6 +151,10 @@ class UsersController < ApplicationController
   private
 
   def set_user
-    @user = User.find params[:id]
+    @user = user_scope.find params[:id]
+  end
+
+  def user_scope
+    User.joins(:community_user)
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,9 +1,10 @@
 # Represents a comment. Comments are attached to both a post and a user.
 class Comment < ApplicationRecord
+  include PostRelated
+
   scope :deleted, -> { where(deleted: true) }
   scope :undeleted, -> { where(deleted: false) }
 
-  belongs_to :post
   belongs_to :user
   has_one :parent_question, through: :post, source: :parent, class_name: 'Question'
 

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -1,0 +1,4 @@
+class Community < ApplicationRecord
+  has_many :community_users
+
+end

--- a/app/models/community_user.rb
+++ b/app/models/community_user.rb
@@ -1,0 +1,6 @@
+class CommunityUser < ApplicationRecord
+  belongs_to :community
+  belongs_to :user
+
+  scope :for_context, ->{ where(community_id: RequestContext.community_id) }
+end

--- a/app/models/concerns/community_related.rb
+++ b/app/models/concerns/community_related.rb
@@ -1,0 +1,8 @@
+module CommunityRelated
+  extend ActiveSupport::Concern
+
+  included do
+    belongs_to :community
+    default_scope { where(community_id: RequestContext.community_id) }
+  end
+end

--- a/app/models/concerns/post_related.rb
+++ b/app/models/concerns/post_related.rb
@@ -1,0 +1,8 @@
+module PostRelated
+  extend ActiveSupport::Concern
+  include CommunityRelated
+
+  included do
+    belongs_to :post
+  end
+end

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -1,6 +1,6 @@
 # Represents a flag. Flags are attached to both a user and a post, and have a single status.
 class Flag < ApplicationRecord
-  belongs_to :post
+  include PostRelated
   belongs_to :user
   belongs_to :handled_by, class_name: 'User', required: false
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,3 +1,4 @@
 class Notification < ApplicationRecord
+  include CommunityRelated
   belongs_to :user
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,6 @@
 class Post < ApplicationRecord
+  include CommunityRelated
+
   belongs_to :user
   belongs_to :post_type
   belongs_to :parent, class_name: 'Post', required: false, counter_cache: :answer_count

--- a/app/models/post_history.rb
+++ b/app/models/post_history.rb
@@ -1,7 +1,7 @@
 class PostHistory < ApplicationRecord
+  include PostRelated
   belongs_to :post_history_type
   belongs_to :user
-  belongs_to :post
 
   def self.method_missing(name, *args, **opts, &block)
     unless args.length >= 2

--- a/app/models/privilege.rb
+++ b/app/models/privilege.rb
@@ -3,6 +3,8 @@
 # there's a backup rep check, but the privilege is not added to the user's privilege collection until they've been
 # checked for it at least once.
 class Privilege < ApplicationRecord
+  include CommunityRelated
+
   has_and_belongs_to_many :users
 
   validates :name, uniqueness: true

--- a/app/models/request_context.rb
+++ b/app/models/request_context.rb
@@ -1,0 +1,25 @@
+class RequestContext
+  class << self
+    def fetch
+      Thread.current[:context] || clear!
+    end
+
+    def clear!
+      Thread.current[:context] = {}
+    end
+
+    %i(user community).each do |field|
+      define_method "#{field}=" do |value|
+        fetch[field] = value
+      end
+
+      define_method field do
+        fetch[field]
+      end
+
+      define_method "#{field}_id" do
+        fetch[field]&.id
+      end
+    end
+  end
+end

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -6,7 +6,7 @@ class SiteSetting < ApplicationRecord
 
   scope :for_community_id, ->(community_id){ where(community_id: community_id) }
   scope :global, ->{ for_community_id(nil) }
-  scope :priority_order, -> { order(Arel::Nodes::Case.new.when(arel_table[:community_id].eq(nil), 1).else(0)) }
+  scope :priority_order, -> { order(Arel.sql('IF(site_settings.community_id IS NULL, 1, 0)')) }
 
   validates :name, uniqueness: true
 

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -1,6 +1,13 @@
 # Represents a site setting. Site settings control the operation and display of most aspects of the site, such as
 # reputation awards, additional content, and site constants such as name and logo.
 class SiteSetting < ApplicationRecord
+  belongs_to :community
+  default_scope { for_community_id(RequestContext.community_id).or(global).priority_order }
+
+  scope :for_community_id, ->(community_id){ where(community_id: community_id) }
+  scope :global, ->{ for_community_id(nil) }
+  scope :priority_order, -> { order(Arel::Nodes::Case.new.when(arel_table[:community_id].eq(nil), 1).else(0)) }
+
   validates :name, uniqueness: true
 
   def self.[](name)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,6 +1,8 @@
 class Subscription < ApplicationRecord
   self.inheritance_column = 'sti_type'
 
+  include CommunityRelated
+
   belongs_to :user
 
   validates :type, presence: true, inclusion: ['all', 'tag', 'user', 'interesting']

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,5 @@
 class Tag < ApplicationRecord
+  include CommunityRelated
+
   has_and_belongs_to_many :posts
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ApplicationRecord
   validates :username, presence: true, length: { minimum: 3 }
   validate :username_not_fake_admin
 
-  delegate :reputation, :reputation=, :is_moderator, :is_admin, to: :community_user
+  delegate :reputation, :reputation=, to: :community_user
 
   def self.list_includes
     includes(:posts, :avatar_attachment)
@@ -63,6 +63,14 @@ class User < ApplicationRecord
 
   def website_domain
     website.nil? ? website : URI.parse(website).hostname
+  end
+
+  def is_moderator
+    is_global_moderator || community_user&.is_moderator
+  end
+
+  def is_admin
+    is_global_admin || community_user&.is_admin
   end
 
   def username_not_fake_admin

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,11 +66,11 @@ class User < ApplicationRecord
   end
 
   def is_moderator
-    is_global_moderator || community_user&.is_moderator
+    !!(is_global_moderator || community_user&.is_moderator)
   end
 
   def is_admin
-    is_global_admin || community_user&.is_admin
+    !!(is_global_admin || community_user&.is_admin)
   end
 
   def username_not_fake_admin

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -1,7 +1,7 @@
 # Represents a vote. A vote is attached to both a 'post' (i.e. a question or an answer - this is a polymorphic
 # association), and to a user.
 class Vote < ApplicationRecord
-  belongs_to :post, required: true
+  include PostRelated
   belongs_to :user, required: true
   belongs_to :recv_user, class_name: 'User', required: true
 

--- a/db/migrate/20200202052500_create_communities_table.rb
+++ b/db/migrate/20200202052500_create_communities_table.rb
@@ -1,0 +1,68 @@
+class CreateCommunitiesTable < ActiveRecord::Migration[5.2]
+  # helper User model without delegation for migration purposes
+  class MigrationSafeUser < ActiveRecord::Base; self.table_name = 'users'; end
+
+  def change
+    create_table :communities do |t|
+      t.string :name, null: false
+      t.string :host, null: false, index: true
+      t.timestamps
+    end
+
+    create_table :community_users do |t|
+      t.references :community, null: false, foreign_key: true, index: true
+      t.references :user, null: false, foreign_key: true, index: true
+      t.boolean :is_moderator
+      t.boolean :is_admin
+      t.integer :reputation
+      t.timestamps
+    end
+
+    reversible do |dir|
+      dir.up do
+        @community = Community.create(name: 'Sample', host: 'sample.qpixel.com')
+        community_users = MigrationSafeUser.pluck(:id, :is_admin, :is_moderator, :reputation).map do |user_id, is_admin, is_moderator, reputation|
+          {community_id: @community.id, user_id: user_id, is_admin: is_admin, is_moderator: is_moderator, reputation: reputation}
+        end
+        CommunityUser.create(community_users)
+        change_table :users do |t|
+          t.remove :is_moderator
+          t.remove :is_admin
+          t.remove :reputation
+        end
+      end
+      dir.down do
+        change_table :users do |t|
+          t.boolean :is_moderator, after: 'updated_at'
+          t.boolean :is_admin, after: 'is_moderator'
+          t.integer :reputation, after: 'is_admin'
+        end
+        @community = Community.first
+        CommunityUser.unscoped.where(community_id: @community.id).pluck(:user_id, :is_admin, :is_moderator, :reputation).map do |user_id, is_admin, is_moderator, reputation|
+          attrs = {is_admin: is_admin, is_moderator: is_moderator, reputation: reputation}
+          MigrationSafeUser.find(user_id).update(attrs)
+        end
+      end
+    end
+
+    %i(posts comments flags post_histories votes
+       notifications privileges site_settings subscriptions tags
+      ).each do |table|
+      change_table table do |t|
+        t.references :community
+      end
+
+      unless table == :site_settings
+        reversible do |dir|
+          dir.up do
+            table.to_s.classify.constantize.unscoped.update_all(community_id: @community.id)
+          end
+        end
+
+        change_column_null table, :community_id, false
+      end
+
+      add_foreign_key table, :communities
+    end
+  end
+end

--- a/db/migrate/20200202052500_create_communities_table.rb
+++ b/db/migrate/20200202052500_create_communities_table.rb
@@ -21,26 +21,25 @@ class CreateCommunitiesTable < ActiveRecord::Migration[5.2]
     reversible do |dir|
       dir.up do
         @community = Community.create(name: 'Sample', host: 'sample.qpixel.com')
-        community_users = MigrationSafeUser.pluck(:id, :is_admin, :is_moderator, :reputation).map do |user_id, is_admin, is_moderator, reputation|
-          {community_id: @community.id, user_id: user_id, is_admin: is_admin, is_moderator: is_moderator, reputation: reputation}
+        community_users = MigrationSafeUser.pluck(:id, :reputation).map do |user_id, reputation|
+          {community_id: @community.id, user_id: user_id, reputation: reputation}
         end
         CommunityUser.create(community_users)
         change_table :users do |t|
-          t.remove :is_moderator
-          t.remove :is_admin
+          t.rename :is_moderator, :is_global_moderator
+          t.rename :is_admin, :is_global_admin
           t.remove :reputation
         end
       end
       dir.down do
         change_table :users do |t|
-          t.boolean :is_moderator, after: 'updated_at'
-          t.boolean :is_admin, after: 'is_moderator'
+          t.rename :is_global_moderator, :is_moderator
+          t.rename :is_global_admin, :is_admin
           t.integer :reputation, after: 'is_admin'
         end
         @community = Community.first
-        CommunityUser.unscoped.where(community_id: @community.id).pluck(:user_id, :is_admin, :is_moderator, :reputation).map do |user_id, is_admin, is_moderator, reputation|
-          attrs = {is_admin: is_admin, is_moderator: is_moderator, reputation: reputation}
-          MigrationSafeUser.find(user_id).update(attrs)
+        CommunityUser.where(community_id: @community.id).pluck(:user_id,:reputation).map do |user_id, reputation|
+          MigrationSafeUser.find(user_id).update(reputation: reputation)
         end
       end
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_28_123353) do
+ActiveRecord::Schema.define(version: 2020_02_02_052500) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -40,8 +40,30 @@ ActiveRecord::Schema.define(version: 2020_01_28_123353) do
     t.text "content"
     t.boolean "deleted", default: false
     t.integer "user_id"
+    t.bigint "community_id", null: false
+    t.index ["community_id"], name: "index_comments_on_community_id"
     t.index ["post_id"], name: "index_comments_on_post_type_and_post_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "communities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "host", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["host"], name: "index_communities_on_host"
+  end
+
+  create_table "community_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "community_id", null: false
+    t.bigint "user_id", null: false
+    t.boolean "is_moderator"
+    t.boolean "is_admin"
+    t.integer "reputation"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["community_id"], name: "index_community_users_on_community_id"
+    t.index ["user_id"], name: "index_community_users_on_user_id"
   end
 
   create_table "flags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
@@ -54,6 +76,8 @@ ActiveRecord::Schema.define(version: 2020_01_28_123353) do
     t.text "message"
     t.integer "handled_by_id"
     t.datetime "handled_at"
+    t.bigint "community_id", null: false
+    t.index ["community_id"], name: "index_flags_on_community_id"
     t.index ["post_id"], name: "index_flags_on_post_type_and_post_id"
     t.index ["user_id"], name: "index_flags_on_user_id"
   end
@@ -65,6 +89,8 @@ ActiveRecord::Schema.define(version: 2020_01_28_123353) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"
+    t.bigint "community_id", null: false
+    t.index ["community_id"], name: "index_notifications_on_community_id"
     t.index ["user_id"], name: "index_notifications_on_user_id"
   end
 
@@ -77,6 +103,8 @@ ActiveRecord::Schema.define(version: 2020_01_28_123353) do
     t.text "before_state"
     t.text "after_state"
     t.text "comment"
+    t.bigint "community_id", null: false
+    t.index ["community_id"], name: "index_post_histories_on_community_id"
     t.index ["post_history_type_id"], name: "index_post_histories_on_post_history_type_id"
     t.index ["post_id"], name: "index_post_histories_on_post_type_and_post_id"
     t.index ["user_id"], name: "index_post_histories_on_user_id"
@@ -120,8 +148,10 @@ ActiveRecord::Schema.define(version: 2020_01_28_123353) do
     t.string "doc_slug"
     t.bigint "last_activity_by_id"
     t.string "category", default: "Main"
+    t.bigint "community_id", null: false
     t.index ["body_markdown"], name: "index_posts_on_body_markdown", type: :fulltext
     t.index ["category"], name: "index_posts_on_category"
+    t.index ["community_id"], name: "index_posts_on_community_id"
     t.index ["last_activity_by_id"], name: "index_posts_on_last_activity_by_id"
   end
 
@@ -137,6 +167,8 @@ ActiveRecord::Schema.define(version: 2020_01_28_123353) do
     t.datetime "updated_at", null: false
     t.string "name"
     t.integer "threshold"
+    t.bigint "community_id", null: false
+    t.index ["community_id"], name: "index_privileges_on_community_id"
     t.index ["name"], name: "index_privileges_on_name"
   end
 
@@ -155,7 +187,9 @@ ActiveRecord::Schema.define(version: 2020_01_28_123353) do
     t.string "value_type", null: false
     t.text "description"
     t.string "category"
+    t.bigint "community_id"
     t.index ["category"], name: "index_site_settings_on_category"
+    t.index ["community_id"], name: "index_site_settings_on_community_id"
     t.index ["name"], name: "index_site_settings_on_name"
   end
 
@@ -169,6 +203,8 @@ ActiveRecord::Schema.define(version: 2020_01_28_123353) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
+    t.bigint "community_id", null: false
+    t.index ["community_id"], name: "index_subscriptions_on_community_id"
     t.index ["user_id"], name: "index_subscriptions_on_user_id"
   end
 
@@ -189,6 +225,8 @@ ActiveRecord::Schema.define(version: 2020_01_28_123353) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "community_id", null: false
+    t.index ["community_id"], name: "index_tags_on_community_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
@@ -204,9 +242,6 @@ ActiveRecord::Schema.define(version: 2020_01_28_123353) do
     t.string "last_sign_in_ip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "is_moderator"
-    t.boolean "is_admin"
-    t.integer "reputation"
     t.string "username"
     t.text "profile"
     t.text "website"
@@ -226,10 +261,24 @@ ActiveRecord::Schema.define(version: 2020_01_28_123353) do
     t.integer "user_id"
     t.integer "post_id"
     t.integer "recv_user_id"
+    t.bigint "community_id", null: false
+    t.index ["community_id"], name: "index_votes_on_community_id"
     t.index ["post_id"], name: "index_votes_on_post_type_and_post_id"
     t.index ["user_id"], name: "index_votes_on_user_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "communities"
+  add_foreign_key "community_users", "communities"
+  add_foreign_key "community_users", "users"
+  add_foreign_key "flags", "communities"
+  add_foreign_key "notifications", "communities"
+  add_foreign_key "post_histories", "communities"
+  add_foreign_key "posts", "communities"
+  add_foreign_key "privileges", "communities"
+  add_foreign_key "site_settings", "communities"
+  add_foreign_key "subscriptions", "communities"
   add_foreign_key "subscriptions", "users"
+  add_foreign_key "tags", "communities"
+  add_foreign_key "votes", "communities"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -242,6 +242,8 @@ ActiveRecord::Schema.define(version: 2020_02_02_052500) do
     t.string "last_sign_in_ip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_global_moderator"
+    t.boolean "is_global_admin"
     t.string "username"
     t.text "profile"
     t.text "website"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,9 +2,11 @@
 
 Rails.application.eager_load!
 
-Dir.glob(Rails.root.join('db/seeds/**/*.yml')).each do |f|
-  basename = Pathname.new(f).relative_path_from(Pathname.new(Rails.root.join('db/seeds'))).to_s
-  type = basename.gsub('.yml', '').singularize.classify.constantize
+RequestContext.community = Community.new(id: 1)
+
+%w(communities post_history_types post_types site_settings users community_users posts privileges).each do |table_name|
+  f = Rails.root.join("db/seeds/#{table_name}.yml").to_s
+  type = table_name.classify.constantize
   begin
     processed = ERB.new(File.read(f)).result(binding)
     data = YAML.load(processed)

--- a/db/seeds/communities.yml
+++ b/db/seeds/communities.yml
@@ -1,0 +1,2 @@
+- name: Sample
+  host: sample.qpixel.com

--- a/db/seeds/community_users.yml
+++ b/db/seeds/community_users.yml
@@ -1,0 +1,6 @@
+- user_id: <%= User.first.id %>
+  community_id: <%= Community.first.id %>
+  reputation: 1
+  is_moderator: 1
+  is_admin: 1
+

--- a/db/seeds/community_users.yml
+++ b/db/seeds/community_users.yml
@@ -1,6 +1,4 @@
 - user_id: <%= User.first.id %>
   community_id: <%= Community.first.id %>
   reputation: 1
-  is_moderator: 1
-  is_admin: 1
 

--- a/db/seeds/posts.yml
+++ b/db/seeds/posts.yml
@@ -5,3 +5,4 @@
   body: >
     <p>This document has been created for you as a placeholder. You should edit it to add your own Terms of Service.</p>
   doc_slug: tos
+  community_id: <%= Community.first.id %>

--- a/db/seeds/privileges.yml
+++ b/db/seeds/privileges.yml
@@ -1,8 +1,12 @@
 - name: Close
   threshold: 250
+  community_id: <%= Community.first.id %>
 - name: Edit
   threshold: 500
+  community_id: <%= Community.first.id %>
 - name: Delete
   threshold: 1000
+  community_id: <%= Community.first.id %>
 - name: ViewDeleted
   threshold: 1000
+  community_id: <%= Community.first.id %>

--- a/db/seeds/users.yml
+++ b/db/seeds/users.yml
@@ -9,3 +9,5 @@
   profile: >
     <p>This is an anonymous user account for system operations. It owns automatically-run operations and
     content from deleted users, among other things.</p>
+  is_global_moderator: true
+  is_global_admin: true

--- a/db/seeds/users.yml
+++ b/db/seeds/users.yml
@@ -3,9 +3,6 @@
   password: saK4CZR6b5gVZRvwMuzHDDFR518kktUYszBMZh47zqNkMJtuHnYDN5pcXwtbGUZlFIiwBFNIsbKYDVZ07kydul33sJvKVHKECZXhVZbNrjkI2YzDRTwpV1lBp1ZWAARP
   encrypted_password: abcdefghijklmnopqrstuvwxyz
   email: system@localhost
-  reputation: 1
-  is_moderator: 1
-  is_admin: 1
   profile_markdown: >
     This is an anonymous user account for system operations. It owns automatically-run operations and
     content from deleted users, among other things.

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -51,6 +51,26 @@ class AdminControllerTest < ActionController::TestCase
     end
   end
 
+  test "should deny admins access to non-admin community" do
+    RequestContext.community = Community.create(host: 'other.qpixel.com', name: 'Other')
+    request.env['HTTP_HOST'] = 'other.qpixel.com'
+    sign_in users(:admin)
+    PARAM_LESS_ACTIONS.each do |path|
+      get path
+      assert_response(404)
+    end
+  end
+
+  test "should grant global admims access to non admin community" do
+    RequestContext.community = Community.create(host: 'other.qpixel.com', name: 'Other')
+    request.env['HTTP_HOST'] = 'other.qpixel.com'
+    sign_in users(:global_admin)
+    PARAM_LESS_ACTIONS.each do |path|
+      get path
+      assert_response(200)
+    end
+  end
+
   test "should get single privilege" do
     sign_in users(:admin)
     get :show_privilege, params: { name: privileges(:close).name, format: :json }

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -9,11 +9,25 @@ class UsersControllerTest < ActionController::TestCase
     assert_response(200)
   end
 
+  test 'should not include users not in current community' do
+    @other_user = create_other_user
+    get :index
+    assert_not_includes assigns(:users), @other_user
+    assert_response(200)
+  end
+
   test "should get show user page" do
     sign_in users(:standard_user)
     get :show, params: { id: users(:standard_user).id }
     assert_not_nil assigns(:user)
     assert_response(200)
+  end
+
+  test "should not show user page for non-community users" do
+    @other_user = create_other_user
+    sign_in users(:standard_user)
+    get :show, params: { id: @other_user.id }
+    assert_response(404)
   end
 
   test "should get mod tools page" do
@@ -189,5 +203,12 @@ class UsersControllerTest < ActionController::TestCase
       assert post.created_at <= previous.created_at,
              "@posts was expected in created_at DESC order, but got #{post.created_at.iso8601} before #{previous.created_at.iso8601}"
     end
+  end
+
+  def create_other_user
+    other_community = Community.create(host: 'other.qpixel.com', name: 'Other')
+    other_user = User.create!(email: 'other@example.com', password: 'abcdefghijklmnopqrstuvwxyz', username: 'other_user')
+    other_user.community_users.create!(community: other_community)
+    other_user
   end
 end

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -2,19 +2,23 @@ one:
   user: standard_user
   post: question_one
   content: ABCDEF GHIJKL MNOPQR
+  community: sample
 
 two:
   user: standard_user
   post: question_two
   content: ABCDEF GHIJKL MNOPQR
+  community: sample
 
 on_answer:
   user: standard_user
   post: answer_one
   content: ABCDEF GHIJKL MNOPQR
+  community: sample
 
 deleted:
   user: standard_user
   post: question_one
   content: ABCDEF GHIJKL MNOPQR
   deleted: true
+  community: sample

--- a/test/fixtures/communities.yml
+++ b/test/fixtures/communities.yml
@@ -1,0 +1,3 @@
+sample:
+  host: sample.qpixel.com
+  name: Sample

--- a/test/fixtures/community_users.yml
+++ b/test/fixtures/community_users.yml
@@ -39,3 +39,17 @@ sample_admin:
   is_admin: true
   is_moderator: false
   reputation: 1
+
+sample_global_moderator:
+  user: global_moderator
+  community: sample
+  is_admin: false
+  is_moderator: false
+  reputation: 1
+
+sample_global_admin:
+  user: global_admin
+  community: sample
+  is_admin: false
+  is_moderator: false
+  reputation: 1

--- a/test/fixtures/community_users.yml
+++ b/test/fixtures/community_users.yml
@@ -1,0 +1,41 @@
+sample_standard_user:
+  user: standard_user
+  community: sample
+  is_admin: false
+  is_moderator: false
+  reputation: 50
+
+sample_closer:
+  user: closer
+  community: sample
+  is_admin: false
+  is_moderator: false
+  reputation: 251
+
+sample_editor:
+  user: editor
+  community: sample
+  is_admin: false
+  is_moderator: false
+  reputation: 501
+
+sample_deleter:
+  user: deleter
+  community: sample
+  is_admin: false
+  is_moderator: false
+  reputation: 1001
+
+sample_moderator:
+  user: moderator
+  community: sample
+  is_admin: false
+  is_moderator: true
+  reputation: 1
+
+sample_admin:
+  user: admin
+  community: sample
+  is_admin: true
+  is_moderator: false
+  reputation: 1

--- a/test/fixtures/flags.yml
+++ b/test/fixtures/flags.yml
@@ -2,3 +2,4 @@ one:
   reason: ABCDEF GHIJKL MNOPQR STUVWX YZ
   post: answer_two
   user: standard_user
+  community: sample

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -2,8 +2,10 @@ one:
   content: ABCDEF GHIJKL MNOPQR STUVWX YZ
   link: /
   user: standard_user
+  community: sample
 
 two:
   content: ABCDEF GHIJKL MNOPQR STUVWX
   link: /
   user: standard_user
+  community: sample

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -9,6 +9,7 @@ question_one:
     - bug
   score: 0
   user: standard_user
+  community: sample
 
 question_two:
   post_type: question
@@ -20,6 +21,7 @@ question_two:
     - bug
   score: 0
   user: editor
+  community: sample
 
 deleted:
   post_type: question
@@ -34,6 +36,7 @@ deleted:
   deleted: true
   deleted_at: 2019-01-01T00:00:00.000000Z
   deleted_by: admin
+  community: sample
 
 closed:
   post_type: question
@@ -48,6 +51,7 @@ closed:
   closed_by: closer
   closed_at: 2019-01-01T00:00:00.000000Z
   user: standard_user
+  community: sample
 
 answer_one:
   post_type: answer
@@ -55,6 +59,7 @@ answer_one:
   score: 0
   parent: question_one
   user: standard_user
+  community: sample
 
 answer_two:
   post_type: answer
@@ -62,6 +67,7 @@ answer_two:
   score: 0
   parent: question_one
   user: editor
+  community: sample
 
 really_old_answer:
   post_type: answer
@@ -70,6 +76,7 @@ really_old_answer:
   parent: question_one
   user: standard_user
   created_at: 2000-01-01T00:00:00.000000Z
+  community: sample
 
 deleted_answer:
   post_type: answer
@@ -80,6 +87,7 @@ deleted_answer:
   deleted: true
   deleted_at: 2019-01-01T00:00:00.000000Z
   deleted_by: admin
+  community: sample
 
 policy_doc:
   post_type: policy_doc
@@ -87,6 +95,7 @@ policy_doc:
   title: Terms of Service
   doc_slug: tos
   user: admin
+  community: sample
 
 help_doc:
   post_type: help_doc
@@ -94,3 +103,4 @@ help_doc:
   title: Asking Questions
   doc_slug: asking-questions
   user: admin
+  community: sample

--- a/test/fixtures/privileges.yml
+++ b/test/fixtures/privileges.yml
@@ -1,15 +1,19 @@
 close:
   name: Close
   threshold: 250
+  community: sample
 
 edit:
   name: Edit
   threshold: 500
+  community: sample
 
 delete:
   name: Delete
   threshold: 1000
+  community: sample
 
 view_deleted:
   name: ViewDeleted
   threshold: 1000
+  community: sample

--- a/test/fixtures/subscriptions.yml
+++ b/test/fixtures/subscriptions.yml
@@ -5,6 +5,7 @@ all:
   frequency: 1
   last_sent_at: 2020-01-01T00:00:00
   name: Everything
+  community: sample
 
 tag:
   type: tag
@@ -14,6 +15,7 @@ tag:
   frequency: 1
   last_sent_at: 2020-01-01T00:00:00
   name: Discussion questions
+  community: sample
 
 user:
   type: user
@@ -23,6 +25,7 @@ user:
   frequency: 1
   last_sent_at: 2020-01-01T00:00:00
   name: standard_user's questions
+  community: sample
 
 interesting:
   type: interesting
@@ -31,3 +34,4 @@ interesting:
   frequency: 1
   last_sent_at: 2020-01-01T00:00:00
   name: Interesting things
+  community: sample

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,23 +1,29 @@
 discussion:
   name: discussion
   description: discussion
+  community: sample
 
 support:
   name: support
   description: support
+  community: sample
 
 bug:
   name: bug
   description: bug
+  community: sample
 
 feature-request:
   name: feature-request
   description: feature-request
+  community: sample
 
 faq:
   name: faq
   description: faq
+  community: sample
 
 status-completed:
   name: status-completed
   description: status-completed
+  community: sample

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -2,18 +2,12 @@ standard_user:
   email: standard@qpixel-test.net
   encrypted_password: abcdefghijklmnopqrstuvwxyz
   sign_in_count: 1337
-  is_admin: false
-  is_moderator: false
-  reputation: 50
   username: standard_user
 
 closer:
   email: closer@qpixel-test.net
   encrypted_password: abcdefghijklmnopqrstuvwxyz
   sign_in_count: 1337
-  is_admin: false
-  is_moderator: false
-  reputation: 251
   username: closer
   website: https://example.com/closer
   twitter: closer
@@ -22,34 +16,22 @@ editor:
   email: editor@qpixel-test.net
   encrypted_password: abcdefghijklmnopqrstuvwxyz
   sign_in_count: 1337
-  is_admin: false
-  is_moderator: false
-  reputation: 501
   username: editor
 
 deleter:
   email: delete@qpixel-test.net
   encrypted_password: abcdefghijklmnopqrstuvwxyz
   sign_in_count: 1337
-  is_admin: false
-  is_moderator: false
-  reputation: 1001
   username: deleter
 
 moderator:
   email: moderator@qpixel-test.net
   encrypted_password: abcdefghijklmnopqrstuvwxyz
   sign_in_count: 1337
-  is_admin: false
-  is_moderator: true
-  reputation: 1
   username: moderator
 
 admin:
   email: admin@qpixel-test.net
   encrypted_password: abcdefghijklmnopqrstuvwxyz
   sign_in_count: 1337
-  is_admin: true
-  is_moderator: false
-  reputation: 1
   username: admin

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,6 +3,8 @@ standard_user:
   encrypted_password: abcdefghijklmnopqrstuvwxyz
   sign_in_count: 1337
   username: standard_user
+  is_global_admin: false
+  is_global_moderator: false
 
 closer:
   email: closer@qpixel-test.net
@@ -11,27 +13,53 @@ closer:
   username: closer
   website: https://example.com/closer
   twitter: closer
+  is_global_admin: false
+  is_global_moderator: false
 
 editor:
   email: editor@qpixel-test.net
   encrypted_password: abcdefghijklmnopqrstuvwxyz
   sign_in_count: 1337
   username: editor
+  is_global_admin: false
+  is_global_moderator: false
 
 deleter:
   email: delete@qpixel-test.net
   encrypted_password: abcdefghijklmnopqrstuvwxyz
   sign_in_count: 1337
   username: deleter
+  is_global_admin: false
+  is_global_moderator: false
 
 moderator:
   email: moderator@qpixel-test.net
   encrypted_password: abcdefghijklmnopqrstuvwxyz
   sign_in_count: 1337
   username: moderator
+  is_global_admin: false
+  is_global_moderator: false
 
 admin:
   email: admin@qpixel-test.net
   encrypted_password: abcdefghijklmnopqrstuvwxyz
   sign_in_count: 1337
   username: admin
+  is_global_admin: false
+  is_global_moderator: false
+
+global_moderator:
+  email: global-moderator@qpixel-test.net
+  encrypted_password: abcdefghijklmnopqrstuvwxyz
+  sign_in_count: 1337
+  username: global-moderator
+  is_global_admin: false
+  is_global_moderator: true
+
+global_admin:
+  email: global-admin@qpixel-test.net
+  encrypted_password: abcdefghijklmnopqrstuvwxyz
+  sign_in_count: 1337
+  username: global-admin
+  is_global_admin: true
+  is_global_moderator: false

--- a/test/fixtures/votes.yml
+++ b/test/fixtures/votes.yml
@@ -3,51 +3,60 @@ one:
   post: question_one
   vote_type: 1
   recv_user: standard_user
+  community: sample
 
 two:
   user: deleter
   post: question_one
   vote_type: -1
   recv_user: standard_user
+  community: sample
 
 three:
   user: editor
   post: answer_one
   vote_type: 1
   recv_user: standard_user
+  community: sample
 
 four:
   user: closer
   post: answer_one
   vote_type: 1
   recv_user: standard_user
+  community: sample
 
 five:
   user: deleter
   post: answer_one
   vote_type: 1
   recv_user: standard_user
+  community: sample
 
 six:
   user: moderator
   post: answer_one
   vote_type: 1
   recv_user: standard_user
+  community: sample
 
 seven:
   user: admin
   post: answer_one
   vote_type: -1
   recv_user: standard_user
+  community: sample
 
 old_answer_1:
   user: closer
   post: really_old_answer
   vote_type: 1
   recv_user: standard_user
+  community: sample
 
 old_answer_2:
   user: editor
   post: really_old_answer
   vote_type: 1
   recv_user: standard_user
+  community: sample

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,6 +1,12 @@
 require 'test_helper'
 
 class CommentTest < ActiveSupport::TestCase
+  include CommunityRelatedHelper
+
+  test 'is post related' do
+    assert_post_related(Comment)
+  end
+
   test "parent_question should return question for a comment on an answer" do
     assert_equal posts(:question_one).id, comments(:on_answer).parent_question.id
   end

--- a/test/models/flag_test.rb
+++ b/test/models/flag_test.rb
@@ -1,7 +1,10 @@
 require 'test_helper'
 
 class FlagTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  include CommunityRelatedHelper
+
+  test 'is post related' do
+    assert_post_related(Flag)
+  end
+
 end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -1,7 +1,10 @@
 require 'test_helper'
 
 class NotificationTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  include CommunityRelatedHelper
+
+  test 'is commmunity related' do
+    assert_community_related(Notification)
+  end
+
 end

--- a/test/models/post_history_test.rb
+++ b/test/models/post_history_test.rb
@@ -1,6 +1,12 @@
 require 'test_helper'
 
 class PostHistoryTest < ActiveSupport::TestCase
+  include CommunityRelatedHelper
+
+  test 'is post related' do
+    assert_post_related(PostHistory)
+  end
+
   test "calling an event with insufficient arguments should throw NoMethodError" do
     assert_raises NoMethodError do
       PostHistory.question_closed

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -1,6 +1,12 @@
 require 'test_helper'
 
 class PostTest < ActiveSupport::TestCase
+  include CommunityRelatedHelper
+
+  test 'is commmunity related' do
+    assert_community_related(Post)
+  end
+
   test "deleting a post should remove reputation change" do
     post = posts(:answer_one)
     previous_rep = post.user.reputation

--- a/test/models/privilege_test.rb
+++ b/test/models/privilege_test.rb
@@ -1,7 +1,10 @@
 require 'test_helper'
 
 class PrivilegeTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  include CommunityRelatedHelper
+
+  test 'is commmunity related' do
+    assert_community_related(Privilege)
+  end
+
 end

--- a/test/models/request_context_test.rb
+++ b/test/models/request_context_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+
+class RequestContextTest < ActiveSupport::TestCase
+  test 'initialized context store accessor' do
+    RequestContext.community = :foo
+    RequestContext.user = :bar
+    assert_equal RequestContext.fetch, {community: :foo, user: :bar}
+  end
+
+  test 'cleared context store' do
+    RequestContext.clear!
+    assert_equal RequestContext.fetch, {}
+  end
+
+  test "community accessors" do
+    @community = Community.new(id: 17)
+    RequestContext.community = @community
+    assert_equal RequestContext.community, @community
+    assert_equal RequestContext.community_id, @community.id
+  end
+
+  test "user accessors" do
+    @user = User.new(id: 17)
+    RequestContext.user = @user
+    assert_equal RequestContext.user, @user
+    assert_equal RequestContext.user_id, @user.id
+  end
+
+  class NonThreadSafe
+    cattr_accessor :community
+  end
+
+  test "thread safety" do
+    @community1 = Community.new(id: 17)
+    @community2 = Community.new(id: 18)
+    @community3 = Community.new(id: 19)
+    RequestContext.community = @community1
+    NonThreadSafe.community = @community1   # as a baseline, to demonstrate non-thread safe behavior
+
+    worker1 = Thread.new do
+      RequestContext.community = @community2
+      NonThreadSafe.community = @community2
+      sleep 0.5
+
+      # this check runs second
+      assert_equal RequestContext.community, @community2
+      assert_not_equal NonThreadSafe.community, @community2
+    end
+
+    worker2 = Thread.new do
+      RequestContext.community = @community3
+      NonThreadSafe.community = @community3
+
+      # this check runs first
+      assert_equal RequestContext.community, @community3
+      assert_equal NonThreadSafe.community, @community3
+    end
+    worker1.join(0.1) # run worker1 until sleep
+    worker2.join(0.5) # run worker2 to completion
+    worker1.join      # finalize worker1
+
+    # this check runs last
+    assert_equal RequestContext.community, @community1
+    assert_not_equal NonThreadSafe.community, @community1
+  end
+end

--- a/test/models/site_setting_test.rb
+++ b/test/models/site_setting_test.rb
@@ -31,4 +31,27 @@ class SiteSettingTest < ActiveSupport::TestCase
     assert_kind_of Array, value['data']
     assert_equal 3, value['data'].size
   end
+
+  test "community settings are in the default scope" do
+    SiteSetting.create(community_id: RequestContext.community, name: 'test', value: 'true', value_type: 'string')
+    assert SiteSetting.where(name: 'test').exists?
+  end
+
+  test "global settings are in the default scope" do
+    SiteSetting.create(community_id: nil, name: 'test', value: 'true', value_type: 'string')
+    assert SiteSetting.where(name: 'test').exists?
+  end
+
+  test "external community settings are not in the default scope" do
+    other_community = Community.create(host: 'other', name: 'other')
+    SiteSetting.create(community_id: other_community, name: 'test', value: 'true', value_type: 'string')
+    assert SiteSetting.where(name: 'test').exists?
+  end
+
+  test "community setting takes precedence over global setting" do
+    setting1 = SiteSetting.create(community_id: RequestContext.community, name: 'test', value: 'foo', value_type: 'string')
+    setting2 = SiteSetting.create(community_id: nil, name: 'test', value: 'bar', value_type: 'string')
+    assert_equal SiteSetting.where(name: 'test').first, setting1
+  end
+
 end

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -1,6 +1,12 @@
 require 'test_helper'
 
 class SubscriptionTest < ActiveSupport::TestCase
+  include CommunityRelatedHelper
+
+  test 'is community related' do
+    assert_community_related(Subscription)
+  end
+
   test "subscription to all should return some questions" do
     questions = subscriptions(:all).questions
     assert_not_nil questions

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,7 +1,9 @@
 require 'test_helper'
 
 class TagTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  include CommunityRelatedHelper
+
+  test 'is community related' do
+    assert_community_related(Tag)
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -24,4 +24,65 @@ class UserTest < ActiveSupport::TestCase
   test "website_domain should strip out everything but domain" do
     assert_equal 'example.com', users(:closer).website_domain
   end
+
+  test 'community_user is based on context' do
+    user = users(:standard_user)
+    community = Community.create(host: 'other', name: 'Other')
+    cu1 = user.community_users.create(community: community)
+    RequestContext.community = community
+    assert_equal user.community_user, cu1
+  end
+
+  test 'is_moderator for community moderator' do
+    assert_equal users(:moderator).is_moderator, true
+  end
+
+  test 'is_moderator for community moderator in another context' do
+    RequestContext.community = Community.create(host: 'other', name: 'Other')
+    assert_equal users(:moderator).is_moderator, false
+  end
+
+  test 'is_moderator for global moderator' do
+    assert_equal users(:global_moderator).is_moderator, true
+  end
+
+  test 'is_admin for community admin' do
+    assert_equal users(:admin).is_admin, true
+  end
+
+  test 'is_admin for community admin in another context' do
+    RequestContext.community = Community.create(host: 'other', name: 'Other')
+    assert_equal users(:admin).is_admin, false
+  end
+
+  test 'is_admin for global admin' do
+    assert_equal users(:global_admin).is_admin, true
+  end
+
+  test 'ensure_community_user! does not alter existing community_user' do
+    user = users(:standard_user)
+    original_count = user.community_users.count
+    original_cu = user.community_user
+    user.reload
+    cu = user.ensure_community_user!
+    current_cu = user.community_user
+    assert_equal cu, original_cu
+    assert_equal cu, current_cu
+    assert_equal user.community_users.count, original_count
+  end
+
+  test 'ensure_community_user! creates community_user for new communities' do
+    RequestContext.community = Community.create(host: 'other', name: 'Other')
+    user = users(:standard_user)
+    original_count = user.community_users.count
+    original_cu = user.community_user
+    user.reload
+    cu = user.ensure_community_user!
+    current_cu = user.community_user
+    assert_nil original_cu
+    assert_not_nil current_cu
+    assert_equal cu, current_cu
+    assert_equal user.community_users.count, original_count + 1
+  end
+
 end

--- a/test/models/vote_test.rb
+++ b/test/models/vote_test.rb
@@ -1,6 +1,12 @@
 require 'test_helper'
 
 class VoteTest < ActiveSupport::TestCase
+  include CommunityRelatedHelper
+
+  test 'is post related' do
+    assert_post_related(Vote)
+  end
+
   test "creating a vote should correctly change post score" do
     [1, -1].each do |vote_type|
       previous_score = posts(:question_two).score

--- a/test/support/community_related_helper.rb
+++ b/test/support/community_related_helper.rb
@@ -1,0 +1,12 @@
+module CommunityRelatedHelper
+  def assert_community_related(model)
+    assert model.reflections['community'].present?, 'Community association missing'
+    assert_equal model.new.community, RequestContext.community, 'Default scope should use context community'
+    assert model.all.to_sql.include?("#{model.connection.quote_column_name('community_id')} = #{RequestContext.community_id}"), 'Default scope should use context community'
+  end
+
+  def assert_post_related(model)
+    assert model.reflections['post'].present?, 'Post association missing'
+    assert_community_related(model)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,9 +20,18 @@ class ActiveSupport::TestCase
 
   def load_seeds
     Rails.application.load_seed
+    RequestContext.community = Community.first
   end
 
   def clear_cache
     Rails.cache.clear
+  end
+end
+
+class ActionController::TestCase
+  setup :load_host
+
+  def load_host
+    request.env['HTTP_HOST'] = Community.first.host
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,8 @@ require 'rails/test_help'
 require 'minitest/ci'
 Minitest::Ci.report_dir = Rails.root.join('test/reports/minitest').to_s
 
+Dir.glob(Rails.root.join('test/support/**/*.rb')).each {|f| require f }
+
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all


### PR DESCRIPTION
This branch includes:
- new Community and CommunityUser model
- refactoring `reputation`, `is_moderator`, `is_admin` out of User into CommunityUser
- RequestContext singleton to hold global request context information: includes current_user and host-mapped community
- required `community_id` on every table holding community specific data, default scope leverages RequestContext
- optional `community_id` on SiteSetting, default looks for current community, fallback to global (nil) if no specific record exists for the community
- Rails.cache namespace is expanded to be community specific, exception for persistent cached values
- default reputation removed from after_create hook, created on next request when a 'new' community is accessed
- single 'sample' Community added to seeds/fixtures, migration will backfill existing records to use this for required community_id values

All existing tests are passing at the moment, new tests still need to be written.