### PR TITLE
Add user auth requirement for reactions control

### DIFF
--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -62,7 +62,7 @@
             </button>
           <% end %>
         </div>
-        <% if post.post_type.has_reactions %>
+        <% if post.post_type.has_reactions && user_signed_in? %>
         <div class="post--react has-text-align-center">
           <% unless post.locked? %>
             <button class="react-button button is-muted is-icon-only-button h-fw-bold"


### PR DESCRIPTION
Currently, we expose a "react" button that is meant to show the reaction panel on posts, even if a user is logged out.

By way of stop gap measure, this removes the button for logged out users until a dev can get a proper fix up for the button's error handling and resolve the linked issue below.

GitHub issue linking tag: resolves #691.