### PR TITLE
`skipping $number$ deleted comments` won't show

### DIFF
--- a/app/views/comments/thread.html.erb
+++ b/app/views/comments/thread.html.erb
@@ -80,7 +80,7 @@
       <%= render 'comments/comment', comment: comment, pingable: pingable %>
     </div>
   <% end %>
-  <% if skipped_deleted > 0 && current_user&.is_moderator%>
+  <% if skipped_deleted > 0 && (current_user&.is_moderator || current_user&.privilege?('flag_curate'))%>
     <div class="widget--body">
       <div class="deleted-comments">
         <p>

--- a/app/views/comments/thread.html.erb
+++ b/app/views/comments/thread.html.erb
@@ -80,7 +80,7 @@
       <%= render 'comments/comment', comment: comment, pingable: pingable %>
     </div>
   <% end %>
-  <% if skipped_deleted > 0 %>
+  <% if skipped_deleted > 0 && current_user&.is_moderator%>
     <div class="widget--body">
       <div class="deleted-comments">
         <p>


### PR DESCRIPTION
Someone had asked [Should regular users know that there are deleted comments?](https://meta.codidact.com/posts/282347#answer-282347). Usually, I think they should know. I had recently seen something in Math SE. I am just quoting what I saw.

>An user had commented that my process is correct and book is wrong. I didn't say anything. Another person told him that "no! you (that user) are wrong". And, briefly explained why he is wrong. Then, the user who told me that I am correct, he deleted his first comment. But, person who replied him he didn't delete that comment. If anyone see that comment he might fall in trouble cause, he might think that he replied to whom. 

That's why I think `skipping $number$  deleted comments` line may be helpful. But, in [that answer](https://meta.codidact.com/posts/282347#answer-282347), he didn't get any downvote that's why I am just proposing the changes. And, we can continue further discussion here ~ I guess. `skipping $number$ deleted comments` only won't show to regular users. It will show to moderators. 
Should user with curate privilege see the text also?