### PR TITLE
Rhoxio/135/blank username unicode fix

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,7 @@ class User < ApplicationRecord
   validates :login_token, uniqueness: { allow_nil: true, allow_blank: true }
   validate :no_links_in_username
   validate :username_not_fake_admin
-  validate :username_does_not_contain_blank_unicode_characters
+  validate :no_blank_unicode_in_username
   validate :email_domain_not_blocklisted
   validate :is_not_blocklisted
   validate :email_not_bad_pattern
@@ -124,7 +124,7 @@ class User < ApplicationRecord
     end
   end
 
-  def username_does_not_contain_blank_unicode_characters
+  def no_blank_unicode_in_username
     not_valid = username.scan(/[\u200B-\u200C\u200D\uFEFF]/).empty?
     if not_valid
       errors.add(:username, 'may not contain blank unicode characters')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -125,7 +125,7 @@ class User < ApplicationRecord
   end
 
   def no_blank_unicode_in_username
-    not_valid = username.scan(/[\u200B-\u200C\u200D\uFEFF]/).empty?
+    not_valid = !username.scan(/[\u200B-\u200C\u200D\uFEFF]/).empty?
     if not_valid
       errors.add(:username, 'may not contain blank unicode characters')
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,7 @@ class User < ApplicationRecord
   validates :login_token, uniqueness: { allow_nil: true, allow_blank: true }
   validate :no_links_in_username
   validate :username_not_fake_admin
+  validate :username_does_not_contain_blank_unicode_characters
   validate :email_domain_not_blocklisted
   validate :is_not_blocklisted
   validate :email_not_bad_pattern
@@ -123,6 +124,13 @@ class User < ApplicationRecord
     end
   end
 
+  def username_does_not_contain_blank_unicode_characters
+    not_valid = username.scan(/[\u200B-\u200C\u200D\uFEFF]/).empty?
+    if not_valid
+      errors.add(:username, 'may not contain blank unicode characters')
+    end
+  end
+
   def email_domain_not_blocklisted
     return unless File.exist?(Rails.root.join('../.qpixel-domain-blocklist.txt'))
     return unless saved_changes.include? 'email'
@@ -211,6 +219,5 @@ class User < ApplicationRecord
                          automatic: true, reason: "#{reason}: #" + @user.id.to_s)
     end
   end
-
   # rubocop:enable Naming/PredicateName
 end


### PR DESCRIPTION
From: https://github.com/codidact/qpixel/issues/135

Checks if any of the blank unicode characters are present, and if so, gives the user feedback about the issue. Does not pass validation if any of the four are present, so this may conflict with emoji or other unicode-based username strings.

Based on: 

> U+200B zero width space
> U+200C zero width non-joiner Unicode code point
> U+200D zero width joiner Unicode code point
> U+FEFF zero width no-break space Unicode code point 

This may need to evolve into a discussion about what symbols we want to exclude, or if something like `^[a-zA-Z0-9]+([._]?[a-zA-Z0-9]+)*$` is more appropriate. 

This commit will fix the issue with usernames showing up as blank for any new sign ups, though. 

<img width="790" alt="52fb0297fefa46c6225a325a7e2606c5" src="https://user-images.githubusercontent.com/8063041/91627714-0f43d700-e96e-11ea-9a22-dc164bf554e3.png">
