### PR TITLE
removing `.` from user card reputation

### DIFF
--- a/app/views/users/_common_card.html.erb
+++ b/app/views/users/_common_card.html.erb
@@ -35,7 +35,7 @@
           <span class="user-card--break"></span>
         <% when 'r' %>
           <span class="user-card--detail">
-            <%= user.reputation %> <span title="reputation">reputation.</span>
+            <%= user.reputation %> <span title="reputation">reputation</span>
           </span>
         <% when 'p' %>
           <span class="user-card--detail">

--- a/app/views/users/_common_card.html.erb
+++ b/app/views/users/_common_card.html.erb
@@ -35,7 +35,7 @@
           <span class="user-card--break"></span>
         <% when 'r' %>
           <span class="user-card--detail">
-            <%= user.reputation %> <span title="reputation">reputation</span>
+            <%= user.reputation %> <span>reputation</span>
           </span>
         <% when 'p' %>
           <span class="user-card--detail">


### PR DESCRIPTION
![Screenshot from 2021-07-13 01-44-32](https://user-images.githubusercontent.com/58106197/125397436-eeb11f80-e37b-11eb-8c43-254f135b3972.png)
![Screenshot from 2021-07-13 01-44-42](https://user-images.githubusercontent.com/58106197/125397449-f375d380-e37b-11eb-8621-80c1a7955e26.png)
The `.` isn't necessary while it is written reputation. Even, the card is looking more better than earlier without the `.`