### PR TITLE
Don't put "last activity" on new posts

### DIFF
--- a/app/views/posts/_list.html.erb
+++ b/app/views/posts/_list.html.erb
@@ -43,7 +43,7 @@
       <% end %>
       posted <span title="<%= post.created_at.iso8601 %>"><%= time_ago_in_words(post.created_at, locale: :en_abbrev) %> ago</span>
       by <%= link_to post.user.rtl_safe_username, user_path(post.user), dir: 'ltr' %>&nbsp;&middot;&nbsp;
-      <% if @last_activity %>
+      <% if post.last_activity != post.created_at %>
         last activity
         <span title="<%= post.last_activity.iso8601 %>"><%= time_ago_in_words(post.last_activity, locale: :en_abbrev) %> ago</span>
         by <%= link_to active_user.rtl_safe_username, user_path(active_user), dir: 'ltr' %>


### PR DESCRIPTION
`@last_activity` isn't important cause, whatever we do that is captured in last_activity. So, last activity forever exists. And, my system has some timing issue that's why I I couldn't test the code. As far as I know it should work. Cause, we know that last_activity's time only match post.created_at ones not twice.  So, when those time isn't equal then, show last_activity.

https://meta.codidact.com/posts/283234