### PR TITLE
update text

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -37,7 +37,7 @@
     </div>
     <div class="comment--links">
       <%= link_to comment_link(comment), class: 'js-comment-permalink' do %>
-        <span class="js-text">permalink</span>
+        <span class="js-text">copy link</span>
       <% end %>
       <% if with_post_link %>
         <%= link_to 'post', generic_share_link(comment.post) %>


### PR DESCRIPTION
It should be Copy Link by default cause, it is showing "Permalink" in post page. When user click on that they get Copied then, Copy Link. So, Copy link is better than Permalink I guess.