### PR TITLE
Disable autocomplete on 2fa forms

### DIFF
--- a/app/views/custom_sessions/verify_2fa.html.erb
+++ b/app/views/custom_sessions/verify_2fa.html.erb
@@ -3,12 +3,12 @@
   Your account has two-factor authentication enabled. Enter a code from your authenticator app here.
 </p>
 
-<%= form_tag login_verify_code_path do %>
+<%= form_tag login_verify_code_path, autocomplete: 'off' do %>
   <%= hidden_field_tag 'uid', params[:uid] %>
 
   <div class="form-group">
     <%= label_tag 'code', 'Code', class: 'form-element' %>
-    <%= number_field_tag 'code', '', class: 'form-element' %>
+    <%= number_field_tag 'code', '', class: 'form-element', autocomplete: 'one-time-code' %>
   </div>
 
   <div class="actions">

--- a/app/views/two_factor/enable_code.html.erb
+++ b/app/views/two_factor/enable_code.html.erb
@@ -1,10 +1,10 @@
 <h1>Confirm your code</h1>
 <p>Last step: to confirm that you're all correctly set up, enter the code shown in your mobile authenticator below.</p>
 
-<%= form_tag two_factor_confirm_enable_path do %>
+<%= form_tag two_factor_confirm_enable_path, autocomplete: 'off' do %>
   <div class="field">
     <%= label_tag 'code', 'Code', class: 'form-element' %>
-    <%= text_field_tag 'code', '', class: 'form-element' %>
+    <%= number_field_tag 'code', '', class: 'form-element', autocomplete: 'one-time-code' %>
   </div>
 
   <%= submit_tag 'Confirm', class: 'button is-filled' %>


### PR DESCRIPTION
To resolve issue #482, I've made changes to the 2fa code forms to disable autocomplete. **I have not tested this** as I haven't worked with Ruby before, but I believe the code is correct based on examining other views. To test the pages affected, visit the following pages after logging in:

- http://localhost:3000/users/two-factor/enable/code
- http://localhost:3000/users/2fa/login