### PR TITLE
Restore badges on user card

### DIFF
--- a/app/views/users/_common_card.html.erb
+++ b/app/views/users/_common_card.html.erb
@@ -10,6 +10,14 @@
     %>
     <%= link_to user_path(user), dir: 'ltr', class: 'user-card--link', data: data do %>
       <%= user.rtl_safe_username %>
+       <% if user.is_admin && SiteSetting['AdminBadgeCharacter'] %>
+        <span class="badge is-user-role" title="Administrator"><%= SiteSetting['AdminBadgeCharacter'] %></span>
+       <% elsif user.is_moderator && SiteSetting['ModBadgeCharacter'] %>
+        <span class="badge is-user-role" title="Moderator"><%= SiteSetting['ModBadgeCharacter'] %></span>
+       <% end %>
+       <% if user.staff? %>
+        <span class="badge is-tag is-filled is-green staff-badge">staff</span>
+       <% end %> 
     <% end %>
     <div class="user-card--meta">
       <% SiteSetting['UserCardDetails'].each_char do |detail| %>


### PR DESCRIPTION
This PR goes and restores badges (like admin, mod etc.) on user cards - they were removed by a previous PR.

If this PR is not appropriate, feel free to close.

//CC @luap42 as person who made the original removal

Issue link: Resolves issue #358.