### PR TITLE
apply some stuff GitHub complains about

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Check if forked
       run: |
         if [ -z ${GITHUB_BASE_REF+x} ]; then IS_FORK=false; else IS_FORK=true; fi
-        echo "::set-env name=IS_FORK::${IS_FORK}"
+        echo "{name}={IS_FORK::${IS_FORK}} >> $GITHUB_ENV"
         echo "Is the pull request a fork? ${IS_FORK}"
 
     - name: Set up SSH key


### PR DESCRIPTION
Here: https://github.com/codidact/qpixel/pull/221/checks?check_run_id=1302596550 it's happening:

this: https://github.com/codidact/qpixel/actions/runs/326139586,

it tells:
> The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

So if you visit:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

From there you can jump to a reference of the replacement usage:
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files

This is for making y'all notice. Please do this on your own (if you feel like - I don't quite care) and whenever this does not happen anymore, close here unmerged.
