### PR TITLE
Markdown parsers

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - uses: nelonoel/branch-name@v1
     - name: Set up SSH key
       run: |
         echo "${{ secrets.DEV_DEPLOY_KEY }}" > ~/deploy_key
@@ -16,4 +17,4 @@ jobs:
     
     - name: Run SSH deploy command
       run: |
-        ssh -i ~/deploy_key -o StrictHostKeyChecking=no ubuntu@dev.codidact.org "cd /var/apps/qpixel ; bash -l ./deploy ${GITHUB_REF##*/}"
+        ssh -i ~/deploy_key -o StrictHostKeyChecking=no ubuntu@dev.codidact.org "cd /var/apps/qpixel ; bash -l ./deploy ${BRANCH_NAME}"

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'tzinfo-data', '~> 1.2019.3'
 gem 'uglifier', '>= 1.3.0'
 
 # Markdown support in both directions.
-gem 'redcarpet', '~> 3.5'
+gem 'commonmarker', '~> 0.21'
 gem 'reverse_markdown', '~> 2.0'
 
 # Charting stuff.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,8 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
+    commonmarker (0.21.0)
+      ruby-enum (~> 0.5)
     concurrent-ruby (1.1.6)
     counter_culture (2.5.1)
       activerecord (>= 4.2)
@@ -193,7 +195,6 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redcarpet (3.5.0)
     redis (4.1.4)
     responders (3.0.0)
       actionpack (>= 5.0)
@@ -217,6 +218,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.0.3)
       parser (>= 2.7.0.1)
+    ruby-enum (0.8.0)
+      i18n
     ruby-progressbar (1.10.1)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -287,6 +290,7 @@ DEPENDENCIES
   byebug (~> 11.1)
   chartkick (~> 3.3)
   coffee-rails (~> 4.2.2)
+  commonmarker (~> 0.21)
   counter_culture (~> 2.0)
   coveralls (~> 0.8)
   devise (~> 4.7)
@@ -304,7 +308,6 @@ DEPENDENCIES
   rails (~> 5.2)
   rails-controller-testing (~> 1.0)
   rails-html-sanitizer (~> 1.3)
-  redcarpet (~> 3.5)
   redis (~> 4.1)
   reverse_markdown (~> 2.0)
   rotp (~> 6.0)

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -47,13 +47,17 @@ $(() => {
 
   $('.post-field').on('keyup markdown', evt => {
     if (!window.converter) {
-      window.converter = new showdown.Converter();
-      window.converter.setFlavor('github');
+      window.converter = window.markdownit({
+        html: true,
+        breaks: false,
+        linkify: true
+      });
+      window.converter.use(window.markdownitFootnote);
     }
     window.setTimeout(() => {
       const converter = window.converter;
       const text = $(evt.target).val();
-      const html = converter.makeHtml(text);
+      const html = converter.render(text);
       $(evt.target).parents('.form-group').siblings('.post-preview').html(html);
     }, 0);
 
@@ -63,6 +67,6 @@ $(() => {
 
     mathjaxTimeout = setTimeout(() => {
       MathJax.typeset();
-    }, 2000);
+    }, 1000);
   });
 });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -175,3 +175,20 @@ hr {
     border-bottom: 1px solid lighten($warning, 10%);
   }
 }
+
+.footnote-ref a::before {
+  content: '[';
+}
+
+.footnote-ref a::after {
+  content: ']';
+}
+
+.footnotes-sep + .footnotes {
+  border-top: 0;
+}
+
+.footnotes {
+  border-top: 1px solid $muted-graphic;
+  font-size: 0.9em;
+}

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -12,7 +12,7 @@ class AnswersController < ApplicationController
   def create
     @question = Question.find params[:id]
     @answer = Answer.new(answer_params.merge(parent: @question, user: current_user, score: 0,
-                                             body: AnswersController.renderer.render(params[:answer][:body_markdown]),
+                                             body: helpers.render_markdown(params[:answer][:body_markdown]),
                                              last_activity: DateTime.now, last_activity_by: current_user,
                                              category: @question.category))
     unless current_user.id == @question.user.id
@@ -36,7 +36,7 @@ class AnswersController < ApplicationController
 
     PostHistory.post_edited(@answer, current_user, before: @answer.body_markdown,
                             after: params[:answer][:body_markdown], comment: params[:edit_comment])
