### PR TITLE
Prevent accidental suspension notice

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,6 +47,8 @@ Style/ClassVars:
   Enabled: false
 Style/Documentation:
   Enabled: false  # No need for specific documentation comments, but please add inline comments where necessary.
+Style/DoubleNegation:
+  Enabled: false
 Style/ExponentialNotation:
   Enabled: true
   EnforcedStyle: scientific

--- a/app/controllers/mod_warning_controller.rb
+++ b/app/controllers/mod_warning_controller.rb
@@ -41,11 +41,11 @@ class ModWarningController < ApplicationController
     suspension_end = DateTime.now + suspension_duration.days
 
     @warning = ModWarning.new(author: current_user, community_user: @user.community_user,
-                              body: params[:mod_warning][:body], is_suspension: params[:mod_warning][:is_suspension],
+                              body: params[:mod_warning][:body], is_suspension: !!params[:mod_warning][:is_suspension],
                               suspension_end: suspension_end, active: true)
     if @warning.save
       if !!params[:mod_warning][:is_suspension]
-        @user.community_user.update(is_suspended: params[:mod_warning][:is_suspension], suspension_end: suspension_end,
+        @user.community_user.update(is_suspended: !!params[:mod_warning][:is_suspension], suspension_end: suspension_end,
                      suspension_public_comment: params[:mod_warning][:suspension_public_notice])
       end
 

--- a/app/controllers/mod_warning_controller.rb
+++ b/app/controllers/mod_warning_controller.rb
@@ -44,8 +44,8 @@ class ModWarningController < ApplicationController
                               body: params[:mod_warning][:body], is_suspension: params[:mod_warning][:is_suspension],
                               suspension_end: suspension_end, active: true)
     if @warning.save
-      if params[:mod_warning][:is_suspension]
-        @user.community_user.update(is_suspended: true, suspension_end: suspension_end,
+      if !!params[:mod_warning][:is_suspension]
+        @user.community_user.update(is_suspended: params[:mod_warning][:is_suspension], suspension_end: suspension_end,
                      suspension_public_comment: params[:mod_warning][:suspension_public_notice])
       end
 

--- a/app/controllers/mod_warning_controller.rb
+++ b/app/controllers/mod_warning_controller.rb
@@ -39,7 +39,7 @@ class ModWarningController < ApplicationController
     suspension_duration = 365 if suspension_duration > 365
 
     suspension_end = DateTime.now + suspension_duration.days
-    
+
     is_suspension = !!params[:mod_warning][:is_suspension]
 
     @warning = ModWarning.new(author: current_user, community_user: @user.community_user,

--- a/app/controllers/mod_warning_controller.rb
+++ b/app/controllers/mod_warning_controller.rb
@@ -39,13 +39,15 @@ class ModWarningController < ApplicationController
     suspension_duration = 365 if suspension_duration > 365
 
     suspension_end = DateTime.now + suspension_duration.days
+    
+    is_suspension = !!params[:mod_warning][:is_suspension]
 
     @warning = ModWarning.new(author: current_user, community_user: @user.community_user,
-                              body: params[:mod_warning][:body], is_suspension: !!params[:mod_warning][:is_suspension],
+                              body: params[:mod_warning][:body], is_suspension: is_suspension,
                               suspension_end: suspension_end, active: true)
     if @warning.save
-      if !!params[:mod_warning][:is_suspension]
-        @user.community_user.update(is_suspended: !!params[:mod_warning][:is_suspension], suspension_end: suspension_end,
+      if is_suspension
+        @user.community_user.update(is_suspended: is_suspension, suspension_end: suspension_end,
                      suspension_public_comment: params[:mod_warning][:suspension_public_notice])
       end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -170,7 +170,7 @@ class Post < ApplicationRecord
   def modify_author_reputation
     sc = saved_changes
     if sc.include?('deleted') && sc['deleted'][0] != sc['deleted'][1] && created_at >= 60.days.ago
-      deleted = !!saved_changes['deleted']&.last # rubocop:disable Style/DoubleNegation
+      deleted = !!saved_changes['deleted']&.last
       if deleted
         user.update(reputation: user.reputation - Vote.total_rep_change(votes))
       else


### PR DESCRIPTION
This *should* prevent accidental display of the suspension message, when it is not selected. However, I wasn't able to test it right now, so please **verify, whether it actually works**.