### PR TITLE
fixed error in docker compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,13 @@ services:
     build:
       context: "."
       dockerfile: docker/Dockerfile.db
-    volumes:  
+    volumes:
       - ./docker/mysql:/var/lib/mysql
     env_file:
       - ${ENV_FILE_LOCATION}
     command: mysqld --default-authentication-plugin=mysql_native_password --skip-mysqlx
+    cap_add:
+      - SYS_NICE
 
   uwsgi:
     restart: always
@@ -21,6 +23,7 @@ services:
       - COMMUNITY_NAME=${COMMUNITY_NAME}
       - RAILS_ENV=${RAILS_ENV}
       - CONFIRMABLE_ALLOWED_ACCESS_DAYS=${CONFIRMABLE_ALLOWED_ACCESS_DAYS}
+      - LOCAL_DEV_PORT=${LOCAL_DEV_PORT}
     env_file:
       - ${ENV_FILE_LOCATION}
     ports:

--- a/docker/create_admin_and_community.rb
+++ b/docker/create_admin_and_community.rb
@@ -1,6 +1,7 @@
 # 1. Create the community
 community_name = ENV['COMMUNITY_NAME'] || 'Dinosaur Community'
 Community.create(name: community_name, host: "localhost:#{ENV['LOCAL_DEV_PORT']}")
+Rails.cache.clear
 
 # 2. Create the admin user, ensure doesn't require confirmation
 username = ENV['COMMUNITY_ADMIN_USERNAME'] || 'admin'


### PR DESCRIPTION
This pull request fixes https://github.com/codidact/qpixel/issues/759, the docker compose setup was not working. It ended up not finding the correct community. 

I found three improvements:

1 Add this capability to the mysql container to solve the` mbind operation not permitted `error (https://docs.docker.com/config/containers/resource_constraints/)
cap_add:
      - SYS_NICE
      
2 Included the` local dev port` in the container as an environment variable

3 Rebuild the cache after creating the community