### PR TITLE
Fix suggested edit notification URL

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -184,7 +184,7 @@ class PostsController < ApplicationController
           if @post_type.has_parent
             message += " on '#{@post.parent.title}'"
           end
-          @post.user.create_notification message, suggested_edit_path(edit)
+          @post.user.create_notification message, suggested_edit_url(edit, host: @post.community.host)
           redirect_to post_path(@post)
         else
           @post.errors = edit.errors


### PR DESCRIPTION
This PR fixes a suggested edit notification by using a URL instead of a site path.

I tested the PR by adding a second community on my local dev box and this patch works, at least for me.

Issue linking tag: resolves #373