### PR TITLE
show question on top of editing answer

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -54,6 +54,14 @@
     </p>
   <% end %>
 
+
+
+  <% if inline_parent && defined?(parent) && parent.present? %>
+    <h2><%= t('posts.responding_to')%></h2>
+
+    <%= render 'posts/expanded', post: parent  %>
+  <% end %>
+
   <%= render 'shared/body_field', f: f, field_name: :body_markdown, field_label: t('posts.body_label'), post: post %>
 
   <div class="post-preview"></div>
@@ -165,10 +173,4 @@
                 class: 'button is-muted is-outlined is-danger js-cancel-edit',
                 data: { question_body: t('posts.unsaved_changes_confirmation') } %>
   </div>
-<% end %>
-
-<% if inline_parent && defined?(parent) && parent.present? %>
-  <h2><%= t('posts.responding_to')%></h2>
-
-  <%= render 'posts/expanded', post: parent  %>
 <% end %>


### PR DESCRIPTION
I think that if "Responding to" or, question shows on top of answer (edit Answer) than it might look good. And, when the feature came I didn't notice that also.

I may set the code wrong way also. Cause, I didn't check main file properly. And, I am completely new to Ruby.