### PR TITLE
Remove FNGM JS reference

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -26,7 +26,6 @@
 <%= javascript_include_tag "/assets/community/#{@community.host.split('.')[0]}.js" %>
 <%= javascript_include_tag 'application' %>
 <script src="https://unpkg.com/@codidact/co-design@0.12.0/js/co-design.js" defer></script>
-<%= javascript_include_tag "/assets/fngm-hotfix.js", defer: true %>
 
 <% if SiteSetting['SyntaxHighlightingEnabled'] %>
   <link rel="stylesheet"


### PR DESCRIPTION
In commit 8f36e90, the FNGM JS package was removed.

This change removes the reference to the package in the QPixel header, so the browser no longer attempts to load the (now nonexistent/present) code