### PR TITLE
Adds nbsp before 'by' in post history

### DIFF
--- a/app/views/post_history/post.html.erb
+++ b/app/views/post_history/post.html.erb
@@ -11,7 +11,7 @@
     <summary>
       <strong><%= event.post_history_type.name.humanize %></strong>
       <span class="text-muted">
-        by
+        &nbsp;by
         <% if event.user.nil? %>
           <span class="text-muted">(deleted user)</span>
         <% else %>


### PR DESCRIPTION
This is a super small fix for a small annoyance i've had on the site where the spacing between by and the edit type was missing. This addresses that.
broken: 
<img width="735" alt="Screen Shot 2020-11-11 at 4 39 44 PM" src="https://user-images.githubusercontent.com/18275831/98867451-8a307000-243c-11eb-93f1-9e3521802dad.png">

Fixed:
<img width="729" alt="Screen Shot 2020-11-11 at 4 40 17 PM" src="https://user-images.githubusercontent.com/18275831/98867482-99afb900-243c-11eb-9ffd-ee2e56e2eafd.png">
