### PR TITLE
Add maximum title length controls

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -34,6 +34,7 @@ class Post < ApplicationRecord
   validate :maximum_tag_length, if: -> { post_type.has_tags }
   validate :no_spaces_in_tags, if: -> { post_type.has_tags }
   validate :stripped_minimum, if: -> { post_type.has_tags }
+  validate :maximum_title_length, if: -> { post_type.has_tags }    
   validate :category_allows_post_type, if: -> { category_id.present? }
   validate :license_valid, if: -> { post_type.has_license }
   validate :required_tags?, if: -> { post_type.has_tags && post_type.has_category }
@@ -264,6 +265,13 @@ class Post < ApplicationRecord
     end
     if (title&.gsub(/(?:^[\s\t\u2000-\u200F]+|[\s\t\u2000-\u200F]+$)/, '')&.length || 0) < 15
       errors.add(:title, 'must be more than 15 non-whitespace characters long')
+    end
+  end
+  
+  def maximum_title_length
+    max_title_len = SiteSetting['MaxTitleLength']
+    if title.length > max_title_len
+      errors.add(:title, "can't be more than #{max_title_len} characters")
     end
   end
 

--- a/db/seeds/site_settings.yml
+++ b/db/seeds/site_settings.yml
@@ -150,6 +150,14 @@
   description: >
     The maximum characters a single tag name may contain. Default is 35 for compatibility with Stack Exchange; going lower
     may introduce validation issues with content imported from SE.
+    
+- name: MaxTitleLength
+  value: 150
+  value_type: integer
+  category: SiteDetails
+  description: >
+    The maximum characters a post title may contain. Default is 150 for compatibility with Stack Exchange; going lower
+    may introduce validation issues with content imported from SE.    
 
 - name: MaxUploadSize
   value: 2MB


### PR DESCRIPTION
We've had a bunch of testers create 200+ character titles for posts on the dev server. I haven't seen this on prod, but to avoid any long term issues its best to place an upper bound on titles.

This patch adds a validator to check the title max length against a site setting value. There is no provision in the code to retroactively enforce this.

Max title length site setting defaults to 150 chars as that is what appears to be the equivalent limit for sites we have previously imported data from.

This also makes some small steps toward resolving issue #582.