### PR TITLE
Remove duplicate keybind for flags

### DIFF
--- a/app/assets/javascripts/keyboard_tools.js
+++ b/app/assets/javascripts/keyboard_tools.js
@@ -166,8 +166,6 @@ $(() => {
         window.location.href = '/users/' + _CodidactKeyboard.user_id;
       } else if (e.key === 'f') {
         window.location.href = '/mod/flags';
-      } else if (e.key === 'f') {
-        window.location.href = '/mod/flags';
       } else if (e.key === "t") {
         const data = Object.entries(_CodidactKeyboard.categories());
         let string_response = "";


### PR DESCRIPTION
This got picked up when I ran the code through a local SonarQube instance - if you ask me, it's a good example of how small bugs/"nits" can get picked up by automated services, demonstrates how having an automated service in a scan only/non blocking mode is useful for codebases such as ours and shows that while a code analyzer is not a must or a hard block (at least not in any hypothetical use by Codidact), it should not be overlooked too easily either.