### PR TITLE
Hide impersonate user link for non developers

### DIFF
--- a/app/views/users/mod.html.erb
+++ b/app/views/users/mod.html.erb
@@ -12,7 +12,9 @@
       <li><a href="/users/<%= @user.id %>/mod/privileges">privileges</a></li>
       <li><a href="/warning/log/<%= @user.id %>">warnings and suspensions sent to user</a> <% if @user.community_user.suspended? %>(includes lifting the suspension)<% end %></li>
       <li><a href="/warning/new/<%= @user.id %>">warn or suspend user</a></li>
-      <li><%= link_to 'impersonate', start_impersonating_path(@user), class: 'is-yellow' %></li>
+      <% if current_user.developer %>
+       <li><%= link_to 'impersonate', start_impersonating_path(@user), class: 'is-yellow' %></li>
+      <% end %>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
Please don't expose the impersonate link to non devs, as they will simply get a 404 error if they click it

This PR gates the impersonate user link behind a developer check, and has not been validated on any test system by its author. The route itself is behind a dev check already - this just hides the otherwise broken for non dev UI element.