### PR TITLE
Stop same post being used in close reasons for itself

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -229,7 +229,7 @@ class PostsController < ApplicationController
         return
       end
       
-      if other = @post
+      if other == @post
         render json: { status: 'failed', message: 'You can not close a post as a duplicate of itself' }, status: :bad_request
         return
       end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -228,6 +228,11 @@ class PostsController < ApplicationController
         render json: { status: 'failed', message: 'Invalid input for other post.' }, status: :bad_request
         return
       end
+      
+      if other = @post
+        render json: { status: 'failed', message: 'You can not close a post as a duplicate of itself' }, status: :bad_request
+        return
+      end
 
       duplicate_of = Question.find(params[:other_post])
     else


### PR DESCRIPTION
This PR blocks a post from being used to close itself as a duplicate, as well as for any other situation requiring a post as part of the close reason.

Currently, this just displays an HTTP 400 error, with details in JSON. Feel free to improve on the UX here, but it has the desired effect already.

GitHub issue linking tag: Fixes #218