### PR TITLE
Switch from unpkg and cdnjs CDNs to jsdelivr CDN

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -14,23 +14,25 @@
 <% icon_path = SiteSetting['IconPath'] %>
 <link rel="icon" href="<%= icon_path.present? ? icon_path : '/assets/favicon.ico' %>" />
 
-<%= stylesheet_link_tag "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" %>
-<%= stylesheet_link_tag "https://unpkg.com/@codidact/co-design@0.12.0/dist/codidact.css" %>
+<link rel="preconnect" href="https://cdn.jsdelivr.net" />
+
+<%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.11.2/css/all.min.css" %>
+<%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/@codidact/co-design@0.12.0/dist/codidact.css" %>
 <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/select2@4.0.12/dist/css/select2.min.css" %>
 <%= stylesheet_link_tag "/assets/community/#{@community.host.split('.')[0]}.css" %>
 <%= stylesheet_link_tag 'application', media: 'all' %>
 
-<%= javascript_include_tag "https://code.jquery.com/jquery-2.2.2.min.js" %>
-<%= javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js" %>
+<%= javascript_include_tag "https://cdn.jsdelivr.net/npm/jquery@2.2.2/dist/jquery.min.js" %>
+<%= javascript_include_tag "https://cdn.jsdelivr.net/npm/moment@2.13.0/min/moment.min.js" %>
 <%= javascript_include_tag "https://cdn.jsdelivr.net/npm/select2@4.0.12/dist/js/select2.min.js" %>
 <%= javascript_include_tag "/assets/community/#{@community.host.split('.')[0]}.js" %>
 <%= javascript_include_tag 'application' %>
-<script src="https://unpkg.com/@codidact/co-design@0.12.0/js/co-design.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/@codidact/co-design@0.12.0/js/co-design.js" defer></script>
 
 <% if SiteSetting['SyntaxHighlightingEnabled'] %>
   <link rel="stylesheet"
-        href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.2/styles/default.min.css">
-  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.2/highlight.min.js"></script>
+        href="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@10.1.2/build/styles/default.min.css">
+  <script src="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@10.1.2/build/highlight.min.js"></script>
   <script defer>hljs.initHighlightingOnLoad();</script>
 <% end %>
 

--- a/app/views/layouts/devise_mailer.html.erb
+++ b/app/views/layouts/devise_mailer.html.erb
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title><%= message.subject %></title>
-  <%= stylesheet_link_tag 'https://unpkg.com/@codidact/co-design@0.12.0/dist/codidact.css' %>
+  <%= stylesheet_link_tag 'https://cdn.jsdelivr.net/npm/@codidact/co-design@0.12.0/dist/codidact.css' %>
   <%= stylesheet_link_tag 'application', media: 'all' %>
 </head>
 <body>

--- a/app/views/posts/_markdown_script.html.erb
+++ b/app/views/posts/_markdown_script.html.erb
@@ -1,2 +1,2 @@
-<script type="application/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/markdown-it-footnote/3.0.2/markdown-it-footnote.min.js"></script>
-<script type="application/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/markdown-it/11.0.0/markdown-it.min.js"></script>
+<script type="application/javascript" src="https://cdn.jsdelivr.net/npm/markdown-it-footnote@3.0.2/dist/markdown-it-footnote.min.js"></script>
+<script type="application/javascript" src="https://cdn.jsdelivr.net/npm/markdown-it@11.0.0/dist/markdown-it.min.js"></script>


### PR DESCRIPTION
This patch switches all (where reasonably possible) JS and CSS packages in QPixel's header to be loaded from the JSDelivr CDN.

This change is made to ensure we are not loading static assets from multiple differing CDNs, which may marginally speed up site loading times. 

A tag has also been added to the HTML header to tell browsers to open a TCP connection before we try to load packages, however the speed up from this may be marginal, and it may be better deployed as an HTML tag.

As usual, if changes are required please request them and I will implement them where possible.  