### PR TITLE
Different delete notice if by post author

### DIFF
--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -115,9 +115,15 @@
                 <strong>deleted</strong> by  <%= link_to post.deleted_by.username, user_path(post.deleted_by) %>
                 on <%= post.deleted_at.strftime('%b %e, %Y at %H:%M') %>
               </h3>
+              <% if post.deleted_by.id == post.user.id %>
+              <p>
+                The author of this post decided to delete it. It can only be seen by users with the delete privilege.
+              </p>
+              <% else %>
               <p>
                 This post was deleted because it violates the rules of this site. It can only be seen by users with the delete privilege.
               </p>
+              <% end %>
 
               <p>Users with the undelete privilege may vote to undelete this post if it has been deleted incorrectly.</p>
            </div>


### PR DESCRIPTION
This fixes https://github.com/ArtOfCode-/qpixel/issues/60.

There'll be the following banner:

![](https://user-images.githubusercontent.com/21335202/77259844-8c16aa80-6c84-11ea-9164-10e917c44fde.png)

>The author of this post decided to delete it. It can only be seen by users with the delete privilege.

instead of the following:

![](https://user-images.githubusercontent.com/21335202/77260036-a7ce8080-6c85-11ea-851f-ca5de505e899.png)

> This post was deleted because it violates the rules of this site. It can only be seen by users with the delete privilege.

when the author deleted their post.