### PR TITLE
Update database.sample.yml to use default creds

### DIFF
--- a/config/database.sample.yml
+++ b/config/database.sample.yml
@@ -4,8 +4,8 @@ default: &default
   collation: utf8mb4_unicode_ci
   host: 127.0.0.1
   port: 3306
-  username: root
-  password: root
+  username: qpixel
+  password: choose_a_password_here
 
 development:
   <<: *default


### PR DESCRIPTION
When initializing the mysql database we create a user qpixel. The yml file uses root but should use qpixel instead.