### PR TITLE
Add keyboard shortcuts for markdown text editor

### DIFF
--- a/app/assets/javascripts/markdown.js
+++ b/app/assets/javascripts/markdown.js
@@ -49,6 +49,39 @@ $(() => {
     }
   });
 
+  $('.js-post-field').on('keydown', ev => {
+    if (ev.ctrlKey) {
+      switch (ev.keyCode) {
+        case 66:
+          $('[data-action="bold"]').click();
+          break;
+        
+        case 73:
+          $('[data-action="italic"]').click();
+          break;
+
+        case 75:
+          ev.preventDefault();
+          $('[data-modal="#markdown-link-insert"]').click();
+          break;
+
+        case 80:
+          ev.preventDefault();
+          $('[data-action="code"]').click();
+          break;
+
+        case 81:
+          $('[data-action="quote"]').click();
+          break;
+
+        case 85:
+          ev.preventDefault();
+          $('[data-modal="#markdown-image-upload"]').click();
+          break;
+      }
+    }
+  });
+
   $(document).on('click', '.js-markdown-insert-link', ev => {
     ev.preventDefault();
 


### PR DESCRIPTION
Resolves #274 - Add the following keyboard shortcuts for the markdown text editor as mentioned in the issue

> Ctrl-I - italics
> Ctrl-B - bold
> Ctrl-K - link
> Ctrl-P - preformatted
> Ctrl-Q - blockquote
> Ctrl-U - upload an image