-    if @answer.update(answer_params.merge(body: AnswersController.renderer.render(params[:answer][:body_markdown]),
+    if @answer.update(answer_params.merge(body: helpers.render_markdown(params[:answer][:body_markdown]),
                                           last_activity: DateTime.now, last_activity_by: current_user))
       redirect_to url_for(controller: :questions, action: :show, id: @answer.parent.id)
     else

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -4,18 +4,9 @@ class AnswersController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy, :undelete]
   before_action :set_answer, only: [:edit, :update, :destroy, :undelete]
 
-  # noinspection RubyArgCount
-  @@markdown_renderer = Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true, fenced_code_blocks: true,
-                                                no_intra_emphasis: true, tables: true, strikethrough: true,
-                                                footnotes: true)
-
   def new
     @answer = Answer.new
     @question = Question.find params[:id]
-  end
-
-  def self.renderer
-    @@markdown_renderer
   end
 
   def create

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,14 +4,6 @@ class CommentsController < ApplicationController
   before_action :set_comment, only: [:update, :destroy, :undelete, :show]
   before_action :check_privilege, only: [:update, :destroy, :undelete]
 
-  # noinspection RubyArgCount
-  @@markdown_renderer = Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true, no_intra_emphasis: true,
-                                                strikethrough: true)
-
-  def self.renderer
-    @@markdown_renderer
-  end
-
   def create
     @comment = Comment.new comment_params.merge(user: current_user)
     if @comment.save

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,4 @@
 class PostsController < ApplicationController
-  require 'redcarpet/render_strip'
-
   before_action :authenticate_user!, except: [:document, :share_q, :share_a, :help_center]
   before_action :set_post, only: [:edit_help, :update_help]
   before_action :check_permissions, only: [:edit_help, :update_help]

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -18,7 +18,7 @@ class PostsController < ApplicationController
   def create
     @category = Category.find(params[:category_id])
     @post = Post.new(post_params.merge(category: @category, user: current_user, post_type_id: params[:post_type_id],
-                                       body: QuestionsController.renderer.render(params[:post][:body_markdown])))
+                                       body: helpers.render_markdown(params[:post][:body_markdown])))
 
     if @category.min_trust_level.present? && @category.min_trust_level > current_user.trust_level
       @post.errors.add(:base, "You don't have a high enough trust level to post in the #{@category.name} category.")
@@ -47,7 +47,7 @@ class PostsController < ApplicationController
         SiteSetting[setting_name] || '(No such setting)'
       end
     end
