### PR TITLE
let user don't use $$Math$$

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -52,7 +52,7 @@ class PostsController < ApplicationController
     if @post.title?
       if @post.title.include? "$$"
         flash[:danger] = I18n.t 'posts.no_block_mathjax_title'
-        redirect_back fallback_location: root_path
+        render :new, status: :bad_request
         return
       end
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -51,7 +51,7 @@ class PostsController < ApplicationController
 
     if @post.title?
       if @post.title.include? "$$"
-        flash[:danger] = helpers.i18ns('You shouldn\'t use $$', type: @post_type.name)
+        flash[:danger] = helpers.i18ns('Title can not contain "$$"', type: @post_type.name)
         redirect_back fallback_location: root_path
         return
       end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -49,6 +49,14 @@ class PostsController < ApplicationController
     @post = Post.new(post_params.merge(user: current_user, body: helpers.post_markdown(:post, :body_markdown),
                                        category: @category, post_type: @post_type, parent: @parent))
 
+    if @post.title?
+      if @post.title.include? "$$"
+        flash[:danger] = helpers.i18ns('You shouldn\'t use $$', type: @post_type.name)
+        redirect_back fallback_location: root_path
+        return
+      end
+    end
+
     if @post_type.has_parent? && @parent.nil?
       flash[:danger] = helpers.i18ns('posts.type_requires_parent', type: @post_type.name)
       redirect_back fallback_location: root_path

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -51,7 +51,7 @@ class PostsController < ApplicationController
 
     if @post.title?
       if @post.title.include? "$$"
-        flash[:danger] = helpers.i18ns('Title can not contain "$$"', type: @post_type.name)
+        flash[:danger] = I18n.t 'posts.no_block_mathjax_title'
         redirect_back fallback_location: root_path
         return
       end

--- a/config/locales/strings/en.posts.yml
+++ b/config/locales/strings/en.posts.yml
@@ -64,3 +64,5 @@ en:
       In a URL of "https://yoursite.codidact.com/help/topic", the "topic" is the slug.
     responding_to: >
       Responding to:
+    no_block_mathjax_title: >
+     Title cannot contain block-level MathJax.

--- a/config/locales/strings/en.posts.yml
+++ b/config/locales/strings/en.posts.yml
@@ -65,4 +65,4 @@ en:
     responding_to: >
       Responding to:
     no_block_mathjax_title: >
-     Title cannot contain block-level MathJax.
+      Title cannot contain block-level MathJax.


### PR DESCRIPTION
I am not sure how can I update text of error. 

Error : translation missing: en.You shouldn't use $$

I don't have any idea why translation missing is showing. I guess, `, type: @post_type.name` not required

Resolves : https://github.com/codidact/qpixel/issues/633