### PR TITLE
Make communities customizable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,7 @@ config/database.yml
 
 deploy
 
+/public/assets/community
+
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,4 +299,4 @@ DEPENDENCIES
   will_paginate-bootstrap (~> 1.0)
 
 BUNDLED WITH
-   1.17.2
+   2.1.4

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -66,7 +66,7 @@ class CategoriesController < ApplicationController
 
   def category_params
     params.require(:category).permit(:name, :short_wiki, :display_post_types, :post_type_ids, :tag_set_id, :is_homepage,
-                                     :min_trust_level, :button_text)
+                                     :min_trust_level, :button_text, :color_code)
   end
 
   def set_list_posts

--- a/app/views/answers/edit.html.erb
+++ b/app/views/answers/edit.html.erb
@@ -42,7 +42,8 @@
   <div class="widget has-margin-4">
     <h4 class="widget--header has-margin-0">Hints and Tips</h4>
     <div class="widget--body">
-      <%= raw(sanitize(QuestionsController.renderer.render(SiteSetting['AnsweringGuidance']), scrubber: scrubber)) %>
+    <% guidance = @answer.category.answering_guidance_override || SiteSetting['AnsweringGuidance'] %>
+      <%= raw(sanitize(QuestionsController.renderer.render(guidance), scrubber: scrubber)) %>
     </div>
   </div>
 <% end %>

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -55,5 +55,12 @@
     <span class="form-caption">Tick this box to set this category as the site homepage.</span>
   </div>
 
+  <div class="form-group">
+    <%= f.label :color_code, 'Color (in the header)', class: 'form-element' %>
+    <span class="form-caption">Select a color, which shall be used for the header of the views within this category. Leave empty for site-wide default.</span>
+    <%= f.select :color_code, options_for_select(['turqoise', 'green', 'blue', 'purple', 'gray', 'yellow', 'orange', 'pink', 'red'], selected: @category.color_code),
+                 { include_blank: true }, class: 'form-element' %>
+  </div>
+
   <%= f.submit 'Save', class: 'button is-filled' %>
 <% end %>

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -56,7 +56,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.label :color_code, 'Color (in the header)', class: 'form-element' %>
+    <%= f.label :color_code, 'Header color', class: 'form-element' %>
     <span class="form-caption">Select a color to be used for the header within this category. Leave empty for site-wide default.</span>
     <%= f.select :color_code, options_for_select(['turqoise', 'green', 'blue', 'purple', 'gray', 'yellow', 'orange', 'pink', 'red'], selected: @category.color_code),
                  { include_blank: true }, class: 'form-element' %>

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -57,7 +57,7 @@
 
   <div class="form-group">
     <%= f.label :color_code, 'Color (in the header)', class: 'form-element' %>
-    <span class="form-caption">Select a color, which shall be used for the header of the views within this category. Leave empty for site-wide default.</span>
+    <span class="form-caption">Select a color to be used for the header within this category. Leave empty for site-wide default.</span>
     <%= f.select :color_code, options_for_select(['turqoise', 'green', 'blue', 'purple', 'gray', 'yellow', 'orange', 'pink', 'red'], selected: @category.color_code),
                  { include_blank: true }, class: 'form-element' %>
   </div>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -8,8 +8,14 @@
 
 <% post_count = @posts.count %>
 <div class="has-color-tertiary-500 category-meta" title="<%= post_count %>">
-  <%= short_number_to_human post_count, precision: 1, significant: false %>
-  <%= 'post'.pluralize(post_count) %>
+  <div>
+    <%= short_number_to_human post_count, precision: 1, significant: false %>
+    <%= 'post'.pluralize(post_count) %>
+
+    <% if current_user&.is_admin %>&middot;
+      <%= link_to 'Edit Category', edit_category_path(@category) %>
+    <% end %>
+  </div>
 
   <div class="button-list is-gutterless has-margin-2">
     <%= link_to 'Activity', query_url(sort: 'activity'),

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, @category.name %>
 
 <% if @category.short_wiki %>
