### PR TITLE
Update comments_controller.rb

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -80,8 +80,7 @@ class CommentsController < ApplicationController
         existing_notification = follower.user.notifications.where(is_read: false)
                                         .where('link LIKE ?', "#{helpers.comment_link(@comment)}%")
         unless existing_notification.exists?
-          follower.user.create_notification("There are new comments in a followed thread '#{@comment_thread.title}' " \
-                                            "on the post '#{@post.title}'",
+          follower.user.create_notification("There are new comments in a followed thread '#{@comment_thread.title}' on the post '#{@post.title}'",
                                             helpers.comment_link(@comment))
         end
       end
@@ -291,8 +290,7 @@ class CommentsController < ApplicationController
       next if user.nil?
 
       unless user.id == @comment.post.user_id
-        user.create_notification("You were mentioned in a comment to #{@comment_thread.title} " \
-                                 "on the post '#{@post.title}'",
+        user.create_notification("You were mentioned in a comment to #{@comment_thread.title} on the post '#{@post.title}'",
                                  helpers.comment_link(@comment))
       end
     end


### PR DESCRIPTION
Earlier there was formatting problem. I was thinking how you wanted to set it. But, couldn't understand that's why I am removing it.

I think you wanted output something just like this : `"There are new comments in a followed thread title "  "on the post post_title"`. But, I can't see why we need quotation mark that way. Your formatting was little bit buggy. e.g. `There are new comments in a followed thread 'Funny that...' on the post ''` I wonder Why " quotation mark had became ' ' (in last example)