### PR TITLE
Change db notifications content field to TEXT type

### DIFF
--- a/db/migrate/20210821080736_change_notifications_content_field_type.rb
+++ b/db/migrate/20210821080736_change_notifications_content_field_type.rb
@@ -1,0 +1,5 @@
+class ChangeNotificationsContentFieldType < ActiveRecord::Migration[5.2]
+  def change
+    change_column :notifications, :content, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_29_174224) do
+ActiveRecord::Schema.define(version: 2021_08_21_080736) do
 
   create_table "abilities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "community_id"
@@ -262,7 +262,7 @@ ActiveRecord::Schema.define(version: 2021_07_29_174224) do
   end
 
   create_table "notifications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "content"
+    t.text "content"
     t.string "link"
     t.boolean "is_read", default: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
This PR goes and adds various changes to migrate the "content" column (used to store reasons for notifications) to a text type. This will require a db migration to be run if not otherwise automatically triggered.

As usual, please suggest changes to this PR if necessary.

GitHub issue linking tag: resolves #626