-  <div class="has-font-size-larger has-color-tertiary-800">
+  <div class="is-lead">
     <%= raw(sanitize(QuestionsController.renderer.render(@category.short_wiki), scrubber: scrubber)) %>
   </div>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -110,7 +110,12 @@
     <% end %>
   </div>
 
+<% if expandable? %>
+  <% cat = current_category %>
+  <header class="category-header is-<%= cat.color_code.present? ? cat.color_code : "blue" %>">
+<% else %>
   <header class="category-header is-blue">
+<% end %>
     <div class="category-header--tabs">
       <div class="container category-header--tabs-container">
         <% @header_categories.each do |cat| %>
@@ -120,7 +125,6 @@
       </div>
     </div>
     <% if expandable? %>
-      <% cat = current_category %>
       <div class="container category-header--container">
         <div class="category-header--name"><%= cat.name %></div>
         <div class="category-header--nav">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
   <link rel="icon" href="<%= SiteSetting['IconPath'] || '/assets/favicon.ico' %>" />
   <%= stylesheet_link_tag "https://fonts.googleapis.com/css?family=Roboto|Roboto+Mono&display=swap" %>
   <%= stylesheet_link_tag "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" %>
-  <%= stylesheet_link_tag "https://unpkg.com/@codidact/co-design@0.7.0/dist/codidact.css" %>
+  <%= stylesheet_link_tag "https://unpkg.com/@codidact/co-design@0.7.1/dist/codidact.css" %>
   <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/select2@4.0.12/dist/css/select2.min.css" %>
   <%= stylesheet_link_tag "/assets/community/" + @community.name + ".css" %>
   <%= stylesheet_link_tag    'application', media: 'all' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -112,9 +112,9 @@
 
 <% if expandable? %>
   <% cat = current_category %>
-  <header class="category-header is-<%= cat.color_code.present? ? cat.color_code : "blue" %>">
+  <header class="category-header is-<%= cat.color_code.present? ? cat.color_code : SiteSetting['SiteCategoryHeaderDefaultColor'] %> %>">
 <% else %>
-  <header class="category-header is-blue">
+  <header class="category-header is-<%= SiteSetting['SiteCategoryHeaderDefaultColor'] %>%">
 <% end %>
     <div class="category-header--tabs">
       <div class="container category-header--tabs-container">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,7 @@
   <%= stylesheet_link_tag "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" %>
   <%= stylesheet_link_tag "https://unpkg.com/@codidact/co-design@0.7.0/dist/codidact.css" %>
   <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/select2@4.0.12/dist/css/select2.min.css" %>
+  <%= stylesheet_link_tag "/assets/community/" + @community.name + ".css" %>
   <%= stylesheet_link_tag    'application', media: 'all' %>
   <%= javascript_include_tag "https://code.jquery.com/jquery-2.2.2.min.js" %>
   <%= javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js" %>
@@ -27,10 +28,10 @@
   <%= yield(:head) %>
 </head>
 <body class="<%= Rails.env.development? ? 'development' : '' %>">
-  <header class="header has-margin-0">
+  <header class="header has-margin-0 <%= SiteSetting['SiteHeaderIsDark'] ? 'is-dark' : '' %>">
     <div class="container header--container">
       <div class="header--brand">
-        <% if SiteSetting.exist?('SiteLogoPath') %>
+        <% if SiteSetting['SiteLogoPath'].present? %>
           <a href="/" class="header--site-name" aria-label="Home"><img alt src="<%= SiteSetting['SiteLogoPath'] %>" /></a>
         <% else %>
           <a href="/" class="header--site-name" aria-label="Home"><%= SiteSetting['SiteName'] %></a>
@@ -63,7 +64,7 @@
           </a>
           <%= link_to user_path(current_user), class: 'header--item is-complex is-visible-on-mobile' do %>
             <img alt="user avatar" src="<%= avatar_url(current_user) %>" class="header--item-image">&nbsp;&nbsp;
