### PR TITLE
Remove username from account edit form

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -19,11 +19,6 @@
   <% end %>
 
   <div class="form-group">
-    <%= f.label :username, class: "form-element" %>
-    <%= f.text_field :username, class: 'form-element', autocomplete: 'off' %>
-  </div>
-
-  <div class="form-group">
     <%= f.label :password, class: "form-element" %>
     <div class="form-caption">
       Leave blank if you don't want to change it.


### PR DESCRIPTION
This PR removes the username field from the devise edit form (which backs users' account tabs on their profile page). 

This reduces duplication of fields, as username is now centrally managed in the same place where profile images, bios and social links are managed instead of a page with more sensitive controls (such as 2fa, email and password). 

I briefly tested the change on the dev server with a live code edit that I then reverted - since it is an html erb file I didn't go and restart the qpixel process before/after the test.

The matter was discussed in the issue linked by the linking tag below.

GitHub linking tag: Resolves #576.