### PR TITLE
Only run push actions on main branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,8 @@ name: "CodeQL analysis"
 
 on:
   push:
+    branches:
+      - develop  
   pull_request:
   schedule:
     - cron: '0 21 * * *'


### PR DESCRIPTION
This PR limits the push actions trigger (for JS CodeQL) to only run on the develop branch.

Change prevents duplication of actions if a user with repo write access works in repo using a feature branch. 

If a change is required, please submit a request changes review with the appropriate changes required.