### PR TITLE
Fix keyboard tools and mentions

### DIFF
--- a/app/assets/javascripts/keyboard_tools.js
+++ b/app/assets/javascripts/keyboard_tools.js
@@ -1,13 +1,14 @@
 $(() => {
     const userLink = $('.header--item.is-complex.is-visible-on-mobile[href^="/users/"]').attr('href');
-    const keyboardToolsAreEnabled = !!window.localStorage.getItem('keyboard__enable');
+    const keyboardToolsAreEnabled = !!window.localStorage.getItem("keyboard__enable");
 
-    $(".js-keyboard_tools-status").text(keyboardToolsAreEnabled ? 'activated' : 'inactive');
+    $(".js-keyboard_tools-status").text(keyboardToolsAreEnabled ? "activated" : "inactive");
     $(".js-keyboard_tools-toggle").click(() => {
-        if (window.localStorage.getItem('keyboard__enable')) {
-            window.localStorage.removeItem('keyboard__enable');
-        } else {
-            window.localStorage.setItem('keyboard__enable', true);
+        if (window.localStorage.getItem("keyboard__enable")) {
+            window.localStorage.removeItem("keyboard__enable");
+        }
+        else {
+            window.localStorage.setItem("keyboard__enable", true);
         }
         window.location.reload();
     })

--- a/app/assets/javascripts/keyboard_tools.js
+++ b/app/assets/javascripts/keyboard_tools.js
@@ -1,5 +1,18 @@
 $(() => {
     const userLink = $('.header--item.is-complex.is-visible-on-mobile[href^="/users/"]').attr('href');
+    const keyboardToolsAreEnabled = !!window.localStorage.getItem('keyboard__enable');
+
+    $(".js-keyboard_tools-status").text(keyboardToolsAreEnabled ? 'activated' : 'inactive');
+    $(".js-keyboard_tools-toggle").click(() => {
+        if (window.localStorage.getItem('keyboard__enable')) {
+            window.localStorage.removeItem('keyboard__enable');
+        } else {
+            window.localStorage.setItem('keyboard__enable', true);
+        }
+        window.location.reload();
+    })
+
+    if (!keyboardToolsAreEnabled) return;
 
     window._CodidactKeyboard = {
         state: 'home',

--- a/app/assets/stylesheets/keyboard_tools.scss
+++ b/app/assets/stylesheets/keyboard_tools.scss
@@ -9,6 +9,9 @@
     position: fixed;
     left: 1rem;
     bottom: 1rem;
+    z-index: 2305843009213693951; /* This is the largest Mersenne-prime shown in full on Wikipedia and should be
+                                     large enough for most practical use cases to ensure that the keyboard help
+                                     is always above everything else. */
 }
 .__keyboard_selected {
     outline: 0.25rem solid red;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,8 @@ class ApplicationController < ActionController::Base
     render layout: 'without_sidebar'
   end
 
+  def keyboard_tools; end
+
   protected
 
   def configure_permitted_parameters

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -19,7 +19,9 @@ class CommentsController < ApplicationController
       match = @comment.content.match(/@(?<name>\S+) /)
       if match && match[:name]
         user = User.where("LOWER(REPLACE(username, ' ', '')) = LOWER(?)", match[:name]).first
-        user&.create_notification('You were mentioned in a comment', comment_link(@comment))
+        unless user&.id == @comment.post.user_id
+          user&.create_notification('You were mentioned in a comment', comment_link(@comment))
+        end
       end
 
       render json: { status: 'success',

--- a/app/views/application/keyboard_tools.html.erb
+++ b/app/views/application/keyboard_tools.html.erb
@@ -1,0 +1,9 @@
+<h1>Keyboard tools</h1>
+<p>Codidact supports keyboard tools to enhance user accessibility. You can activate (and then later deactivate) them here on this page:</p>
+<p>You'll need JavaScript to be enabled for the tools to work.</p>
+
+<p>Keyboard tools are currently <strong class="js-keyboard_tools-status">unknown</strong>.
+<button class="button is-outlined js-keyboard_tools-toggle">Toggle</button>
+</p>
+
+<p>This setting is stored in your browser and not your user account, so you can set it as you want it on any device.</p>

--- a/app/views/users/edit_profile.erb
+++ b/app/views/users/edit_profile.erb
@@ -52,6 +52,12 @@
   <%= f.submit 'Save', class: 'button is-very-large is-filled' %>
 <% end %>
 
+<h2>Preferences</h2>
+<p>You can edit the following preferences:</p>
+<ul>
+  <li><a href="<%= keyboard_tools_path %>">Enable or disable keyboard tools</a></li>
+</ul>
+
 <% unless SiteSetting['AllowContentTransfer'] %>
   <h2>Link with Stack Exchange</h2>
   <div class="notice is-warning">

--- a/app/views/users/edit_profile.erb
+++ b/app/views/users/edit_profile.erb
@@ -55,7 +55,7 @@
 <h2>Preferences</h2>
 <p>You can edit the following preferences:</p>
 <ul>
-  <li><a href="<%= keyboard_tools_path %>">Enable or disable keyboard tools</a></li>
+  <li><%= link_to 'Enable or disable keyboard shortcuts', keyboard_tools_path %></li>
 </ul>
 
 <% unless SiteSetting['AllowContentTransfer'] %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -222,6 +222,8 @@ Rails.application.routes.draw do
     get 'reports/subscriptions',           to: 'reports#subs_global', as: :global_subs_report
     get 'reports/posts',                   to: 'reports#posts_global', as: :global_posts_report
   end
+  
+  get    'feature/keyboard-tools',           to: 'application#keyboard_tools', as: :keyboard_tools
 
   scope 'ca' do
     root                                   to: 'advertisement#index', as: :ads


### PR DESCRIPTION
This PR fixes:

* keyboard tools being on by default by adding a toggle function (https://meta.codidact.com/questions/278042),
* keyboard tools being below the tag input (https://meta.codidact.com/questions/277257) and
* double-mentions when the post author is also mentioned in a comment (https://meta.codidact.com/questions/278102).