### PR TITLE
Fix bug where Signup form is incorrectly disabled

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,5 +1,5 @@
 $(() => {
-  if (location.pathname === '/users/sign_up' || location.pathname === '/users/sign_in' && !navigator.cookieEnabled) {
+  if ((location.pathname === '/users/sign_up' || location.pathname === '/users/sign_in') && !navigator.cookieEnabled) {
     $('input[type="submit"]').attr('disabled', true).addClass('is-muted is-outlined');
     $('.js-errors').text('Cookies must be enabled in your browser for you to be able to sign up or sign in.');
   }


### PR DESCRIPTION
The signup form is being disabled in all cases because of an operator precedence problem. The result is that the submit button is *always* disabled on the signup page.