-    @post = Post.new(new_post_params.merge(body: QuestionsController.renderer.render(params[:post][:body_markdown]),
+    @post = Post.new(new_post_params.merge(body: helpers.render_markdown(params[:post][:body_markdown]),
                                            user: User.find(-1)))
 
     if @post.policy_doc? && !current_user&.is_admin
@@ -76,7 +76,7 @@ class PostsController < ApplicationController
       end
     end
     PostHistory.post_edited(@post, current_user, before: @post.body_markdown, after: params[:post][:body_markdown])
-    if @post.update(help_post_params.merge(body: QuestionsController.renderer.render(params[:post][:body_markdown]),
+    if @post.update(help_post_params.merge(body: helpers.render_markdown(params[:post][:body_markdown]),
                                            last_activity: DateTime.now, last_activity_by: current_user))
       redirect_to policy_path(slug: @post.doc_slug)
     else

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -6,13 +6,6 @@ class PostsController < ApplicationController
   before_action :check_permissions, only: [:edit_help, :update_help]
   before_action :verify_moderator, only: [:new_help, :create_help]
 
-  # noinspection RubyArgCount
-  @@plain_renderer = Redcarpet::Markdown.new(Redcarpet::Render::StripDown)
-
-  def self.renderer
-    @@plain_renderer
-  end
-
   def new
     @category = Category.find(params[:category_id])
     @post = Post.new(category: @category, post_type_id: params[:post_type_id])

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -5,15 +5,6 @@ class QuestionsController < ApplicationController
                                             :close, :reopen]
   before_action :set_question, only: [:show, :edit, :update, :destroy, :undelete, :close, :reopen]
 
-  # noinspection RubyArgCount
-  @@markdown_renderer = Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true, fenced_code_blocks: true,
-                                                no_intra_emphasis: true, tables: true, strikethrough: true,
-                                                footnotes: true)
-
-  def self.renderer
-    @@markdown_renderer
-  end
-
   def index
     sort_params = { activity: :last_activity, age: :created_at, score: :score }
     sort_param = sort_params[params[:sort]&.to_sym] || :last_activity

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -64,7 +64,7 @@ class QuestionsController < ApplicationController
 
     PostHistory.post_edited(@question, current_user, before: @question.body_markdown,
                             after: params[:question][:body_markdown], comment: params[:edit_comment])
-    body_rendered = QuestionsController.renderer.render(params[:question][:body_markdown])
+    body_rendered = helpers.render_markdown(params[:question][:body_markdown])
     if @question.update(question_params.merge(tags_cache: params[:question][:tags_cache]&.reject(&:empty?),
                                               body: body_rendered, last_activity: DateTime.now,
                                               last_activity_by: current_user))

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -116,7 +116,7 @@ class UsersController < ApplicationController
       @user.avatar.attach(params[:user][:avatar])
     end
 
-    profile_rendered = QuestionsController.renderer.render(profile_params[:profile_markdown])
+    profile_rendered = helpers.render_markdown(profile_params[:profile_markdown])
     if @user.update(profile_params.merge(profile: profile_rendered))
       flash[:success] = 'Your profile details were updated.'
     else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -56,9 +56,9 @@ module ApplicationHelper
   end
 
   def render_markdown(md)
-    CommonMarker.render_html md,
-                             [:FOOTNOTES, :LIBERAL_HTML_TAG, :STRIKETHROUGH_DOUBLE_TILDE],
-                             [:table, :strikethrough, :autolink]
+    CommonMarker.render_doc(md,
+                            [:FOOTNOTES, :LIBERAL_HTML_TAG, :STRIKETHROUGH_DOUBLE_TILDE],
+                            [:table, :strikethrough, :autolink]).to_html
   end
 
   # This isn't a perfect way to strip out Markdown, so it should only be used for non-critical things like

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,24 +55,24 @@ module ApplicationHelper
     ActiveSupport::NumberHelper.number_to_human(*args, **opts)
   end
 
-  def render_markdown(md)
-    CommonMarker.render_doc(md,
+  def render_markdown(markdown)
+    CommonMarker.render_doc(markdown,
                             [:FOOTNOTES, :LIBERAL_HTML_TAG, :STRIKETHROUGH_DOUBLE_TILDE],
                             [:table, :strikethrough, :autolink]).to_html
   end
 
   # This isn't a perfect way to strip out Markdown, so it should only be used for non-critical things like
   # page descriptions - things that will later be supplemented by the full formatted content.
-  def strip_markdown(md)
+  def strip_markdown(markdown)
     # Remove block-level formatting: headers, hr, references, images, HTML tags
-    md = md.gsub(/(?:^#+ +|^-{3,}|^\[[^\]]+\]: ?.+$|^!\[[^\]]+\](?:\([^)]+\)|\[[^\]]+\])$|<[^>]+>)/, '')
+    markdown = markdown.gsub(/(?:^#+ +|^-{3,}|^\[[^\]]+\]: ?.+$|^!\[[^\]]+\](?:\([^)]+\)|\[[^\]]+\])$|<[^>]+>)/, '')
 
     # Remove inline formatting: bold, italic, strike etc.
-    md = md.gsub(/[*_~]+/, '')
+    markdown = markdown.gsub(/[*_~]+/, '')
 
     # Remove links and inline images but replace them with their text/alt text.
-    md = md.gsub(/!?\[([^\]]+)\](?:\([^)]+\)|\[[^\]]+\])/, '\1')
+    markdown = markdown.gsub(/!?\[([^\]]+)\](?:\([^)]+\)|\[[^\]]+\])/, '\1')
 
-    md
+    markdown
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,4 +60,19 @@ module ApplicationHelper
                              [:FOOTNOTES, :LIBERAL_HTML_TAG, :STRIKETHROUGH_DOUBLE_TILDE],
                              [:table, :strikethrough, :autolink]
   end
+
+  # This isn't a perfect way to strip out Markdown, so it should only be used for non-critical things like
+  # page descriptions - things that will later be supplemented by the full formatted content.
+  def strip_markdown(md)
+    # Remove block-level formatting: headers, hr, references, images, HTML tags
+    md = md.gsub(/(?:^#+ +|^-{3,}|^\[[^\]]+\]: ?.+$|^!\[[^\]]+\](?:\([^)]+\)|\[[^\]]+\])$|<[^>]+>)/, '')
+
+    # Remove inline formatting: bold, italic, strike etc.
+    md = md.gsub(/[*_~]+/, '')
+
+    # Remove links and inline images but replace them with their text/alt text.
+    md = md.gsub(/!?\[([^\]]+)\](?:\([^)]+\)|\[[^\]]+\])/, '\1')
+
+    md
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,7 +58,7 @@ module ApplicationHelper
   def render_markdown(markdown)
     CommonMarker.render_doc(markdown,
                             [:FOOTNOTES, :LIBERAL_HTML_TAG, :STRIKETHROUGH_DOUBLE_TILDE],
-                            [:table, :strikethrough, :autolink]).to_html
+                            [:table, :strikethrough, :autolink]).to_html(:UNSAFE)
   end
 
   # This isn't a perfect way to strip out Markdown, so it should only be used for non-critical things like

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,4 +54,10 @@ module ApplicationHelper
              format: '%n%u' }.merge(opts)
     ActiveSupport::NumberHelper.number_to_human(*args, **opts)
   end
