### PR TITLE
Expand thread in post page

### DIFF
--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -45,7 +45,7 @@ $(() => {
     $inlineHeader.removeClass('hide');
     $jsExpandThread.addClass('hide');
     $inlineComments.removeClass('hide');
-    $comments.removeClass('hide');
+    $comments.addClass('hide');
     //$commentsAdditionalTools.removeClass('hide');
     $inlineCommentField.removeClass('hide');
     

--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -31,6 +31,25 @@ $(() => {
     window.MathJax && MathJax.typeset();
   });
 
+  $(document).on('click', '.js-expand-thread', evt => {
+    const $droppanel = $('.inline-droppanel');
+    const $footerInlineThread = $('.footer-inline-thread');
+    const $inlineHeader = $('.inline--header');
+    const $jsExpandThread = $('.js-expand-thread');
+    const $inlineComments = $('.inline-comments');
+    const $comments = $('.comments');
+    const $commentsAdditionalTools = $('.comment-additional-tools');
+    const $inlineCommentField = $('.inline-comment-field');
+    $droppanel.removeClass('hide');
+    $footerInlineThread.addClass('hide');
+    $inlineHeader.removeClass('hide');
+    $jsExpandThread.addClass('hide');
+    $inlineComments.removeClass('hide');
+    $comments.removeClass('hide');
+    $commentsAdditionalTools.removeClass('hide');
+    $inlineCommentField.removeClass('hide');
+  });
+  
   $(document).on('click', '.js-collapse-thread', async ev => {
     const $tgt = $(ev.target);
     const $widget = $tgt.parents('.widget');

--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -48,6 +48,12 @@ $(() => {
     $comments.removeClass('hide');
     $commentsAdditionalTools.removeClass('hide');
     $inlineCommentField.removeClass('hide');
+    
+    //just hiding them since they aren't working for inline
+    const $flag = $('.js-comment-flag');
+    const $tools = $('.mod-tools');
+    $flag.addClass('hide');
+    $tools.addClass('hide');
   });
   
   $(document).on('click', '.js-collapse-thread', async ev => {

--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -46,13 +46,11 @@ $(() => {
     $jsExpandThread.addClass('hide');
     $inlineComments.removeClass('hide');
     $comments.removeClass('hide');
-    $commentsAdditionalTools.removeClass('hide');
+    //$commentsAdditionalTools.removeClass('hide');
     $inlineCommentField.removeClass('hide');
     
     //just hiding them since they aren't working for inline
-    const $flag = $('.js-comment-flag');
     const $tools = $('.mod-tools');
-    $flag.addClass('hide');
     $tools.addClass('hide');
   });
   

--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -46,12 +46,23 @@ $(() => {
     $jsExpandThread.addClass('hide');
     $inlineComments.removeClass('hide');
     $comments.addClass('hide');
-    //$commentsAdditionalTools.removeClass('hide');
+    $commentsAdditionalTools.removeClass('hide');
     $inlineCommentField.removeClass('hide');
     
     //just hiding them since they aren't working for inline
     const $tools = $('.mod-tools');
     $tools.addClass('hide');
+  });
+  
+  $(document).on('click', '.flag-button', ['data-drop'], ev => {
+      const $tgt = $(ev.target);
+      const $data = $($tgt.attr('data-drop'));
+      console.log('hello');
+      if($data.hasClass('is-active')){
+          $data.removeClass('is-active');
+      }else{
+          $data.addClass('is-active');
+      }
   });
   
   $(document).on('click', '.js-collapse-thread', async ev => {

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -60,8 +60,12 @@
         <% if params[:inline] == 'true' %>
           <div class="comment-additional-tools hide">
         <% end %>
-          <a href="javascript:void(0)" data-drop="#flag-comment-<%= comment.id %>">flag</a>
-          <div class="droppanel is-large h-c-black" id="flag-comment-<%= comment.id %>">
+          <% if params[:inline] == 'true' %>
+            <a href="javascript:void(0)" class="flag-button" data-drop=".flag-comment-<%= comment.id %>">flag</a>
+          <% else %>
+            <a href="javascript:void(0)" data-drop="#flag-comment-<%= comment.id %>">flag</a>
+          <% end %>
+          <div class="droppanel is-large h-c-black flag-comment-<%= comment.id %>" id="flag-comment-<%= comment.id %>">
             <label for="flag-post-<%= comment.id %>">Flag reason</label>
             <input type="text" id="flag-post-<%= comment.id %>" class="form-element" />
             <a href="javascript:void(0)" class="flag-link js-comment-flag button is-danger" data-post-id="<%= comment.id %>"

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -42,22 +42,34 @@
       <% if with_post_link %>
         <%= link_to 'post', generic_share_link(comment.post) %>
       <% end %>
-      <% if user_signed_in? && (comment.user == current_user || current_user.is_moderator) && params[:inline] != 'true' %>
-        <a href="#" class="js-comment-edit">edit</a>
-        <% if comment.deleted %>
-          <a href="#" class="is-red js-comment-undelete">undelete</a>
-        <% else %>
-          <a href="#" class="is-red js-comment-delete">delete</a>
+      <% if user_signed_in? && (comment.user == current_user || current_user.is_moderator) %>
+        <% if params[:inline] == 'true' %>
+          <div class="comment-additional-tools hide">
+        <% end %>
+          <a href="#" class="js-comment-edit">edit</a>
+          <% if comment.deleted %>
+            <a href="#" class="is-red js-comment-undelete">undelete</a>
+          <% else %>
+            <a href="#" class="is-red js-comment-delete">delete</a>
+          <% end %>
+        <% if params[:inline] == 'true' %>
+          </div>
         <% end %>
       <% end %>
-      <% if user_signed_in? && params[:inline] != 'true' %>
-        <a href="javascript:void(0)" data-drop="#flag-comment-<%= comment.id %>">flag</a>
-        <div class="droppanel is-large h-c-black" id="flag-comment-<%= comment.id %>">
-          <label for="flag-post-<%= comment.id %>">Flag reason</label>
-          <input type="text" id="flag-post-<%= comment.id %>" class="form-element" />
-          <a href="javascript:void(0)" class="flag-link js-comment-flag button is-danger" data-post-id="<%= comment.id %>"
-             data-requires-details="true">Flag</a>
-        </div>
+      <% if user_signed_in? %>
+        <% if params[:inline] == 'true' %>
+          <div class="comment-additional-tools hide">
+        <% end %>
+          <a href="javascript:void(0)" data-drop="#flag-comment-<%= comment.id %>">flag</a>
+          <div class="droppanel is-large h-c-black" id="flag-comment-<%= comment.id %>">
+            <label for="flag-post-<%= comment.id %>">Flag reason</label>
+            <input type="text" id="flag-post-<%= comment.id %>" class="form-element" />
+            <a href="javascript:void(0)" class="flag-link js-comment-flag button is-danger" data-post-id="<%= comment.id %>"
+               data-requires-details="true">Flag</a>
+          </div>
+        <% if params[:inline] == 'true' %>
+          </div>
+        <% end %>    
       <% end %>
     </div>
   </div>

--- a/app/views/comments/thread.html.erb
+++ b/app/views/comments/thread.html.erb
@@ -29,8 +29,14 @@
       </a>
       <a href="javascript:void(0)" class="js-collapse-thread widget--header-link">
         collapse
+      </a>   
+      <a href="javascript:void(0)" class="js-expand-thread widget--header-link">
+        expand
       </a>
-    <% else %>
+    <% end %>
+    <% if params[:inline] == 'true' %>
+      <div class="inline--header hide">
+    <% end %>
       <% if current_user&.privilege? 'flag_curate' %>
         <a href="#" class="widget--header-link" data-drop=".js--tools-thread-<%= @comment_thread.id %>"><i class="fa fa-cog fa-fw"></i>tools</a>
       <% end %>
@@ -47,6 +53,8 @@
           </a>
         <% end %>
       <% end %>
+    <% if params[:inline] == 'true' %>
+      </div>
     <% end %>
     <% if @comment_thread.deleted %>
       <i class="fas fa-trash fa-fw" title="Deleted. This thread has been deleted."></i>
@@ -59,39 +67,83 @@
   </div>
   <% skipped_deleted = 0 %>
   <% comments = @comment_thread.comments %>
+  
+  <!--below code is only for inline preview. It will fetch all of comments-->
   <% if params[:inline] == 'true' %>
-    <% comments = comments.where(deleted: false).take 5 %>
-  <% end %>
-  <% comments.each do |comment| %>
-    <% if comment.deleted && !(current_user&.is_moderator && params[:show_deleted_comments] == "1") %>
-      <% skipped_deleted += 1%>
-      <% next %>
-    <% elsif skipped_deleted > 0 %>
-      <div class="widget--body">
-        <div class="deleted-comments">
-          <p>
-          <% if skipped_deleted == 1 %>
-            Skipping <%= skipped_deleted %> deleted comment.
-            <% if current_user&.is_moderator %>
-              <a href="?show_deleted_comments=1">Show it anyway.</a>
-            <% end %>
-          <% else %>
-            Skipping <%= skipped_deleted %> deleted comments.
-            <% if current_user&.is_moderator %>
-              <a href="?show_deleted_comments=1">Show them anyway.</a>
-            <% end %>
-          <% end %>
-          </p>
+    <div class="inline-comments hide">
+      <% comments.each do |comment| %>
+        <% if comment.deleted && !(current_user&.is_moderator && params[:show_deleted_comments] == "1") %>
+          <% skipped_deleted += 1%>
+          <% next %>
+        <% elsif skipped_deleted > 0 %>
+          <div class="widget--body">
+            <div class="deleted-comments">
+              <p>
+                <% if skipped_deleted == 1 %>
+                  Skipping <%= skipped_deleted %> deleted comment.
+                  <% if current_user&.is_moderator %>
+                    <a href="?show_deleted_comments=1">Show it anyway.</a>
+                  <% end %>
+                <% else %>
+                  Skipping <%= skipped_deleted %> deleted comments.
+                  <% if current_user&.is_moderator %>
+                    <a href="?show_deleted_comments=1">Show them anyway.</a>
+                  <% end %>
+                <% end %>
+              </p>
+            </div>
+          </div>
+          <% skipped_deleted = 0 %>
+        <% else %>
+          <% skipped_deleted = 0 %>
+        <% end %>
+        <div class="widget--body">
+          <%= render 'comments/comment', comment: comment, pingable: pingable %>
         </div>
-      </div>
-      <% skipped_deleted = 0 %>
-    <% else %>
-      <% skipped_deleted = 0 %>
-    <% end %>
-    <div class="widget--body">
-      <%= render 'comments/comment', comment: comment, pingable: pingable %>
+      <% end %>
     </div>
   <% end %>
+  <!--completely fetched all comments-->
+  
+  <% if params[:inline] == 'true' %>
+    <div class="comments">
+  <% end %>
+    <% if params[:inline] == 'true' %>
+      <% comments = comments.where(deleted: false).take 5 %>
+    <% end %>
+    <% comments.each do |comment| %>
+      <% if comment.deleted && !(current_user&.is_moderator && params[:show_deleted_comments] == "1") %>
+        <% skipped_deleted += 1%>
+        <% next %>
+      <% elsif skipped_deleted > 0 %>
+        <div class="widget--body">
+          <div class="deleted-comments">
+            <p>
+            <% if skipped_deleted == 1 %>
+              Skipping <%= skipped_deleted %> deleted comment.
+              <% if current_user&.is_moderator %>
+                <a href="?show_deleted_comments=1">Show it anyway.</a>
+              <% end %>
+            <% else %>
+              Skipping <%= skipped_deleted %> deleted comments.
+              <% if current_user&.is_moderator %>
+                <a href="?show_deleted_comments=1">Show them anyway.</a>
+              <% end %>
+            <% end %>
+            </p>
+          </div>
+        </div>
+        <% skipped_deleted = 0 %>
+      <% else %>
+        <% skipped_deleted = 0 %>
+      <% end %>
+      <div class="widget--body">
+        <%= render 'comments/comment', comment: comment, pingable: pingable %>
+      </div>
+    <% end %>
+  <% if params[:inline] == 'true' %>
+    </div>
+  <% end %>    
   <% if skipped_deleted > 0 %>
     <div class="widget--body">
       <div class="deleted-comments">
@@ -112,49 +164,55 @@
     </div>
     <% skipped_deleted = 0 %>
   <% end %>
-  <% unless current_user.nil? || params[:inline] == 'true' %>
-    <div class="widget--footer">
-      <% if !@comment_thread.read_only? %>
-        <% if @post.locked? && !moderator? && !admin? %>
-          <p class="has-color-tertiary-500">Comments are disabled on locked posts.</p>
-        <% elsif @post.deleted %>
-          <p class="has-color-tertiary-500">Comments are disabled on deleted posts.</p>
-        <% elsif @post.comments_disabled && !moderator? && !admin? %>
-          <p class="has-color-red-500"><i class="fa fa-lock"></i> Comments have been disabled on the parent post.</p>
-        <% else %>
-          <% if @post.locked? %>
-            <p class="has-color-red-500"><i class="fa fa-lock"></i> Comments are disabled on locked posts, but as a moderator you are exempt from that block.</p>
-          <% elsif @post.comments_disabled %>
-            <p class="has-color-red-500"><i class="fa fa-lock"></i> Comments have been disabled on this post, but as a moderator you are exempt from that block.</p>
+  <% unless current_user.nil? %>
+    <% if params[:inline] == 'true' %>
+      <div class="inline-comment-field hide">
+    <% end %>
+      <div class="widget--footer">
+        <% if !@comment_thread.read_only? %>
+          <% if @post.locked? && !moderator? && !admin? %>
+            <p class="has-color-tertiary-500">Comments are disabled on locked posts.</p>
+          <% elsif @post.deleted %>
+            <p class="has-color-tertiary-500">Comments are disabled on deleted posts.</p>
+          <% elsif @post.comments_disabled && !moderator? && !admin? %>
+            <p class="has-color-red-500"><i class="fa fa-lock"></i> Comments have been disabled on the parent post.</p>
+          <% else %>
+            <% if @post.locked? %>
+              <p class="has-color-red-500"><i class="fa fa-lock"></i> Comments are disabled on locked posts, but as a moderator you are exempt from that block.</p>
+            <% elsif @post.comments_disabled %>
+              <p class="has-color-red-500"><i class="fa fa-lock"></i> Comments have been disabled on this post, but as a moderator you are exempt from that block.</p>
+            <% end %>
+            <h4>Reply to this thread</h4>
+            <%= form_tag create_comment_path(@comment_thread.id) do %>
+              <%= hidden_field_tag :post_id, @post.id %>
+
+              <%= label_tag :content, 'Your message', class: 'form-element' %>
+              <%= text_area_tag :content, '', class: 'form-element js-comment-field',
+                                data: { thread: @comment_thread.id, post: @comment_thread.post_id,
+                                        character_count: ".js-character-count-#{@post.id}" } %>
+              <span class="has-float-right has-font-size-caption js-character-count-<%= @post.id %>"
+                    data-max="1000" data-min="15">
+                <i class="fas fa-ellipsis-h js-character-count__icon"></i>
+                <span class="js-character-count__count">0 / 1000</span>
+              </span>
+
+              <%= submit_tag 'Add reply', class: 'button is-muted is-filled', disabled:true %>
+            <% end %>
           <% end %>
-          <h4>Reply to this thread</h4>
-          <%= form_tag create_comment_path(@comment_thread.id) do %>
-            <%= hidden_field_tag :post_id, @post.id %>
-            
-            <%= label_tag :content, 'Your message', class: 'form-element' %>
-            <%= text_area_tag :content, '', class: 'form-element js-comment-field',
-                              data: { thread: @comment_thread.id, post: @comment_thread.post_id,
-                                      character_count: ".js-character-count-#{@post.id}" } %>
-            <span class="has-float-right has-font-size-caption js-character-count-<%= @post.id %>"
-                  data-max="1000" data-min="15">
-              <i class="fas fa-ellipsis-h js-character-count__icon"></i>
-              <span class="js-character-count__count">0 / 1000</span>
-            </span>
-            
-            <%= submit_tag 'Add reply', class: 'button is-muted is-filled', disabled:true %>
-          <% end %>
+        <% elsif @comment_thread.deleted %>
+          <p class="h-c-red-700"><i class="fas fa-trash fa-fw"></i> You cannot reply to this thread because it has been deleted.</p>
+        <% elsif @comment_thread.locked? %>
+          <p class="h-c-red-700"><i class="fas fa-lock fa-fw"></i> You cannot reply to this thread because it has been locked.</p>
+        <% elsif @comment_thread.archived %>
+          <p class="h-c-tertiary-700"><i class="fas fa-archive fa-fw"></i> This thread has been archived and cannot be replied to.</p>
         <% end %>
-      <% elsif @comment_thread.deleted %>
-        <p class="h-c-red-700"><i class="fas fa-trash fa-fw"></i> You cannot reply to this thread because it has been deleted.</p>
-      <% elsif @comment_thread.locked? %>
-        <p class="h-c-red-700"><i class="fas fa-lock fa-fw"></i> You cannot reply to this thread because it has been locked.</p>
-      <% elsif @comment_thread.archived %>
-        <p class="h-c-tertiary-700"><i class="fas fa-archive fa-fw"></i> This thread has been archived and cannot be replied to.</p>
-      <% end %>
-    </div>
+      </div>
+    <% if params[:inline] == 'true' %>
+      </div>
+    <% end %>      
   <% end %>
   <% if params[:inline] == 'true' %>
-    <div class="widget--footer">
+    <div class="widget--footer footer-inline-thread">
       <p class="h-m-0">
         Showing <%= [5, @comment_thread.reply_count].min %> of <%= pluralize(@comment_thread.reply_count, 'comment') %>.
         <%= link_to 'See the whole thread', comment_thread_path(@comment_thread) %>.
@@ -165,94 +223,100 @@
 
 </div>
 
-<% if current_user&.privilege?('flag_curate') && params[:inline] != 'true' %>
-  <div class="droppanel js--tools-thread-<%= @comment_thread.id %>">
-    <div class="droppanel--header">thread options</div>
-    <div class="droppanel--menu">
-      <% if current_user.is_moderator || !@comment_thread.read_only? %>
-        <a href="#" data-modal=".js--rename-thread-<%= @comment_thread.id %>" data-drop=".js--tools-thread-<%= @comment_thread.id %>"><i class="fas fa-pen fa-fw"></i> rename</a>
-      <% end %>
-
-      <% unless @comment_thread.archived || @comment_thread.deleted %>
-        <% if @comment_thread.locked? %>
-          <a href="#" class="js--unrestrict-thread" data-action="lock" data-drop=".js--tools-thread-<%= @comment_thread.id %>" data-thread="<%= @comment_thread.id %>"><i class="fas fa-lock fa-fw"></i> unlock</a>
-        <% else %>
-          <a href="#" data-modal=".js--lock-thread-<%= @comment_thread.id %>" data-drop=".js--tools-thread-<%= @comment_thread.id %>"><i class="fas fa-lock fa-fw"></i> lock</a>
+<% if current_user&.privilege?('flag_curate') %>
+  <% if params[:inline] == 'true' %>
+    <div class="inline-droppanel hide">
+  <% end %>
+    <div class="droppanel js--tools-thread-<%= @comment_thread.id %>">
+      <div class="droppanel--header">thread options</div>
+      <div class="droppanel--menu">
+        <% if current_user.is_moderator || !@comment_thread.read_only? %>
+          <a href="#" data-modal=".js--rename-thread-<%= @comment_thread.id %>" data-drop=".js--tools-thread-<%= @comment_thread.id %>"><i class="fas fa-pen fa-fw"></i> rename</a>
         <% end %>
-      <% end %>
-      
-      <% unless @comment_thread.locked? || @comment_thread.deleted %>
-        <% if @comment_thread.archived %>
-          <a href="#" class="js--unrestrict-thread" data-action="archive" data-drop=".js--tools-thread-<%= @comment_thread.id %>" data-thread="<%= @comment_thread.id %>"><i class="fas fa-archive fa-fw"></i> restore</a>
-        <% else %>
-          <a href="#" class="js--restrict-thread" data-action="archive" data-drop=".js--tools-thread-<%= @comment_thread.id %>" data-thread="<%= @comment_thread.id %>"><i class="fas fa-archive fa-fw"></i> archive</a>
-        <% end %>
-      <% end %>
 
-      <% unless @comment_thread.locked? || @comment_thread.archived %>
-        <% if @comment_thread.deleted %>
-          <a href="#" class="js--unrestrict-thread" data-action="delete" data-drop=".js--tools-thread-<%= @comment_thread.id %>" data-thread="<%= @comment_thread.id %>"><i class="fas fa-trash fa-fw"></i> undelete</a>
-        <% else %>
-          <a href="#" class="js--restrict-thread" data-action="delete" data-drop=".js--tools-thread-<%= @comment_thread.id %>" data-thread="<%= @comment_thread.id %>"><i class="fas fa-trash fa-fw"></i> delete</a>
+        <% unless @comment_thread.archived || @comment_thread.deleted %>
+          <% if @comment_thread.locked? %>
+            <a href="#" class="js--unrestrict-thread" data-action="lock" data-drop=".js--tools-thread-<%= @comment_thread.id %>" data-thread="<%= @comment_thread.id %>"><i class="fas fa-lock fa-fw"></i> unlock</a>
+          <% else %>
+            <a href="#" data-modal=".js--lock-thread-<%= @comment_thread.id %>" data-drop=".js--tools-thread-<%= @comment_thread.id %>"><i class="fas fa-lock fa-fw"></i> lock</a>
+          <% end %>
         <% end %>
-      <% end %>
 
-      <% if current_user&.is_moderator || current_user&.is_admin %>
-        <a href="#" class="js--show-followers" data-modal="#js-followers-<%= @comment_thread.id %>"
-           data-drop=".js--tools-thread-<%= @comment_thread.id %>" data-thread="<%= @comment_thread.id %>">
-          <i class="fas fa-users"></i> followers
-        </a>
+        <% unless @comment_thread.locked? || @comment_thread.deleted %>
+          <% if @comment_thread.archived %>
+            <a href="#" class="js--unrestrict-thread" data-action="archive" data-drop=".js--tools-thread-<%= @comment_thread.id %>" data-thread="<%= @comment_thread.id %>"><i class="fas fa-archive fa-fw"></i> restore</a>
+          <% else %>
+            <a href="#" class="js--restrict-thread" data-action="archive" data-drop=".js--tools-thread-<%= @comment_thread.id %>" data-thread="<%= @comment_thread.id %>"><i class="fas fa-archive fa-fw"></i> archive</a>
+          <% end %>
+        <% end %>
+
+        <% unless @comment_thread.locked? || @comment_thread.archived %>
+          <% if @comment_thread.deleted %>
+            <a href="#" class="js--unrestrict-thread" data-action="delete" data-drop=".js--tools-thread-<%= @comment_thread.id %>" data-thread="<%= @comment_thread.id %>"><i class="fas fa-trash fa-fw"></i> undelete</a>
+          <% else %>
+            <a href="#" class="js--restrict-thread" data-action="delete" data-drop=".js--tools-thread-<%= @comment_thread.id %>" data-thread="<%= @comment_thread.id %>"><i class="fas fa-trash fa-fw"></i> delete</a>
+          <% end %>
+        <% end %>
+
+        <% if current_user&.is_moderator || current_user&.is_admin %>
+          <a href="#" class="js--show-followers" data-modal="#js-followers-<%= @comment_thread.id %>"
+             data-drop=".js--tools-thread-<%= @comment_thread.id %>" data-thread="<%= @comment_thread.id %>">
+            <i class="fas fa-users"></i> followers
+          </a>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="modal is-with-backdrop is-small js--rename-thread-<%= @comment_thread.id %>">
+      <%= form_tag rename_comment_thread_path(@comment_thread.id), class: 'modal--container' do %>
+        <div class="modal--header">
+          <button type="button" class="button is-close-button modal--header-button" data-modal=".js--rename-thread-<%= @comment_thread.id %>">&times;</button>
+          Rename...
+        </div>
+        <div class="modal--body">
+          <%= label_tag :title, 'Title', class: 'form-element' %>
+          <%= text_field_tag :title, @comment_thread.title, class: 'form-element' %>
+        </div>
+        <div class="modal--footer">
+          <%= submit_tag 'Update thread', class: 'button is-muted is-filled' %>
+          <button type="button" class="button is-muted" data-modal=".js--rename-thread-<%= @comment_thread.id %>">Cancel</button>
+        </div>
       <% end %>
     </div>
-  </div>
 
-  <div class="modal is-with-backdrop is-small js--rename-thread-<%= @comment_thread.id %>">
-    <%= form_tag rename_comment_thread_path(@comment_thread.id), class: 'modal--container' do %>
-      <div class="modal--header">
-        <button type="button" class="button is-close-button modal--header-button" data-modal=".js--rename-thread-<%= @comment_thread.id %>">&times;</button>
-        Rename...
-      </div>
-      <div class="modal--body">
-        <%= label_tag :title, 'Title', class: 'form-element' %>
-        <%= text_field_tag :title, @comment_thread.title, class: 'form-element' %>
-      </div>
-      <div class="modal--footer">
-        <%= submit_tag 'Update thread', class: 'button is-muted is-filled' %>
-        <button type="button" class="button is-muted" data-modal=".js--rename-thread-<%= @comment_thread.id %>">Cancel</button>
-      </div>
-    <% end %>
-  </div>
-
-  <div class="modal is-with-backdrop is-small js--lock-thread-<%= @comment_thread.id %>">
-    <%= form_tag restrict_comment_thread_path(@comment_thread.id), class: 'modal--container' do %>
-      <%= hidden_field_tag :type, 'lock' %>
-      <div class="modal--header">
-        <button type="button" class="button is-close-button modal--header-button" data-modal=".js--lock-thread-<%= @comment_thread.id %>">&times;</button>
-        Lock...
-      </div>
-      <div class="modal--body">
-        <%= label_tag :duration, 'Duration in days (optional)', class: 'form-element' %>
-        <div class="form-caption">You may enter a lock duration in days. If you leave this blank, the thread will need to be unlocked manually.</div>
-        <%= number_field_tag :duration, nil, class: 'form-element' %>
-      </div>
-      <div class="modal--footer">
-        <%= submit_tag 'Lock thread', class: 'button is-muted is-filled' %>
-        <button type="button" class="button is-muted" data-modal=".js--lock-thread-<%= @comment_thread.id %>">Cancel</button>
-      </div>
-    <% end %>
-  </div>
-
-  <% if current_user&.is_moderator || current_user&.is_admin %>
-    <div class="modal is-with-backdrop is-small" id="js-followers-<%= @comment_thread.id %>">
-      <div class="modal--container">
+    <div class="modal is-with-backdrop is-small js--lock-thread-<%= @comment_thread.id %>">
+      <%= form_tag restrict_comment_thread_path(@comment_thread.id), class: 'modal--container' do %>
+        <%= hidden_field_tag :type, 'lock' %>
         <div class="modal--header">
-          <button type="button" class="button is-close-button modal--header-button" data-modal="#js-followers-<%= @comment_thread.id %>">&times;</button>
-          Thread Followers
+          <button type="button" class="button is-close-button modal--header-button" data-modal=".js--lock-thread-<%= @comment_thread.id %>">&times;</button>
+          Lock...
         </div>
-        <div class="modal--body js-follower-display">
-          Loading...
+        <div class="modal--body">
+          <%= label_tag :duration, 'Duration in days (optional)', class: 'form-element' %>
+          <div class="form-caption">You may enter a lock duration in days. If you leave this blank, the thread will need to be unlocked manually.</div>
+          <%= number_field_tag :duration, nil, class: 'form-element' %>
+        </div>
+        <div class="modal--footer">
+          <%= submit_tag 'Lock thread', class: 'button is-muted is-filled' %>
+          <button type="button" class="button is-muted" data-modal=".js--lock-thread-<%= @comment_thread.id %>">Cancel</button>
+        </div>
+      <% end %>
+    </div>
+
+    <% if current_user&.is_moderator || current_user&.is_admin %>
+      <div class="modal is-with-backdrop is-small" id="js-followers-<%= @comment_thread.id %>">
+        <div class="modal--container">
+          <div class="modal--header">
+            <button type="button" class="button is-close-button modal--header-button" data-modal="#js-followers-<%= @comment_thread.id %>">&times;</button>
+            Thread Followers
+          </div>
+          <div class="modal--body js-follower-display">
+            Loading...
+          </div>
         </div>
       </div>
+    <% end %>
+  <% if current_user&.privilege?('flag_curate') && params[:inline] == 'true' %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/comments/thread.html.erb
+++ b/app/views/comments/thread.html.erb
@@ -29,9 +29,6 @@
       </a>
       <a href="javascript:void(0)" class="js-collapse-thread widget--header-link">
         collapse
-      </a>   
-      <a href="javascript:void(0)" class="js-expand-thread widget--header-link">
-        expand
       </a>
     <% end %>
     <% if params[:inline] == 'true' %>
@@ -197,6 +194,9 @@
               </span>
 
               <%= submit_tag 'Add reply', class: 'button is-muted is-filled', disabled:true %>
+              <% if params[:inline] == 'true' %>
+                <%= link_to 'Go to thread page', comment_thread_path(@comment_thread) %>
+              <% end %>
             <% end %>
           <% end %>
         <% elsif @comment_thread.deleted %>
@@ -215,7 +215,13 @@
     <div class="widget--footer footer-inline-thread">
       <p class="h-m-0">
         Showing <%= [5, @comment_thread.reply_count].min %> of <%= pluralize(@comment_thread.reply_count, 'comment') %>.
-        <%= link_to 'See the whole thread', comment_thread_path(@comment_thread) %>.
+        <a href="javascript:void(0)" class="js-expand-thread widget--header-link">
+          <% if [5, @comment_thread.reply_count].min == 5 %>
+            Show more
+          <% else %>
+            See the whole thread
+          <% end %>
+        </a>.
       </p>
     </div>
   <% end %>

--- a/app/views/comments/thread.html.erb
+++ b/app/views/comments/thread.html.erb
@@ -38,7 +38,7 @@
       <div class="inline--header hide">
     <% end %>
       <% if current_user&.privilege? 'flag_curate' %>
-        <a href="#" class="widget--header-link" data-drop=".js--tools-thread-<%= @comment_thread.id %>"><i class="fa fa-cog fa-fw"></i>tools</a>
+        <a href="#" class="widget--header-link mod-tools" data-drop=".js--tools-thread-<%= @comment_thread.id %>"><i class="fa fa-cog fa-fw"></i>tools</a>
       <% end %>
       <% unless current_user.nil? %>
         <% if @comment_thread.followed_by? current_user %>

--- a/app/views/comments/thread.html.erb
+++ b/app/views/comments/thread.html.erb
@@ -1,5 +1,9 @@
 <% pingable = get_pingable(@comment_thread) %>
 
+<h1>Comments on
+  <a href="<%= generic_share_link(@post) %>"><%= @post.title.blank? && @post.parent.present? ? @post.parent.title : @post.title %></a>
+</h1>
+
 <% if @post.parent.present? %>
   <details>
     <summary>Parent</summary>
@@ -11,10 +15,6 @@
   <summary>Post</summary>
   <%= render 'posts/expanded', post: @post %>
 </details>
-
-<h1>Comments on
-  <a href="<%= generic_share_link(@post) %>"><%= @post.title.blank? && @post.parent.present? ? @post.parent.title : @post.title %></a>
-</h1>
 
 <!-- THREAD STARTS BELOW -->
 <div class="<%= @comment_thread.deleted ? 'h-bg-red-050' : '' %> <%= params[:inline] == 'true' ? 'post--comments-thread is-embedded' : '' %>">


### PR DESCRIPTION
Said all the things right [here](https://github.com/codidact/qpixel/issues/546#issuecomment-913581697). Not sure if the method is acceptable or not...

![Screenshot from 2021-09-09 09-00-25](https://user-images.githubusercontent.com/58106197/132615221-3ac058b7-19b2-4af0-b20e-fdf2b51a0c46.png)

Showing "Go to thread page" at bottom cause, @cellio had said that user won't like to move to top again. So, showing it with Add reply.

Oops, flag button wasn't hide.

~~Wait a minute... Currently, my code is fetching every comment twice.(fixed)~~

Currently, I can flag from inline preview. But, If I try to show tools same as flag then it will work for few items not for all cause, there's lot of tools which also contains modal. 

resolves : https://github.com/codidact/qpixel/issues/670
resolves : #546 