### PR TITLE
Quick fix to the Code Golf leaderboard script

### DIFF
--- a/public/assets/community/codegolf.js
+++ b/public/assets/community/codegolf.js
@@ -70,7 +70,7 @@
 
     const pagePromises = [];
     for (let i = 1; i <= num_pages; i++) {
-      pagePromises.push(fetch(`/posts/${id}?sort=age&page=${i}`).then(response => response.text()));
+      pagePromises.push(fetch(`/posts/${id}?sort=active&page=${i}`).then(response => response.text()));
     }
 
     const leaderboard = [];


### PR DESCRIPTION
`sort=age` no longer works, apparently, so I changed it to use `sort=active` instead.