### PR TITLE
Update error codes from 404 to 403 in various places

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,7 +67,7 @@ class ApplicationController < ActionController::Base
   def check_your_privilege(name, post = nil, render_error = true)
     unless current_user&.has_privilege?(name) || (current_user&.has_post_privilege?(name, post) if post)
       @privilege = Privilege.find_by(name: name)
-      render 'errors/forbidden', layout: 'without_sidebar', privilege_name: name, status: 401 if render_error
+      render 'errors/forbidden', layout: 'without_sidebar', privilege_name: name, status: 403 if render_error
       return false
     end
     true

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -101,7 +101,7 @@ class CommentsController < ApplicationController
 
   def check_privilege
     unless current_user.is_moderator || current_user.is_admin || current_user == @comment.user
-      render template: 'errors/forbidden', status: 401
+      render template: 'errors/forbidden', status: 403
     end
   end
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -16,8 +16,8 @@ class NotificationsController < ApplicationController
 
     unless @notification.user == current_user
       respond_to do |format|
-        format.html { render template: 'errors/forbidden', status: 401 }
-        format.json { render json: nil, status: 401 }
+        format.html { render template: 'errors/forbidden', status: 403 }
+        format.json { render json: nil, status: 403 }
       end
       return
     end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -64,19 +64,19 @@ class CommentsControllerTest < ActionController::TestCase
   test 'should prevent users from editing comments from another' do
     sign_in users(:editor) # Editor only applies to main posts, not comments.
     patch :update, params: { id: comments(:one).id }
-    assert_response(401)
+    assert_response(403)
   end
 
   test 'should prevent users from deleting comments from another' do
     sign_in users(:editor)
     delete :destroy, params: { id: comments(:one).id }
-    assert_response(401)
+    assert_response(403)
   end
 
   test 'should prevent users from undeleting comments from another' do
     sign_in users(:editor)
     delete :undelete, params: { id: comments(:one).id }
-    assert_response(401)
+    assert_response(403)
   end
 
   test 'should allow moderators to update comment' do

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -33,7 +33,7 @@ class NotificationsControllerTest < ActionController::TestCase
   test 'should prevent users marking others notifications read' do
     sign_in users(:editor)
     post :read, params: { id: notifications(:one).id, format: :json }
-    assert_response(401)
+    assert_response(403)
   end
 
   test 'should require authentication to get index' do

--- a/test/controllers/questions_controller_test.rb
+++ b/test/controllers/questions_controller_test.rb
@@ -115,7 +115,7 @@ class QuestionsControllerTest < ActionController::TestCase
   test 'should require viewdeleted privileges to view deleted question' do
     sign_in users(:editor)
     get :show, params: { id: posts(:deleted).id }
-    assert_response(401)
+    assert_response(403)
   end
 
   test 'should close question' do

--- a/test/controllers/tags_controller_test.rb
+++ b/test/controllers/tags_controller_test.rb
@@ -89,7 +89,7 @@ class TagsControllerTest < ActionController::TestCase
   test 'should deny edit to unprivileged user' do
     sign_in users(:standard_user)
     get :edit, params: { id: categories(:main).id, tag_id: tags(:topic).id }
-    assert_response 401
+    assert_response 403
   end
 
   test 'should get edit' do
@@ -111,7 +111,7 @@ class TagsControllerTest < ActionController::TestCase
     sign_in users(:standard_user)
     patch :update, params: { id: categories(:main).id, tag_id: tags(:topic).id,
                              tag: { parent_id: tags(:discussion).id, excerpt: 'things' } }
-    assert_response 401
+    assert_response 403
   end
 
   test 'should update tag' do


### PR DESCRIPTION
This commit replaces 401 status codes with 403s in some places to conform with HTTP specs

At the time of writing, no tests were run by the PR author.

Please feel free to mark this PR as draft if changes are required - this way its status is clear to everyone.

GitHub issue linking tag: closes #201