### PR TITLE
Make requested answer be the top result

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -115,7 +115,7 @@ class PostsController < ApplicationController
 
   def show
     if @post.parent_id.present?
-      return redirect_to post_path(@post.parent_id)
+      return redirect_to post_path(@post.parent_id, answer: @post.id, anchor: "answer-#{@post.id}")
     end
 
     if @post.post_type_id == HelpDoc.post_type_id
@@ -143,6 +143,7 @@ class PostsController < ApplicationController
                   Post.where(parent_id: @post.id).undeleted
                       .or(Post.where(parent_id: @post.id, user_id: current_user&.id))
                 end.includes(:votes, :user, :comments, :license, :post_type)
+                .order(Post.arel_table[:id].not_eq(params[:answer]))
                 .user_sort({ term: params[:sort], default: Arel.sql('deleted ASC, score DESC, RAND()') },
                            score: Arel.sql('deleted ASC, score DESC, RAND()'), age: :created_at)
                 .paginate(page: params[:page], per_page: 20)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -77,11 +77,7 @@ module ApplicationHelper
   end
 
   def generic_share_link(post)
-    if second_level_post_types.include?(post.post_type_id)
-      post_url(post, anchor: "answer-#{post.id}")
-    else
       post_url(post)
-    end
   end
 
   def generic_edit_link(post)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -77,7 +77,11 @@ module ApplicationHelper
   end
 
   def generic_share_link(post)
+    if second_level_post_types.include?(post.post_type_id)
+      answer_post_url(id: post.parent_id, answer: post.id, anchor: "answer-#{post.id}")
+    else
       post_url(post)
+    end
   end
 
   def generic_edit_link(post)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,6 +101,7 @@ Rails.application.routes.draw do
     get    ':id',                          to: 'posts#show', as: :post
 
     get    ':id/history',                  to: 'post_history#post', as: :post_history
+    get    ':id/:answer',                  to: 'posts#show', as: :answer_post
     post   'upload',                       to: 'posts#upload', as: :upload
     post   'save-draft',                   to: 'posts#save_draft', as: :save_draft
     post   'delete-draft',                 to: 'posts#delete_draft', as: :delete_draft


### PR DESCRIPTION
Closes #518 

Creates a new path `/posts/:id/:answer` which puts the requested answer at the top of the list of answers. Post links (e.g. the Table of Contents and Copy Link) have been updated to use this path.