### PR TITLE
Fix first visit notice

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -135,8 +135,9 @@ $(document).on('ready', function() {
     });
   });
 
-
-  document.getElementById("fvn-dismiss").onclick = function() {
-    document.cookie = 'dismiss_fvn=true; path=/; expires=Fri, 31 Dec 9999 23:59:59 GMT';
+  if (document.cookie.indexOf ('dismiss_fvn') == -1 ) {
+    document.getElementById("fvn-dismiss").onclick = function() {
+      document.cookie = 'dismiss_fvn=true; path=/; expires=Fri, 31 Dec 9999 23:59:59 GMT';
+    }
   };
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -135,7 +135,7 @@ $(document).on('ready', function() {
     });
   });
 
-  if (document.cookie.indexOf ('dismiss_fvn') == -1 ) {
+  if (document.cookie.indexOf('dismiss_fvn') === -1 ) {
     document.getElementById("fvn-dismiss").onclick = function() {
       document.cookie = 'dismiss_fvn=true; path=/; expires=Fri, 31 Dec 9999 23:59:59 GMT';
     }

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -136,7 +136,7 @@ $(document).on('ready', function() {
   });
 
 
-  $('.js-first-visit-notice').on('close.bs.alert', async () => {
+  document.getElementById("fvn-dismiss").onclick = function() {
     document.cookie = 'dismiss_fvn=true; path=/; expires=Fri, 31 Dec 9999 23:59:59 GMT';
-  });
+  };
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -136,8 +136,8 @@ $(document).on('ready', function() {
   });
 
   if (document.cookie.indexOf('dismiss_fvn') === -1 ) {
-    document.getElementById("fvn-dismiss").onclick = function() {
+    $('#fvn_dismiss').on('click', () => {
       document.cookie = 'dismiss_fvn=true; path=/; expires=Fri, 31 Dec 9999 23:59:59 GMT';
-    }
+    });
   };
 });

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,8 +22,8 @@
           <% if @first_visit_notice %>
             <% notice = SiteSetting['FirstVisitGuidance'] %>
             <% if notice.present? %>
-              <div class="notice js-first-visit-notice">
-                <button type="button" class="button is-close-button" data-dismiss=".notice.js-first-visit-notice" aria-label="Close" id="fvn-dismiss">
+              <div class="notice js-first-visit-notice" id="fvn">
+                <button type="button" class="button is-close-button" data-dismiss="#fvn" aria-label="Close" id="fvn-dismiss">
                   <span aria-hidden="true">&times;</span>
                 </button>
                 <%= raw(sanitize(notice, scrubber: scrubber)) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
             <% notice = SiteSetting['FirstVisitGuidance'] %>
             <% if notice.present? %>
               <div class="notice js-first-visit-notice">
-                <button type="button" class="button is-close-button" data-dismiss="alert" aria-label="Close">
+                <button type="button" class="button is-close-button" data-dismiss=".notice.js-first-visit-notice" aria-label="Close">
                   <span aria-hidden="true">&times;</span>
                 </button>
                 <%= raw(sanitize(notice, scrubber: scrubber)) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
             <% notice = SiteSetting['FirstVisitGuidance'] %>
             <% if notice.present? %>
               <div class="notice js-first-visit-notice">
-                <button type="button" class="button is-close-button" data-dismiss=".notice.js-first-visit-notice" aria-label="Close">
+                <button type="button" class="button is-close-button" data-dismiss=".notice.js-first-visit-notice" aria-label="Close" id="fvn-dismiss">
                   <span aria-hidden="true">&times;</span>
                 </button>
                 <%= raw(sanitize(notice, scrubber: scrubber)) %>

--- a/app/views/layouts/without_sidebar.html.erb
+++ b/app/views/layouts/without_sidebar.html.erb
@@ -23,7 +23,7 @@
           <% notice = SiteSetting['FirstVisitGuidance'] %>
           <% if notice.present? %>
             <div class="notice js-first-visit-notice">
-              <button type="button" class="button is-close-button" data-dismiss="alert" aria-label="Close">
+              <button type="button" class="button is-close-button" data-dismiss=".notice.js-first-visit-notice" aria-label="Close" id="fvn-dismiss">
                 <span aria-hidden="true">&times;</span>
               </button>
               <%= raw(sanitize(notice, scrubber: scrubber)) %>

--- a/app/views/layouts/without_sidebar.html.erb
+++ b/app/views/layouts/without_sidebar.html.erb
@@ -22,8 +22,8 @@
         <% if @first_visit_notice %>
           <% notice = SiteSetting['FirstVisitGuidance'] %>
           <% if notice.present? %>
-            <div class="notice js-first-visit-notice">
-              <button type="button" class="button is-close-button" data-dismiss=".notice.js-first-visit-notice" aria-label="Close" id="fvn-dismiss">
+            <div class="notice js-first-visit-notice" id="fvn">
+              <button type="button" class="button is-close-button" data-dismiss="#fvn" aria-label="Close" id="fvn-dismiss">
                 <span aria-hidden="true">&times;</span>
               </button>
               <%= raw(sanitize(notice, scrubber: scrubber)) %>


### PR DESCRIPTION
This PR fixes an issue with the first visit notice, which also resolves an issue with opening the hamburger menu on mobile for sites with such a notice enabled.

This patch was tested on a local dev instance and on first inspection appears to work.

Please mark this as draft or submit a request changes review if changes are required.

GitHub issue linking tag: resolves #217.