### PR TITLE
support line break for comments

### DIFF
--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -81,7 +81,7 @@ end
 class CommentScrubber < Rails::Html::PermitScrubber
   def initialize
     super
-    self.tags = %w[a b i em strong s strike del pre code p blockquote span sup sub]
+    self.tags = %w[a b i em strong s strike del pre code p blockquote span sup sub br]
     self.attributes = %w[href title lang dir id class]
   end
 


### PR DESCRIPTION
https://meta.codidact.com/comments/thread/4708 I don't think h1, h2.... or any of them will be helpful for comments. If user uses them than the comment will be bigger than expected.. It will harder to see all comments properly (if there's too much). br is for line break. I think user should have ability to use br or multi-line whatever they prefer. I mostly use br for blockquote instead of multiline that's easier to use.