### PR TITLE
Option for mandatory 2fa for global staff

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -275,8 +275,8 @@ class ApplicationController < ActionController::Base
   if current_user &&
     !current_user.enabled_2fa? &&
     Rails.env.production? &&
-    # Users can set env var QPIXEL_DISABLE_MANDATORY_2FA to '1' to disable mandatory staff 2fa
-    ENV['QPIXEL_DISABLE_MANDATORY_2FA'] != "1" &&
+    # Don't enforce 2fa auth unless the setting is enabled
+    SiteSetting['EnableMandatoryGlobalAdminMod2FA'] &&
     # Enable users to log out even if 2fa is enforced
     !request.fullpath.end_with?("/users/sign_out") &&
     (current_user.is_global_admin ||

--- a/app/controllers/two_factor_controller.rb
+++ b/app/controllers/two_factor_controller.rb
@@ -1,5 +1,6 @@
 class TwoFactorController < ApplicationController
   before_action :authenticate_user!
+  skip_before_action :enforce_2fa
 
   def tf_status; end
 

--- a/db/seeds/site_settings.yml
+++ b/db/seeds/site_settings.yml
@@ -429,3 +429,10 @@
     Which details are to be shown on the user card. "." means new line, "r" reputation, "p" number of posts,
     "1" top-level posts, "2" second-level posts (answers), "s" score of votes received (up - down),
     "v" number of votes received, "V" number of votes cast, "E" number of edits made on posts.
+
+- name: EnableMandatoryGlobalAdminMod2FA
+  value: false
+  value_type: boolean
+  category: AdvancedSettings
+  description: >
+    Whether two-factor authentication should be enforced for all global admins and global moderators.


### PR DESCRIPTION
This PR implements mandatory 2fa for global staff (global admins and mods) for security purposes, due to their elevated access across the Codidact network.

A new site setting is added (its specific details may be changed through a suggested change via review), to enable this feature if and when it is toggled on. By default, this setting is set to false.

When this setting is enabled, all global staff will be forced to enable 2fa through 302 redirects. The only actions available to them in this forced mode are to enable 2fa or log out.

In an case of a 2fa lock out of a staff account, a sysadmin may disable the account's 2fa status. If there are issues with the redirects or enforcement, removal of the site setting by a sysadmin will disable the enforcement of 2fa.

This PR is submitted pursuant to a discussion on the platform's Discord server and should be treated accordingly.