### PR TITLE
Fix incorrect grammar in close reasons

### DIFF
--- a/db/seeds/close_reasons.yml
+++ b/db/seeds/close_reasons.yml
@@ -7,7 +7,7 @@
   active: true
   requires_other_post: false
 - name: unclear
-  description: This question cannot be answered in its current form, because critical information are missing.
+  description: This question cannot be answered in its current form, because critical information is missing.
   active: true
   requires_other_post: false
 - name: too generic


### PR DESCRIPTION
I think one of the close reasons has slightly incorrect grammar - this PR fixes that instance of incorrect grammar.

Happy for this to be closed and change directly made by a dev with write access.