### PR TITLE
moves dashboard link to header making it easier to access

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -45,6 +45,9 @@
         <%= link_to help_center_path, class: 'header--item' do %>
           <i class="fas fa-fw fa-question-circle"></i> Help
         <% end %>
+        <%= link_to dashboard_path, class: 'header--item' do %>
+          <i class="fas fa-fw fa-th" title='Dashboard'></i>
+        <% end %>
       <% end %>
       <% if user_signed_in? %>
         <a href="#" class="header--item inbox-toggle is-visible-on-mobile" data-header-slide="#js-inbox">
@@ -105,12 +108,6 @@
       </div>
     <% end %>
   </div>
-  <hr class="has-margin-top-2 has-margin-bottom-2" />
-  <div>
-    <%= link_to dashboard_path, class: 'button is-muted has-float-right' do %>
-      Dashboard
-    <% end %>
-  </div>
 </div>
 
 <div class="header-slide is-large" id="search-slide">
@@ -141,7 +138,9 @@
 
     <div class='header-slide--separator'></div>
 
-    <%= link_to 'Help', help_center_path, class: 'menu--item' %>
+    <%= link_to 'Help', help_center_path, class: 'menu--item' %>	
+
+    <%= link_to 'Dashboard', dashboard_path, class: 'menu--item' %>
 
     <% if user_signed_in? %>
       <% if current_user.is_admin || current_user.is_moderator %>


### PR DESCRIPTION
removed dashboard link from the communities drop down
added it to the header row after help (and before notifications)

makes it easier for people to know about and access the dashboard

see also this post by Alexei: https://meta.codidact.com/posts/285449

quite small change, but good training for me to get better into qpixel

not done (but could be done): remove mobile signin button from header row (is also on profile page)