### PR TITLE
First visit notice: Fix incorrect CSS selector

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -136,7 +136,7 @@ $(document).on('ready', function() {
   });
 
   if (document.cookie.indexOf('dismiss_fvn') === -1 ) {
-    $('#fvn_dismiss').on('click', () => {
+    $('#fvn-dismiss').on('click', () => {
       document.cookie = 'dismiss_fvn=true; path=/; expires=Fri, 31 Dec 9999 23:59:59 GMT';
     });
   };


### PR DESCRIPTION
This fixes an incorrectly implemented CSS selector from PR #223 by way of follow up.

The current version does not properly disable the first visit notice message (i.e. on refresh the notice will re-appear). This CSS fix will remove that regression.

This PR properly resolves issue #217.

In the event it is required, I can fix the CSS selector to use underscores in the layout files, hence mooting this PR. Let me know if that's the case.

Original reviewer ping as a follow up: /CC @ArtOfCode- 