### PR TITLE
Bump to CD 0.12.0

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -14,7 +14,7 @@
 <link rel="icon" href="<%= SiteSetting['IconPath'] || '/assets/favicon.ico' %>" />
 
 <%= stylesheet_link_tag "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" %>
-<%= stylesheet_link_tag "https://unpkg.com/@codidact/co-design@0.11.3/dist/codidact.css" %>
+<%= stylesheet_link_tag "https://unpkg.com/@codidact/co-design@0.12.0/dist/codidact.css" %>
 <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/select2@4.0.12/dist/css/select2.min.css" %>
 <%= stylesheet_link_tag "/assets/community/#{@community.host.split('.')[0]}.css" %>
 <%= stylesheet_link_tag 'application', media: 'all' %>
@@ -24,7 +24,7 @@
 <%= javascript_include_tag "https://cdn.jsdelivr.net/npm/select2@4.0.12/dist/js/select2.min.js" %>
 <%= javascript_include_tag "/assets/community/#{@community.host.split('.')[0]}.js" %>
 <%= javascript_include_tag 'application' %>
-<script src="https://unpkg.com/@codidact/co-design@0.11.3/js/co-design.js" defer></script>
+<script src="https://unpkg.com/@codidact/co-design@0.12.0/js/co-design.js" defer></script>
 
 <% if SiteSetting['MathJaxEnabled'] %>
   <script>


### PR DESCRIPTION
Bumps to Co-Design 0.12.0.

Includes changes to the post score meters:

![visualization of change; now relative rather than "absolute" score presentation](https://user-images.githubusercontent.com/21335202/87532324-3d59aa00-c693-11ea-9cd3-b1a94f84f79a.png)
