### PR TITLE
Update CodeQL configuration

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,7 +10,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-   # Apply least privilege to token 
+   # Apply principle of least privilege to GITHUB_TOKEN 
     permissions:
       actions: read
       contents: read
@@ -25,22 +25,7 @@ jobs:
       uses: github/codeql-action/init@v1
       with:
         languages: javascript
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
-
+    
+    # Actually perform an analysis
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   analyze:
-    name: Analyze
+    name: Analyze JS
     runs-on: ubuntu-latest
    # Apply principle of least privilege to GITHUB_TOKEN 
     permissions:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,27 +7,22 @@ on:
     - cron: '0 21 * * *'
 
 jobs:
-  CodeQL-Build:
-
+  analyze:
+    name: Analyze
     runs-on: ubuntu-latest
+   # Apply least privilege to token 
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
-      # Override language selection by uncommenting this and choosing your languages
       with:
         languages: javascript
 


### PR DESCRIPTION
This PR syncs the CodeQL code scanning configuration partially with GitHub's current "base" configuration for new repos.

The key changes made are:
1) Permissions are dropped  - the CodeQL job uses a GitHub Actions supplied "GITHUB_TOKEN" to authenticate. This token currently has write access to everything (except metadata) in this repo, which is a bad practice for when we don't need the access, and undesirable in the very unlikely event a bad actor is somehow able to use the token in write mode. This change drops permissions for the token and means we can enforce restrictive tokens in repository settings, thus making it clear what permissions we are granting and what we are not, as well as applying the principle of least privilege to them. You can see the difference between a permissive (current) and restricted (proposed token configuration) here: https://docs.github.com/en/actions/reference/authentication-in-a-workflow.
2) No more git history checkouts - previously, we fetched additional git history, for the purposes of not analyzing a merge commit. Due to GitHub warnings on every action, this change removes the code causing the checkout, thus dropping the warning for future actions runs
3) Autobuild code not relevant to this repo (only needed for compiled languages, as per the comment removed) is removed
4) The CodeQL job is renamed to be more descriptive of what it actually does
5) Some redundant comments have been removed, and others have been added to assist those reading the configuration file.

If someone with admin access to this repo wishes to take advantage of the new token security features from this PR, after merging navigate to (repository settings button) >> actions >> (select "read repository contents permission" from the buttons at the bottom) >> (click the save button under the options). This will update the token to not have unnecessary permissions, while still allowing the CodeQL job to pass.

As usual, if a change is required to this PR, please submit it as a code review.