### PR TITLE
Starting a thread with a comment at least of 15 Chars

### DIFF
--- a/app/views/comments/_new_thread_modal.html.erb
+++ b/app/views/comments/_new_thread_modal.html.erb
@@ -17,7 +17,7 @@
         <%= label_tag :body, 'Your comment', class: 'form-element' %>
         <div class="form-caption">Start the thread with a comment.</div>
         <%= text_area_tag :body, '', class: 'form-element js-comment-field', data: { post: post.id, thread: '-1' },
-                          required: true %>
+                          required: true, minlength:"15" %>
         <span class="has-float-right has-font-size-caption js-character-count"
               data-target=".js-comment-field" data-max="500">0 / 500</span>
 


### PR DESCRIPTION
Starting a thread with a comment at least of 15 Chars.

Error Example:

![Screenshot](https://user-images.githubusercontent.com/71846550/125203453-afe67100-e278-11eb-872e-2773989c41c2.png)

Built using built in attribute in Text Area element (`minlength`).

Solves #541 