### PR TITLE
Remove username from devise parameters

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:username, :profile, :website, :twitter])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:profile, :website, :twitter])
   end
 
   def not_found(**add)


### PR DESCRIPTION
Let's ensure that the backend reflects the frontend by removing the username param from devise allowlist

This completes functionality realignment started in PR #614