+
+  def render_markdown(md)
+    CommonMarker.render_html md,
+                             [:FOOTNOTES, :LIBERAL_HTML_TAG, :STRIKETHROUGH_DOUBLE_TILDE],
+                             [:table, :strikethrough, :autolink]
+  end
 end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -2,8 +2,8 @@ module PostsHelper
   class PostScrubber < Rails::Html::PermitScrubber
     def initialize
       super
-      self.tags = %w[a p b i em strong hr h1 h2 h3 h4 h5 h6 blockquote img strike del code pre br ul ol li]
-      self.attributes = %w[href title src height width]
+      self.tags = %w[a p b i em strong hr h1 h2 h3 h4 h5 h6 blockquote img strike del code pre br ul ol li sup sub section]
+      self.attributes = %w[id class href title src height width]
     end
 
     def skip_node?(node)

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -2,7 +2,8 @@ module PostsHelper
   class PostScrubber < Rails::Html::PermitScrubber
     def initialize
       super
-      self.tags = %w[a p b i em strong hr h1 h2 h3 h4 h5 h6 blockquote img strike del code pre br ul ol li sup sub section]
+      self.tags = %w[a p b i em strong hr h1 h2 h3 h4 h5 h6 blockquote img strike del code pre br ul ol li sup sub
+                     section]
       self.attributes = %w[id class href title src height width]
     end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -90,7 +90,7 @@ class Post < ApplicationRecord
   end
 
   def body_plain
-    PostsController.renderer.render(body_markdown)
+    ActionController::Base.helpers.strip_markdown(body_markdown)
   end
 
   def question?

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,5 @@
 # rubocop:disable Metrics/ClassLength
 class Post < ApplicationRecord
-  require 'redcarpet/render_strip'
-
   include CommunityRelated
 
   belongs_to :user
@@ -90,7 +88,7 @@ class Post < ApplicationRecord
   end
 
   def body_plain
-    ActionController::Base.helpers.strip_markdown(body_markdown)
+    ApplicationController.helpers.strip_markdown(body_markdown)
   end
 
   def question?

--- a/app/views/answers/edit.html.erb
+++ b/app/views/answers/edit.html.erb
@@ -40,7 +40,7 @@
     <h4 class="widget--header has-margin-0">Hints and Tips</h4>
     <div class="widget--body">
     <% guidance = @answer.category.answering_guidance_override || SiteSetting['AnsweringGuidance'] %>
-      <%= raw(sanitize(QuestionsController.renderer.render(guidance), scrubber: scrubber)) %>
+      <%= raw(sanitize(render_markdown(guidance), scrubber: scrubber)) %>
     </div>
   </div>
 <% end %>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -6,7 +6,7 @@
     <div class="widget--body">
       <h3><%= cat.name %></h3>
       <% if cat.short_wiki.present? %>
-        <%= raw(sanitize(QuestionsController.renderer.render(cat.short_wiki), scrubber: scrubber)) %>
+        <%= raw(sanitize(render_markdown(cat.short_wiki), scrubber: scrubber)) %>
       <% end %>
       <% post_count = cat.posts.undeleted.count %>
       <span class="has-color-tertiary-500" title="<%= post_count %>">

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -3,7 +3,7 @@
 <% if @category.short_wiki %>
   <div class="is-lead">
     <% cache [@category, 'description-rendered'] do %>
-      <%= raw(sanitize(QuestionsController.renderer.render(@category.short_wiki), scrubber: scrubber)) %>
+      <%= raw(sanitize(render_markdown(@category.short_wiki), scrubber: scrubber)) %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,6 +1,6 @@
 <div class="comment <%= comment.deleted? ? 'deleted-content' : '' %>" data-id="<%= comment.id %>" id="comment-<%= comment.id %>">
   <p class="comment--content">
-    <%= raw(sanitize(CommentsController.renderer.render(comment.content), scrubber: CommentScrubber.new)) %>
+    <%= raw(sanitize(render_markdown(comment.content), scrubber: CommentScrubber.new)) %>
     <span class="comment--meta">
       &mdash; <%= link_to comment.user.username, user_path(comment.user) %>
         <span class="text-muted" title="<%= comment.created_at.iso8601 %>"><%= time_ago_in_words(comment.created_at) %> ago</span>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -18,8 +18,8 @@
 <%= stylesheet_link_tag "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" %>
 <%= stylesheet_link_tag "https://unpkg.com/@codidact/co-design@0.8.0/dist/codidact.css" %>
 <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/select2@4.0.12/dist/css/select2.min.css" %>
