### PR TITLE
Change db flags reason field to TEXT type

### DIFF
--- a/db/migrate/20210422090732_change_flags_reason_field_type.rb
+++ b/db/migrate/20210422090732_change_flags_reason_field_type.rb
@@ -1,0 +1,5 @@
+class ChangeFlagsReasonFieldType < ActiveRecord::Migration[5.2]
+  def change
+    change_column :flags, :reason, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_12_225651) do
+ActiveRecord::Schema.define(version: 2021_04_22_090732) do
 
   create_table "abilities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "community_id"
@@ -194,7 +194,7 @@ ActiveRecord::Schema.define(version: 2021_01_12_225651) do
   end
 
   create_table "flags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "reason"
+    t.text "reason"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"


### PR DESCRIPTION
This PR goes and adds various changes to migrate the "reason" column (used to store reasons for a flag) to a text type. This will require a db migration to be run if not otherwise automatically triggered.

No other changes have been made to the frontend or Rails controllers - only a db change has been made. As usual, please suggest changes to this PR if necessary.

GitHub issue linking tag: resolves #473 