### PR TITLE
Fix privilege escalation for tools display

### DIFF
--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -230,6 +230,8 @@
                   <% end %>
                 <% end %>
               <% end %>
+            <% end %>
+            <% if check_your_privilege('flag_curate') %>
               <a href="javascript:void(0);" data-modal="#mod-tools-<%= post.id %>" class="tools--item">
                 <i class="fa fa-wrench"></i>
                 Tools


### PR DESCRIPTION
Sounds scarier than it is; it's just that Tools and Show Flags Inline buttons were visible to the post author, even if they didn't have the flag_curate Abilities and so they were not connected to any action.