### PR TITLE
Missing update fields when approving suggested edit?

### DIFF
--- a/app/controllers/suggested_edit_controller.rb
+++ b/app/controllers/suggested_edit_controller.rb
@@ -93,14 +93,18 @@ class SuggestedEditController < ApplicationController
         body: @edit.body,
         body_markdown: @edit.body_markdown,
         last_activity: DateTime.now,
-        last_activity_by: @edit.user
+        last_activity_by: @edit.user,
+        last_edited_at: DateTime.now,
+        last_edited_by_id: @edit.user
       }.compact
     elsif @post.answer?
       {
         body: @edit.body,
         body_markdown: @edit.body_markdown,
         last_activity: DateTime.now,
-        last_activity_by: @edit.user
+        last_activity_by: @edit.user,
+        last_edited_at: DateTime.now,
+        last_edited_by_id: @edit.user
       }.compact
     end
   end


### PR DESCRIPTION
Maybe you already added this after conversation, but just in case you didn't and forgot afterwards.

---

https://discord.com/channels/634104110131445811/634104110131445815/752337241568968744
https://discord.com/channels/634104110131445811/634104110131445815/752436133987745853
https://discord.com/channels/634104110131445811/634104110131445815/752461960548974593
https://discord.com/channels/634104110131445811/634104110131445815/752538715653537863

At the time of writing, these changes are not tested.