### PR TITLE
Fix Dockerfile ruby version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.5
+FROM ruby:2.6.6
 
 # docker build -f docker/Dockerfile -t qpixel_uwsgi .
 


### PR DESCRIPTION
I was trying to build a Codidact instance using docker for development, but a bundle install failed for some reason due to a mismatch in ruby versions.

This PR upgrades ruby in docker to resolve that issue.