### PR TITLE
Fix broken doc seeds

### DIFF
--- a/db/seeds/abilities/flag_close.html
+++ b/db/seeds/abilities/flag_close.html
@@ -1,5 +1,5 @@
 <h2>What does this ability allow me to do?</h2>
-<p>This ability allows you to vote to place questions and articles on hold, and to vote to reopen posts that are currently on hold; you can also see pending votes for either placing a post on hold or reopening a post. The reasons for placing a post on hold vary from site to site; the guidance for posts on this site is available in the [Help Center](/help/faq).</p>
+<p>This ability allows you to vote to place questions and articles on hold, and to vote to reopen posts that are currently on hold; you can also see pending votes for either placing a post on hold or reopening a post. The reasons for placing a post on hold vary from site to site; the guidance for posts on this site is available in the <a href="/help/faq">Help Center</a>.</p>
 
 <img src="/assets/ability-help/close-dialog.png" alt="the close dialog you can see with this ability">
 

--- a/db/seeds/posts/abilities.html
+++ b/db/seeds/posts/abilities.html
@@ -5,7 +5,7 @@
 <ul>
     <li><a href="/abilities/unrestricted"><strong>Participate Everywhere</strong></a> lifts new user restriction and raises rate limits</li>
     <li><a href="/abilities/edit_posts"><strong>Edit Posts</strong></a> allows you to edit other people's posts without review</li>
-    <li><a href="/abilities/edit_tagd"><strong>Edit Tags</strong></a> allows you to edit tag metadata</li>
+    <li><a href="/abilities/edit_tags"><strong>Edit Tags</strong></a> allows you to edit tag metadata</li>
     <li><a href="/abilities/flag_close"><strong>Vote on Holds</strong></a> gives you votes to put questions on hold and to reopen</li>
     <li><a href="/abilities/flag_curate"><strong>Curate</strong></a> gives you access to advanced moderation tools like seeing flags, deleting or locking posts</li>
 </ul>


### PR DESCRIPTION
Sorry if this PR is treading on anyone else's plans, but it seems like the linked issues are medium or high priority, so I went ahead and opened this.

This PR fixes 2 specific doc bugs: 
* one (issue flagged medium priority) relates to an abilities help page not rendering markdown properly, this was resolved by switching the link to an HTML one per precedent on related help pages
* the other (issue flagged high priority) relates to a help article linking to an incorrect location, this was resolved by fixing the URL to point to the correct location.

As always, please feel free to leave comments for review.

**Special note:** If not otherwise caused as a result of the deploy process, please ensure all Codidact sites are updated with the new db seed content if using default seeded content, and/or that any customized help articles based off the ones updated in this PR are fixed in a similar manner.

GitHub linking tag:
* Resolves #331 
* Resolves #332