-<%= stylesheet_link_tag "/assets/community/" + @community.name + ".css" %>
-<%= stylesheet_link_tag    'application', media: 'all' %>
+<%= stylesheet_link_tag "/assets/community/#{@community.host.split('.')[0]}.css" %>
+<%= stylesheet_link_tag 'application', media: 'all' %>
 
 <%= javascript_include_tag "https://code.jquery.com/jquery-2.2.2.min.js" %>
 <%= javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js" %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -6,7 +6,7 @@
     <% cache SiteSetting.find_by(name: 'SidebarNoticeText') do %>
       <div class="widget has-margin-4 is-warning">
         <div class="widget--body">
-          <%= raw(sanitize(QuestionsController.renderer.render(notice_text), scrubber: scrubber)) %>
+          <%= raw(sanitize(render_markdown(notice_text), scrubber: scrubber)) %>
         </div>
       </div>
     <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -6,7 +6,7 @@
   <p><strong>Posting Tips</strong></p>
   <div class="has-font-size-caption">
   <% guidance = @category.asking_guidance_override || SiteSetting['AskingGuidance'] %>
-    <%= raw(sanitize(QuestionsController.renderer.render(guidance), scrubber: scrubber)) %>
+    <%= raw(sanitize(render_markdown(guidance), scrubber: scrubber)) %>
   </div>
 </div>
 

--- a/app/views/posts/_markdown_script.html.erb
+++ b/app/views/posts/_markdown_script.html.erb
@@ -1,1 +1,2 @@
-<script type="application/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.9.1/showdown.min.js"></script>
+<script type="application/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/markdown-it-footnote/3.0.2/markdown-it-footnote.min.js"></script>
+<script type="application/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/markdown-it/11.0.0/markdown-it.min.js"></script>

--- a/app/views/questions/edit.html.erb
+++ b/app/views/questions/edit.html.erb
@@ -9,7 +9,7 @@
       <h4 class="widget--header has-margin-0">Hints and Tips</h4>
       <div class="widget--body">
       <% guidance = @question.category.asking_guidance_override || SiteSetting['AskingGuidance'] %>
-        <%= raw(sanitize(QuestionsController.renderer.render(guidance), scrubber: scrubber)) %>
+        <%= raw(sanitize(render_markdown(guidance), scrubber: scrubber)) %>
       </div>
     </div>
   <% end %>

--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -26,7 +26,7 @@
     <div class="widget has-margin-4">
       <h4 class="widget--header has-margin-0">Hints and Tips</h4>
       <div class="widget--body">
-        <%= raw(sanitize(QuestionsController.renderer.render(SiteSetting['AskingGuidance']), scrubber: scrubber)) %>
+        <%= raw(sanitize(render_markdown(SiteSetting['AskingGuidance']), scrubber: scrubber)) %>
       </div>
     </div>
   <% end %>

--- a/app/views/questions/new_meta.html.erb
+++ b/app/views/questions/new_meta.html.erb
@@ -28,7 +28,7 @@
     <div class="widget has-margin-4">
       <h4 class="widget--header has-margin-0">Hints and Tips</h4>
       <div class="widget--body">
-        <%= raw(sanitize(QuestionsController.renderer.render(SiteSetting['AskingGuidance']), scrubber: scrubber)) %>
+        <%= raw(sanitize(render_markdown(SiteSetting['AskingGuidance']), scrubber: scrubber)) %>
       </div>
     </div>
   <% end %>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -16,7 +16,7 @@
 
 <% if @posts.nil? %>
     <h3>Advanced Search Options</h3>
-    <%= raw(sanitize(QuestionsController.renderer.render(SiteSetting['JITAdvancedSearchHelp']), scrubber: scrubber)) %>
+    <%= raw(sanitize(render_markdown(SiteSetting['JITAdvancedSearchHelp']), scrubber: scrubber)) %>
 
     <p class="has-color-tertiary-500"><em>Search for something to start finding posts.</em></p>
 <% else %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'redcarpet/render_strip'
-
 Rails.application.eager_load!
 
 if ENV['SEEDS'].present?


### PR DESCRIPTION
Switches Markdown parser to using commonmarker on the backend, and markdown-it on the frontend. They should be much closer in terms of configuration, so the preview should be accurate more of the time. We also get superscript, subscript, proper footnotes, proper auto-linkify, and some other things.

This shouldn't cause any visible difference; this PR is here for code review and sanity-check.