### PR TITLE
Sanitize search terms before using in LIKE

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -4,7 +4,7 @@ class TagsController < ApplicationController
                  TagSet.find(params[:tag_set])
                end
     @tags = if params[:term].present?
-              (@tag_set&.tags || Tag).where('name LIKE ?', "#{params[:term]}%")
+              (@tag_set&.tags || Tag).search(params[:term])
             else
               @tag_set&.tags || Tag.all
             end.order(:name).paginate(page: params[:page], per_page: 50)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
   def index
     sort_param = { reputation: :reputation, age: :created_at }[params[:sort]&.to_sym] || :reputation
     @users = if params[:search].present?
-               user_scope.where('username LIKE ?', "#{params[:search]}%")
+               user_scope.search(params[:search])
              else
                user_scope.order(sort_param => :desc)
              end.paginate(page: params[:page], per_page: 48)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -3,4 +3,8 @@ class Tag < ApplicationRecord
 
   has_and_belongs_to_many :posts
   belongs_to :tag_set
+
+  def self.search(term)
+    where('name LIKE ?', "#{sanitize_sql_like(term)}%"))
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,10 @@ class User < ApplicationRecord
     includes(:posts, :avatar_attachment)
   end
 
+  def self.search(term)
+    where('username LIKE ?', "#{sanitize_sql_like(term)}%")
+  end
+
   # This class makes heavy use of predicate names, and their use is prevalent throughout the codebase
   # because of the importance of these methods.
   # rubocop:disable Naming/PredicateName


### PR DESCRIPTION
Use [`sanitize_sql_like`](https://api.rubyonrails.org/classes/ActiveRecord/Sanitization/ClassMethods.html#method-i-sanitize_sql_like) to make tag/user search terms "safe" to use in an SQL `LIKE` clause.

There isn't much in the way of vulnerability here, it just prevents search terms like `%foo` or `_____` from being treated as wildcard characters. It also prevents searches like `foo_bar` from matching things like `fooAbar` unintentionally.