### PR TITLE
Fix post edit logic to check correct ability

### DIFF
--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -181,7 +181,7 @@
               History
             <% end %>
             <% if (post_type.is_public_editable && !post.locked?) || current_user&.is_moderator || post.user == current_user %>
-              <% if check_your_post_privilege(post, 'edit_post') %>
+              <% if check_your_post_privilege(post, 'edit_posts') %>
                 <% if post.pending_suggested_edit? %>
                   <%= link_to suggested_edit_url(post.pending_suggested_edit.id), class: 'tools--item is-danger is-filled' do %>
                     <i class="fa fa-spell-check"></i>


### PR DESCRIPTION
This fixes an incorrect labeling of "Suggest edit" on posts even where a user had the post edit ability.

An 's' was missing from the relevant conditional check, so that part of the check always returned 'false'. This gave non mod users the incorrect perception that they could only suggest post edits despite having full edit access.

GitHub issue linking tag: fixes #540