### PR TITLE
Allow mods to disable comments

### DIFF
--- a/app/assets/javascripts/moderator.js
+++ b/app/assets/javascripts/moderator.js
@@ -1,5 +1,5 @@
 $(() => {
-  $('.js-convert-to-comment').on('ajax:success', ev => {
+  $('.js-convert-to-comment, .js-toggle-comments').on('ajax:success', ev => {
     location.reload();
   });
 });

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -5,6 +5,11 @@ class CommentsController < ApplicationController
   before_action :check_privilege, only: [:update, :destroy, :undelete]
 
   def create
+    @post = Post.find(params[:comment][:post_id])
+    if @post.comments_disabled && !current_user.is_moderator && !current_user.is_admin
+      render json: { status: 'failed', message: 'Comments have been disabled on this post.' }, status: 403
+      return
+    end
     @comment = Comment.new comment_params.merge(user: current_user)
     if @comment.save
       unless @comment.post.user == current_user

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,9 +1,9 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!, except: [:document, :share_q, :share_a, :help_center]
-  before_action :set_post, only: [:edit_help, :update_help]
+  before_action :set_post, only: [:edit_help, :update_help, :toggle_comments]
   before_action :set_scoped_post, only: [:change_category]
   before_action :check_permissions, only: [:edit_help, :update_help]
-  before_action :verify_moderator, only: [:new_help, :create_help]
+  before_action :verify_moderator, only: [:new_help, :create_help, :toggle_comments]
 
   def new
     @category = Category.find(params[:category_id])
@@ -146,6 +146,20 @@ class PostsController < ApplicationController
     end
     @post.tags = new_tags
     @post.save
+    render json: { success: true }
+  end
+
+  def toggle_comments
+    @post.comments_disabled = !@post.comments_disabled
+    @post.save
+    if @post.comments_disabled
+      if params[:delete_all_comments]
+        @post.comments.undeleted.map do |c|
+          c.deleted = true
+          c.save
+        end
+      end
+    end
     render json: { success: true }
   end
 

--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -319,8 +319,13 @@
             <% end %>
             <% if user_signed_in? %>
               <% if post.deleted %>
-                <span class="has-color-tertiary-500">Comments disabled on deleted posts</span>
+                <p class="has-color-tertiary-500">Comments disabled on deleted posts</p>
+              <% elsif post.comments_disabled && !moderator? && !admin? %>
+                <p class="has-color-red-500"><i class="fa fa-lock"></i> Comments have been disabled on this post.</p>
               <% else %>
+                <% if post.comments_disabled %>
+                  <p class="has-color-red-500"><i class="fa fa-lock"></i> Comments have been disabled on this post, but as a moderator you are exempt from that block.</p>
+                <% end %>
                 <a href="#" class="js-add-comment">Add a comment</a>
   
                 <%= form_for Comment.new, url: create_comment_path, remote: true, html: { class: 'comment-form js-comment-form', id: nil } do |f| %>

--- a/app/views/posts/_post_tools.html.erb
+++ b/app/views/posts/_post_tools.html.erb
@@ -41,6 +41,34 @@
           <% end %>
         </details>
       <% end %>
+      <% if moderator? && !post.comments_disabled %>
+        <details>
+          <summary>Disable comments</summary>
+          <p>
+            Disallows comments by non-moderators. Should only be used rarely.
+          </p>
+          <%= form_tag post_comments_allowance_toggle_path(post), remote: true, class: 'js-toggle-comments' do %>
+            <div class="form-group">
+              <%= label_tag :delete_all_comments, 'Purge all comments?', class: 'form-element', for: "purge_comments_id_#{post.id}" %>
+              <div class="form-caption">You can optionally remove all comments. You can undelete them manually later.</div>
+              <%= check_box_tag :delete_all_comments, 'yes' %>
+            </div>
+
+            <%= submit_tag 'Disable', class: 'button is-filled' %>
+          <% end %>
+        </details>
+      <% end %>
+      <% if moderator? && post.comments_disabled %>
+        <details>
+          <summary>Enable comments</summary>
+          <p>
+            Allows comments again, after they have been previously disabled.
+          </p>
+          <%= form_tag post_comments_allowance_toggle_path(post), remote: true, class: 'js-toggle-comments' do %>
+            <%= submit_tag 'Enable', class: 'button is-filled' %>
+          <% end %>
+        </details>
+      <% end %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,8 @@ Rails.application.routes.draw do
   patch  'posts/:id/edit-help',            to: 'posts#update_help', as: :update_help_post
 
   post   'posts/:id/category',             to: 'posts#change_category', as: :change_category
+  post   'posts/:id/toggle_comments',      to: 'posts#toggle_comments', as: :post_comments_allowance_toggle
+  
 
   get  'posts/suggested-edit/:id',         to: 'suggested_edit#show', as: :suggested_edit
   post 'posts/suggested-edit/:id/approve', to: 'suggested_edit#approve', as: :suggested_edit_approve

--- a/db/migrate/20200716191141_add_comments_disabled_to_posts.rb
+++ b/db/migrate/20200716191141_add_comments_disabled_to_posts.rb
@@ -1,0 +1,5 @@
+class AddCommentsDisabledToPosts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :posts, :comments_disabled, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_01_132654) do
+ActiveRecord::Schema.define(version: 2020_07_16_191141) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -31,6 +31,16 @@ ActiveRecord::Schema.define(version: 2020_07_01_132654) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "blocked_items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "type"
+    t.text "value"
+    t.datetime "expires"
+    t.boolean "automatic"
+    t.string "reason"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
@@ -240,6 +250,7 @@ ActiveRecord::Schema.define(version: 2020_07_01_132654) do
     t.integer "help_ordering"
     t.integer "upvote_count", default: 0, null: false
     t.integer "downvote_count", default: 0, null: false
+    t.boolean "comments_disabled"
     t.index ["att_source"], name: "index_posts_on_att_source"
     t.index ["body_markdown"], name: "index_posts_on_body_markdown", type: :fulltext
     t.index ["category_id"], name: "index_posts_on_category_id"


### PR DESCRIPTION
This PR adds the option for mods to disable comments on a post.

General screenshot:
![General screenshot](https://user-images.githubusercontent.com/21335202/87716628-64a59980-c7af-11ea-9501-8723851e885a.png)


Screenshot for mods:
![Screenshot for mods](https://user-images.githubusercontent.com/21335202/87716582-535c8d00-c7af-11ea-83c6-17942349bdaf.png)

Mod tools:

![Mod tools](https://user-images.githubusercontent.com/21335202/87716566-4c357f00-c7af-11ea-9bbc-4998242a79bc.png)
