### PR TITLE
Update _comment.html.erb

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -38,7 +38,7 @@
     <div class="comment--links">
       <%= link_to comment_link(comment), class: 'tools--item js-permalink' do %>
         <i class="fa fa-link"></i>
-        <span class="js-text">Permalink</span>
+        <span class="js-text">Copy Link</span>
       <% end %>
       <a href="<%= comment_link(comment) %>">link</a>
       <% if with_post_link %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -36,9 +36,16 @@
       <span title="<%= comment.created_at.iso8601 %>"><%= time_ago_in_words(comment.created_at) %> ago:</span>
     </div>
     <div class="comment--links">
-      <%= link_to comment_link(comment), class: 'tools--item js-permalink' do %>
-        <i class="fa fa-link"></i>
-        <span class="js-text">Copy Link</span>
+      <% if params[:inline] != 'true' %>
+        <%= link_to comment_link(comment), class: 'tools--item js-permalink' do %>
+          <i class="fa fa-link"></i>
+          <span class="js-text">Permalink</span>
+        <% end %>
+      <% else %>
+        <a href="<%= comment_link(comment) %>">link</a>
+        <% if with_post_link %>
+          <%= link_to 'post', generic_share_link(comment.post) %>
+        <% end %>
       <% end %>
       <% if user_signed_in? && (comment.user == current_user || current_user.is_moderator) && params[:inline] != 'true' %>
         <a href="#" class="js-comment-edit">edit</a>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -40,10 +40,6 @@
         <i class="fa fa-link"></i>
         <span class="js-text">Copy Link</span>
       <% end %>
-      <a href="<%= comment_link(comment) %>">link</a>
-      <% if with_post_link %>
-        <%= link_to 'post', generic_share_link(comment.post) %>
-      <% end %>
       <% if user_signed_in? && (comment.user == current_user || current_user.is_moderator) && params[:inline] != 'true' %>
         <a href="#" class="js-comment-edit">edit</a>
         <% if comment.deleted %>


### PR DESCRIPTION
Usually, earlier it wasn't changing to Copy in Post page. So, I think Copy Link would be better by default

![Screenshot from 2021-08-03 04-48-57](https://user-images.githubusercontent.com/58106197/127987058-ae04ee6f-77ba-405d-a301-b4e794a4fe9e.png)
![Screenshot from 2021-08-03 04-49-09](https://user-images.githubusercontent.com/58106197/127987065-a03aaaca-ea6a-47d5-bca6-8df2eb1e5ee0.png)


Earlier, the UI was little bit messy for Android.