-            <span class="has-font-size-larger has-color-tertiary-600"><%= current_user.reputation %></span>
+            <span class="has-font-size-larger <%= SiteSetting['SiteHeaderIsDark'] ? 'has-color-white' : 'has-color-tertiary-600' %>"><%= current_user.reputation %></span>
           <% end %>
           <%= link_to 'Sign Out', destroy_user_session_path, method: :delete, class: 'header--item' %>
         <% else %>
@@ -114,7 +115,7 @@
   <% cat = current_category %>
   <header class="category-header is-<%= cat.color_code.present? ? cat.color_code : SiteSetting['SiteCategoryHeaderDefaultColor'] %> %>">
 <% else %>
-  <header class="category-header is-<%= SiteSetting['SiteCategoryHeaderDefaultColor'] %>%">
+  <header class="category-header is-<%= SiteSetting['SiteCategoryHeaderDefaultColor'] %>">
 <% end %>
     <div class="category-header--tabs">
       <div class="container category-header--tabs-container">

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -5,7 +5,8 @@
 <div class="notice is-info">
   <p><strong>Posting Tips</strong></p>
   <div class="has-font-size-caption">
-    <%= raw(sanitize(QuestionsController.renderer.render(SiteSetting['AskingGuidance']), scrubber: scrubber)) %>
+  <% guidance = @category.asking_guidance_override || SiteSetting['AskingGuidance'] %>
+    <%= raw(sanitize(QuestionsController.renderer.render(guidance), scrubber: scrubber)) %>
   </div>
 </div>
 

--- a/app/views/questions/edit.html.erb
+++ b/app/views/questions/edit.html.erb
@@ -10,7 +10,8 @@
     <div class="widget has-margin-4">
       <h4 class="widget--header has-margin-0">Hints and Tips</h4>
       <div class="widget--body">
-        <%= raw(sanitize(QuestionsController.renderer.render(SiteSetting['AskingGuidance']), scrubber: scrubber)) %>
+      <% guidance = @question.category.asking_guidance_override || SiteSetting['AskingGuidance'] %>
+        <%= raw(sanitize(QuestionsController.renderer.render(guidance), scrubber: scrubber)) %>
       </div>
     </div>
   <% end %>

--- a/db/migrate/20200428181938_add_customization_fields_to_category.rb
+++ b/db/migrate/20200428181938_add_customization_fields_to_category.rb
@@ -1,0 +1,7 @@
+class AddCustomizationFieldsToCategory < ActiveRecord::Migration[5.2]
+  def change
+    change_table :categories do |t|
+      t.string :color_code
+    end
+  end
+end

--- a/db/migrate/20200430123008_add_posting_tips_overrides_to_category.rb
+++ b/db/migrate/20200430123008_add_posting_tips_overrides_to_category.rb
@@ -1,0 +1,8 @@
+class AddPostingTipsOverridesToCategory < ActiveRecord::Migration[5.2]
+  def change
+    change_table :categories do |t|
+      t.text :asking_guidance_override
+      t.text :answering_guidance_override
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_28_181938) do
+ActiveRecord::Schema.define(version: 2020_04_30_123008) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -45,6 +45,8 @@ ActiveRecord::Schema.define(version: 2020_04_28_181938) do
     t.integer "min_trust_level"
     t.string "button_text"
     t.string "color_code"
+    t.text "asking_guidance_override"
+    t.text "answering_guidance_override"
     t.index ["community_id"], name: "index_categories_on_community_id"
     t.index ["tag_set_id"], name: "index_categories_on_tag_set_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_22_152359) do
+ActiveRecord::Schema.define(version: 2020_04_28_181938) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2020_04_22_152359) do
     t.bigint "tag_set_id"
     t.integer "min_trust_level"
     t.string "button_text"
+    t.string "color_code"
     t.index ["community_id"], name: "index_categories_on_community_id"
     t.index ["tag_set_id"], name: "index_categories_on_tag_set_id"
   end
@@ -171,7 +172,7 @@ ActiveRecord::Schema.define(version: 2020_04_22_152359) do
     t.integer "post_type_id", null: false
     t.text "body_markdown"
     t.integer "answer_count", default: 0, null: false
