### PR TITLE
direct to accurate link of answer

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -121,7 +121,7 @@ class PostsController < ApplicationController
 
   def show
     if @post.parent_id.present?
-      return redirect_to answer_post_path(@post.parent_id, answer: @post.id, anchor: "answer-#{@post.id}")
+      return redirect_to answer_post_path(@post.parent_id, answer: @post.id, anchor: "/#{@post.id}/answer-#{@post.id}")
     end
 
     if @post.post_type_id == HelpDoc.post_type_id


### PR DESCRIPTION
I didn't test it so I don't have idea if it will work as I expected. That's the code what was looking the accurate one.

If you post a new answer than it will redirect you to `/parent_id#id-post_id` but we are currently supporting `/parent_id/post_id#id-post_id