### PR TITLE
Make reactions with no comment clearer

### DIFF
--- a/app/views/reactions/_list.html.erb
+++ b/app/views/reactions/_list.html.erb
@@ -65,7 +65,7 @@
                                     <% end %>
                                 </div>
                             <% else %>
-                            (no comment)
+                            <em>(no comment)</em>
                             <% end %>
                         </td>
                         <td class="h-fs-caption">


### PR DESCRIPTION
Right now, we just show the word "no" for reactions that do not have a comment attached. This is confusing for users (did the commenter just comment "no", or was there actually no comment by the user?).

This PR fixes that confusion by making the following changes:
* We change the word "no" that is shown when a reaction has no comment attached to "(no comment)". By wrapping the statement in brackets and making it clear that there was no comment, we avert some of this confusion.
* We italicise the "(no comment)" comment to emphasize that there is indeed no comment and not just a user commenting the no comment phrase.

If we prefer alternative text or formatting for this section, feel free to make those views known via a request changes review.