### PR TITLE
Role grant (and revokation) UI

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -179,4 +179,28 @@ $(document).on('ready', function() {
   $('.js-first-visit-notice').on('close.bs.alert', async () => {
     document.cookie = 'dismiss_fvn=true; path=/; expires=Fri, 31 Dec 9999 23:59:59 GMT';
   });
+
+
+  $('.js-role-grant-btn').on("click", (e) => {
+    $this = $(e.target);
+
+    $.ajax({
+      'type': 'POST',
+      'url': '/users/' + $this.attr("data-user") + "/mod/toggle-role",
+      'data': { role: $this.attr("data-toggle") },
+      'target': $this
+    })
+    .done((response) => {
+      if(response.status !== 'success') {
+        QPixel.createNotification('danger', '<strong>Failed:</strong> ' + response.message);
+      }
+      else {
+        window.location.reload();
+      }
+    })
+    .fail((jqXHR, textStatus, errorThrown) => {
+      QPixel.createNotification('danger', '<strong>Failed:</strong> ' + jqXHR.status);
+      console.log(jqXHR.responseText);
+    });
+  });
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -182,7 +182,7 @@ $(document).on('ready', function() {
 
 
   $('.js-role-grant-btn').on("click", (e) => {
-    $this = $(e.target);
+    const $this = $(e.target);
 
     $.ajax({
       'type': 'POST',
@@ -191,7 +191,7 @@ $(document).on('ready', function() {
       'target': $this
     })
     .done((response) => {
-      if(response.status !== 'success') {
+      if (response.status !== 'success') {
         QPixel.createNotification('danger', '<strong>Failed:</strong> ' + response.message);
       }
       else {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -80,8 +80,8 @@ class UsersController < ApplicationController
                                .to_h.select { |_, cs| cs.include?('user_id') }
                                .map do |k, _|
       k.singularize.classify.constantize
-                     rescue
-                       nil
+    rescue
+      nil
     end .compact
     needs_transfer.each do |model|
       model.where(user_id: @user.id).update_all(user_id: SiteSetting['SoftDeleteTransferUser'])
@@ -122,37 +122,35 @@ class UsersController < ApplicationController
     redirect_to edit_user_profile_path
   end
 
-
   def role_toggle
-    if params[:role] == "mod"
+    if params[:role] == 'mod'
       @user.community_user.update(is_moderator: !@user.is_moderator)
-      render json: { status: "success" }
+      render json: { status: 'success' }
       return
     end
 
     if current_user.is_global_admin
-      if params[:role] == "admin"
+      if params[:role] == 'admin'
         @user.community_user.update(is_admin: !@user.is_admin)
-        render json: { status: "success" }
+        render json: { status: 'success' }
         return
       end
 
-      if params[:role] == "mod-global"
+      if params[:role] == 'mod-global'
         @user.update(is_global_moderator: !@user.is_global_moderator)
-        render json: { status: "success" }
+        render json: { status: 'success' }
         return
       end
 
-      if params[:role] == "admin-global"
+      if params[:role] == 'admin-global'
         @user.update(is_global_admin: true)
-        render json: { status: "success" }
+        render json: { status: 'success' }
         return
       end
     end
 
-    render json: { status: "error", message: "Role not found: #{params[:role]}" }
+    render json: { status: 'error', message: "Role not found: #{params[:role]}" }
   end
-
 
   def stack_redirect
     response = Net::HTTP.post_form(URI('https://stackoverflow.com/oauth/access_token/json'),

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -126,31 +126,31 @@ class UsersController < ApplicationController
   def role_toggle
     if params[:role] == "mod"
       @user.community_user.update(is_moderator: !@user.is_moderator)
-      render json: { "status": "success" }
+      render json: { status: "success" }
       return
     end
 
     if current_user.is_global_admin
       if params[:role] == "admin"
         @user.community_user.update(is_admin: !@user.is_admin)
-        render json: { "status": "success" }
+        render json: { status: "success" }
         return
       end
 
       if params[:role] == "mod-global"
         @user.update(is_global_moderator: !@user.is_global_moderator)
-        render json: { "status": "success" }
+        render json: { status: "success" }
         return
       end
 
       if params[:role] == "admin-global"
         @user.update(is_global_admin: true)
-        render json: { "status": "success" }
+        render json: { status: "success" }
         return
       end
     end
 
-    render json: { "status": "error", "message": "Role not found: " + params[:role] }
+    render json: { status: "error", message: "Role not found: #{params[:role]}" }
   end
 
 

--- a/app/views/users/mod.html.erb
+++ b/app/views/users/mod.html.erb
@@ -5,6 +5,41 @@
   <li><a href="/mod/votes/user/<%= @user.id %>">suspicious voting patterns</a></li>
 </ul>
 
+<% if @current_user.is_admin %>
+  <h2>Granting / revoking special permissions</h2>
+  <p>You can grant or revoke special user permissions to this user.</p>
+  <% if @user.is_moderator %>
+    <button class="button is-filled js-role-grant-btn" data-toggle="mod" data-user="<%= @user.id %>">Revoke Moderator</button>
+  <% else %>
+    <button class="button is-outlined js-role-grant-btn" data-toggle="mod" data-user="<%= @user.id %>">Grant Moderator</button>
+  <% end %>
+  <% if @current_user.is_global_admin %>
+    <% if @user.is_admin %>
+      <button class="button is-filled js-role-grant-btn" data-toggle="admin" data-user="<%= @user.id %>">Revoke Admin</button>
+    <% else %>
+      <button class="button is-outlined js-role-grant-btn" data-toggle="admin" data-user="<%= @user.id %>">Grant Admin</button>
+    <% end %>
+
+    <% if @user.is_global_moderator %>
+      <button class="button is-filled js-role-grant-btn" data-toggle="mod-global" data-user="<%= @user.id %>">Revoke Global Moderator</button>
+    <% else %>
+      <button class="button is-outlined js-role-grant-btn" data-toggle="mod-global" data-user="<%= @user.id %>">Grant Gobal Moderator</button>
+    <% end %>
+
+    <p>
+      You can also grant global admin permissions, but they can only be revoked by direct database
+      access, so be careful, to whom you give them.
+    </p>
+
+    <% if @user.is_global_admin %>
+      <button class="button is-muted is-filled" disabled>This user is a Global Admin</button>
+    <% else %>
+      <button class="button is-outlined js-role-grant-btn" data-toggle="admin-global" data-user="<%= @user.id %>">Grant Gobal Admin</button>
+    <% end %>
+      
+  <% end %>
+<% end %>
+
 <div class="notice is-danger">
   <h2>Danger Zone</h2>
   <p><strong>Take care!</strong> Actions in this section may not be reversible, and you will not be asked to confirm

--- a/app/views/users/mod.html.erb
+++ b/app/views/users/mod.html.erb
@@ -36,7 +36,7 @@
   
       <p>
         You can also grant global admin permissions, but they can only be revoked by direct database
-        access, so be careful, to whom you give them.
+        access, so be careful to whom you grant them.
       </p>
   
       <% if @user.is_global_admin %>

--- a/app/views/users/mod.html.erb
+++ b/app/views/users/mod.html.erb
@@ -1,47 +1,57 @@
 <% content_for :title, "Moderator Tools: #{@user.username}" %>
 
 <h1>Moderator Tools: <%= link_to @user.username, user_path(@user) %></h1>
-<ul>
-  <li><a href="/mod/votes/user/<%= @user.id %>">suspicious voting patterns</a></li>
-</ul>
+
+<div class="widget">
+  <div class="widget--header">Links</div>
+  <div class="widget--body">
+    <ul>
+      <li><a href="/mod/votes/user/<%= @user.id %>">suspicious voting patterns</a></li>
+    </ul>
+  </div>
+</div>
 
 <% if @current_user.is_admin %>
-  <h2>Granting / revoking special permissions</h2>
-  <p>You can grant or revoke special user permissions to this user.</p>
-  <% if @user.is_moderator %>
-    <button class="button is-filled js-role-grant-btn" data-toggle="mod" data-user="<%= @user.id %>">Revoke Moderator</button>
-  <% else %>
-    <button class="button is-outlined js-role-grant-btn" data-toggle="mod" data-user="<%= @user.id %>">Grant Moderator</button>
-  <% end %>
-  <% if @current_user.is_global_admin %>
-    <% if @user.is_admin %>
-      <button class="button is-filled js-role-grant-btn" data-toggle="admin" data-user="<%= @user.id %>">Revoke Admin</button>
+<div class="widget">
+  <div class="widget--header">Granting / revoking special permissions</div>
+  <div class="widget--body">
+    <p>You can grant or revoke special user permissions to this user.</p>
+    <% if @user.is_moderator %>
+      <button class="button is-filled js-role-grant-btn" data-toggle="mod" data-user="<%= @user.id %>">Revoke Moderator</button>
     <% else %>
-      <button class="button is-outlined js-role-grant-btn" data-toggle="admin" data-user="<%= @user.id %>">Grant Admin</button>
+      <button class="button is-outlined js-role-grant-btn" data-toggle="mod" data-user="<%= @user.id %>">Grant Moderator</button>
     <% end %>
-
-    <% if @user.is_global_moderator %>
-      <button class="button is-filled js-role-grant-btn" data-toggle="mod-global" data-user="<%= @user.id %>">Revoke Global Moderator</button>
-    <% else %>
-      <button class="button is-outlined js-role-grant-btn" data-toggle="mod-global" data-user="<%= @user.id %>">Grant Gobal Moderator</button>
+    <% if @current_user.is_global_admin %>
+      <% if @user.is_admin %>
+        <button class="button is-filled js-role-grant-btn" data-toggle="admin" data-user="<%= @user.id %>">Revoke Admin</button>
+      <% else %>
+        <button class="button is-outlined js-role-grant-btn" data-toggle="admin" data-user="<%= @user.id %>">Grant Admin</button>
+      <% end %>
+  
+      <% if @user.is_global_moderator %>
+        <button class="button is-filled js-role-grant-btn" data-toggle="mod-global" data-user="<%= @user.id %>">Revoke Global Moderator</button>
+      <% else %>
+        <button class="button is-outlined js-role-grant-btn" data-toggle="mod-global" data-user="<%= @user.id %>">Grant Gobal Moderator</button>
+      <% end %>
+  
+      <p>
+        You can also grant global admin permissions, but they can only be revoked by direct database
+        access, so be careful, to whom you give them.
+      </p>
+  
+      <% if @user.is_global_admin %>
+        <button class="button is-muted is-filled" disabled>This user is a Global Admin</button>
+      <% else %>
+        <button class="button is-outlined js-role-grant-btn" data-toggle="admin-global" data-user="<%= @user.id %>">Grant Gobal Admin</button>
+      <% end %>   
     <% end %>
-
-    <p>
-      You can also grant global admin permissions, but they can only be revoked by direct database
-      access, so be careful, to whom you give them.
-    </p>
-
-    <% if @user.is_global_admin %>
-      <button class="button is-muted is-filled" disabled>This user is a Global Admin</button>
-    <% else %>
-      <button class="button is-outlined js-role-grant-btn" data-toggle="admin-global" data-user="<%= @user.id %>">Grant Gobal Admin</button>
-    <% end %>
-      
-  <% end %>
+  </div>
+</div>
 <% end %>
 
-<div class="notice is-danger">
-  <h2>Danger Zone</h2>
+<div class="widget">
+<div class="widget--header h-c-red-700"><span class="h-fw-bold">Danger Zone</span></div>
+<div class="widget--body">
   <p><strong>Take care!</strong> Actions in this section may not be reversible, and you will not be asked to confirm
     after initiating an action.</p>
   <div class="delete-actions">
@@ -50,4 +60,6 @@
       <%= link_to "Soft-Delete", url_for(controller: :users, action: :soft_delete, id: @user.id, transfer: SiteSetting['SoftDeleteTransferUser']), method: :delete, remote: true, class: "soft-delete  button is-danger is-filled" %>
     <% end %>
   </div>
+</div>
+
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
   get    'users/me/notifications',         to: 'notifications#index', as: :notifications
   get    'users/edit/profile',             to: 'users#edit_profile', as: :edit_user_profile
   patch  'users/edit/profile',             to: 'users#update_profile', as: :update_user_profile
+  post   'users/:id/mod/toggle-role',      to: 'users#role_toggle', as: :toggle_user_role
 
   post   'notifications/:id/read',         to: 'notifications#read', as: :read_notifications
   post   'notifications/read_all',         to: 'notifications#read_all', as: :read_all_notifications

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -80,8 +80,8 @@ class UsersControllerTest < ActionController::TestCase
                                         .to_h.select { |_, cs| cs.include?('user_id') }
                                         .map do |k, _|
         k.singularize.classify.constantize
-                       rescue
-                         nil
+      rescue
+        nil
       end .compact
       pre_counts = needs_transfer.map { |model| [model, model.count] }.to_h
 


### PR DESCRIPTION
This PR adds a role grant and revokation UI:

![The described UI](https://user-images.githubusercontent.com/21335202/80319687-0f8e6300-8812-11ea-99f2-4a572c0e7a3f.png)

Roles can be given and taken according to the following rules:

- community admins can grant and revoke community moderator roles.
- global admins can grant and revoke community moderators and admins and global moderator roles.
- global admins can grant, but not revoke, global admin roles.

Global admin roles can only be revoked by direct database access; this is by-design.