### PR TITLE
Add ability check to deleted post history

### DIFF
--- a/app/controllers/post_history_controller.rb
+++ b/app/controllers/post_history_controller.rb
@@ -1,6 +1,11 @@
 class PostHistoryController < ApplicationController
   def post
     @post = Post.find(params[:id])
+    
+    if @post.deleted? && !current_user&.has_post_privilege?('flag_curate', @post)
+      return not_found
+    end
+    
     @history = PostHistory.where(post_id: params[:id]).includes(:post_history_type, :user, post_history_tags: [:tag])
                           .order(created_at: :desc).paginate(per_page: 20, page: params[:page])
     render layout: 'without_sidebar'


### PR DESCRIPTION
This does what it says in the PR title, to prevent people from accessing post history for deleted posts if they shouldn't be able to see the deleted post.

I reused code from https://github.com/codidact/qpixel/blob/2a627321dc65e92a81215e688218d4e56bb965b4/app/controllers/posts_controller.rb#L133-L135.

Is there any chance we could get small bits of common logic like that and set up a library/package or something to avoid duplication?

GitHub linking tag: resolves #736