### PR TITLE
disable button by default

### DIFF
--- a/app/views/comments/thread.html.erb
+++ b/app/views/comments/thread.html.erb
@@ -134,7 +134,7 @@
               <span class="js-character-count__count">0 / 500</span>
             </span>
             
-            <%= submit_tag 'Add reply', class: 'button is-muted is-filled' %>
+            <%= submit_tag 'Add reply', class: 'button is-muted is-filled', disabled:true %>
           <% end %>
         <% end %>
       <% elsif @comment_thread.deleted %>


### PR DESCRIPTION
The button should be disabled by default. Which means it will be disable when there's no text available