### PR TITLE
Fix protocol check in update_profile

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -90,7 +90,7 @@ class UsersController < ApplicationController
     profile_params = params.require(:user).permit(:username, :profile_markdown, :website, :twitter)
     profile_params[:twitter] = profile_params[:twitter].gsub('@', '')
 
-    if profile_params[:website].present? && URI.parse(profile_params[:website]).is_a?(URI::Generic)
+    if profile_params[:website].present? && URI.parse(profile_params[:website]).instance_of?(URI::Generic)
       # URI::Generic indicates the user didn't include a protocol, so we'll add one now so that it can be
       # parsed correctly in the view later on.
       profile_params[:website] = 'https://' + profile_params[:website]


### PR DESCRIPTION
is_a? returns true for subclasses. URI::HTTPS is a subclass of URI::Generic, so any URI will have 'https://' prepended.
instance_of? returns true only for that specific class