### PR TITLE
User can edit, delete or undelete from post page

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -42,7 +42,7 @@
       <% if with_post_link %>
         <%= link_to 'post', generic_share_link(comment.post) %>
       <% end %>
-      <% if user_signed_in? && (comment.user == current_user || current_user.is_moderator) && params[:inline] != 'true' %>
+      <% if user_signed_in? && (comment.user == current_user || current_user.is_moderator) %>
         <a href="#" class="js-comment-edit">edit</a>
         <% if comment.deleted %>
           <a href="#" class="is-red js-comment-undelete">undelete</a>


### PR DESCRIPTION
When I was trying to remove inline from flag I noticed, flag's popup isn't showing in post page. That's why  I am not removing inline from flag now. It needs some more works I think.

Usually, I was trying to find which javascript file is fetching data-drop. But, I didn't find any specific page. I was searching in flags.js that page didn't add is-active class either. That's why I can't take a look for flags. I was trying to add is-active my own way. But, there was some problem. That's why I am not doing that.