### PR TITLE
Fix score search

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -26,7 +26,7 @@ module SearchHelper
         next unless value.match?(valid_value[:numeric])
 
         operator, val = numeric_value_sql value
-        ["score #{operator.present? ? operator : '='} ?", val.to_i]
+        ["score #{operator.present? ? operator : '='} ?", val.to_f]
       when 'created'
         next unless value.match?(valid_value[:date])
 

--- a/test/helpers/search_helper_test.rb
+++ b/test/helpers/search_helper_test.rb
@@ -37,7 +37,7 @@ class SearchHelperTest < ActionView::TestCase
   end
 
   test 'qualifiers_to_sql should return a correct SQL string' do
-    assert_equal 'score = 1 AND created_at <= DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 2 WEEK)',
+    assert_equal 'score = 1.0 AND created_at <= DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 2 WEEK)',
                  qualifiers_to_sql(['score:1', 'created:>=2w'])
     assert_equal '', qualifiers_to_sql([])
   end


### PR DESCRIPTION
Search by score is broken after the update of moving to Wilson score. This PR fixes it.

The issue is, that QPixel expects an integer as score (to_i). Hence `score:>0.7` are interpreted as `score:>0`, which is obviously wrong. The fix should be just changing from to_i to to_f.