-    t.datetime "last_activity", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "last_activity", default: -> { "current_timestamp()" }, null: false
     t.text "att_source"
     t.string "att_license_name"
     t.string "att_license_link"
@@ -275,60 +276,6 @@ ActiveRecord::Schema.define(version: 2020_04_22_152359) do
     t.bigint "tag_set_id", null: false
     t.index ["community_id"], name: "index_tags_on_community_id"
     t.index ["tag_set_id"], name: "index_tags_on_tag_set_id"
-  end
-
-  create_table "tposts", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "id", default: 0, null: false
-    t.string "title"
-    t.text "body"
-    t.string "tags_cache"
-    t.integer "score", default: 0, null: false
-    t.integer "parent_id"
-    t.integer "user_id"
-    t.boolean "closed", default: false, null: false
-    t.integer "closed_by_id"
-    t.datetime "closed_at"
-    t.boolean "deleted", default: false, null: false
-    t.integer "deleted_by_id"
-    t.datetime "deleted_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "post_type_id", null: false
-    t.text "body_markdown"
-    t.integer "answer_count", default: 0, null: false
-    t.datetime "last_activity", default: -> { "CURRENT_TIMESTAMP" }, null: false
-    t.text "att_source"
-    t.string "att_license_name"
-    t.string "att_license_link"
-    t.string "doc_slug"
-    t.bigint "last_activity_by_id"
-    t.bigint "community_id", null: false
-    t.string "category"
-  end
-
-  create_table "tusers", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "id", default: 0, null: false
-    t.string "email"
-    t.string "encrypted_password"
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.string "current_sign_in_ip"
-    t.string "last_sign_in_ip"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "is_global_moderator"
-    t.boolean "is_global_admin"
-    t.string "username"
-    t.text "profile"
-    t.text "website"
-    t.string "twitter"
-    t.text "profile_markdown"
-    t.integer "se_acct_id"
-    t.boolean "transferred_content", default: false
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|

--- a/db/seeds/site_settings.yml
+++ b/db/seeds/site_settings.yml
@@ -12,6 +12,13 @@
   description: >
     The path, relative to the root of the domain, to the site's logo file. Can also be an absolute URL.
 
+- name: SiteCategoryHeaderDefaultColor
+  value: blue
+  value_type: string
+  category: SiteDetails
+  description: >
+    Select a color, which shall be used for categories, that don't define a header color and for category-neutral views. Valid are: turqoise, green, blue, purple, gray, yellow, orange, pink and red
+
 - name: QuestionUpVoteRep
   value: 5
   value_type: integer

--- a/db/seeds/site_settings.yml
+++ b/db/seeds/site_settings.yml
@@ -17,7 +17,7 @@
   value_type: string
   category: SiteDetails
   description: >
-    Select a color, which shall be used for categories, that don't define a header color and for category-neutral views. Valid are: turqoise, green, blue, purple, gray, yellow, orange, pink and red
+    Select a color to be used for categories that don't define a header color, and for category-neutral views. Valid are: turquoise, green, blue, purple, gray, yellow, orange, pink, red.
 
 - name: SiteHeaderIsDark
   value: false

--- a/db/seeds/site_settings.yml
+++ b/db/seeds/site_settings.yml
@@ -19,6 +19,13 @@
   description: >
     Select a color, which shall be used for categories, that don't define a header color and for category-neutral views. Valid are: turqoise, green, blue, purple, gray, yellow, orange, pink and red
 
+- name: SiteHeaderIsDark
+  value: false
+  value_type: boolean
+  category: SiteDetails
+  description: >
+    Whether or not the site header has a dark color. The theme can be edited in `/public/assets/community/[Community Name].css`
+
 - name: QuestionUpVoteRep
   value: 5
   value_type: integer


### PR DESCRIPTION
This PR adds various ways, which allow communities to be customized:

- Community Theme (CSS file included per-community automatically)
- Light/Dark Header switch
- Different category header colors per category (with default from site settings)