### PR TITLE
Stamp date on subsequent error modals.

### DIFF
--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -13,7 +13,7 @@ window.QPixel = {
   },
 
   /** Counts notifications popped up at any time. */
-  var popped_modals_ct = 0;
+  let popped_modals_ct = 0;
 
   /**
    * Create a notification popup - not an inbox notification.
@@ -21,30 +21,28 @@ window.QPixel = {
    * @param message the message to show
    */
   createNotification: function(type, message) {
-    /** Some messages include a date stamp. */
-    var append_date = false;
-    var message_with_date = message;
-    var span, button;
+    // Some messages include a date stamp, `append_date` governs that.
+    let append_date = false;
+    let message_with_date = message;
     if (type === 'danger') {
       if (popped_modals_ct > 0 ) {
-        /* Modals stack each on top, so repeating an errored action over
-         * and over again is gonna create multiple error modals in the
-         * same exact place. While this happens this way, an user
-         * closing the error modal will not have an immediate visual
-         * action feedback if two or more error modals are printed.
-         * A date is stamped in order to cope with that. */
+        /* At the time of writing, modals stack each one exactly on top of previous one, so repeating an errored action
+         * over and over again is going to create multiple error modals in the same exact place. While this happens this
+         * way, an user closing the error modal will not have an immediate visual action feedback if two or more error
+         * modals have been printed. A date is stamped in order to cope with that. Could be anything. Probablye a cycle
+         * of different emoji characters would be cuter while having the purpose met. But if so make sure character in
+         * step `i` is actually different than character in step `i + 1`. And then you could print an emoji just every
+         * time a modal is popped up, not just from the second one; removing `mesage_with_date`, using only `message`,
+         * and removing `append_date` and the different situations guarded by it. */
         append_date = true;
       }
     }
     if (append_date) {
       message_with_date += ' (' + new Date(Date.now()).toISOString() + ')';
     }
-    span = '<span aria-hidden="true">&times;</span>';
-    button = '<button';
-    button += ' type="button" class="button is-close-button"';
-    button += ' data-dismiss="alert" aria-label="Close"';
-    button += '>';
-    button += span + '</button>';
+    const span = '<span aria-hidden="true">&times;</span>';
+    const button = ('<button type="button" class="button is-close-button" data-dismiss="alert" aria-label="Close">' +
+        span + '</button>');
     $("<div></div>")
     .addClass("notice has-shadow-3 is-" + type)
     .html(button + '<p>' + message_with_date + '</p>')

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -1,5 +1,8 @@
 const validators = [];
 
+/** Counts notifications popped up at any time. */
+let popped_modals_ct = 0;
+
 window.QPixel = {
   /**
    * Get the current CSRF anti-forgery token. Should be passed as the X-CSRF-Token header when
@@ -11,9 +14,6 @@ window.QPixel = {
     QPixel.csrfToken = () => token;
     return token;
   },
-
-  /** Counts notifications popped up at any time. */
-  let popped_modals_ct = 0;
 
   /**
    * Create a notification popup - not an inbox notification.

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -12,15 +12,42 @@ window.QPixel = {
     return token;
   },
 
+  /** Counts notifications popped up at any time. */
+  var popped_modals_ct = 0;
+
   /**
    * Create a notification popup - not an inbox notification.
    * @param type the type to apply to the popup - warning, danger, etc.
    * @param message the message to show
    */
   createNotification: function(type, message) {
+    /** Some messages include a date stamp. */
+    var append_date = false;
+    var message_with_date = message;
+    var span, button;
+    if (type === 'danger') {
+      if (popped_modals_ct > 0 ) {
+        /* Modals stack each on top, so repeating an errored action over
+         * and over again is gonna create multiple error modals in the
+         * same exact place. While this happens this way, an user
+         * closing the error modal will not have an immediate visual
+         * action feedback if two or more error modals are printed.
+         * A date is stamped in order to cope with that. */
+        append_date = true;
+      }
+    }
+    if (append_date) {
+      message_with_date += ' (' + new Date(Date.now()).toISOString() + ')';
+    }
+    span = '<span aria-hidden="true">&times;</span>';
+    button = '<button';
+    button += ' type="button" class="button is-close-button"';
+    button += ' data-dismiss="alert" aria-label="Close"';
+    button += '>';
+    button += span + '</button>';
     $("<div></div>")
     .addClass("notice has-shadow-3 is-" + type)
-    .html('<button type="button" class="button is-close-button" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><p>' + message+"</p>")
+    .html(button + '<p>' + message_with_date + '</p>')
     .css({
       'position': 'fixed',
       'top': "50px",
@@ -34,9 +61,11 @@ window.QPixel = {
     .on('click', function(ev) {
       $(this).fadeOut(200, function() {
         $(this).remove();
+        popped_modals_ct = popped_modals_ct > 0 ? (popped_modals_ct - 1) : 0;
       });
     })
     .appendTo(document.body);
+    popped_modals_ct += 1;
   },
 
   /**


### PR DESCRIPTION
Before this change modals stack on the same exact place, so the user
does not receive visual feedback until all of them are closed, in case
the errored action is requested over and over again.

This change adds a stamp to subsequent error modals, so the user would
receive visual feedback every time one of the error modals is closed.

**At the time of writing this code hasn't been run yet.**
