### PR TITLE
Consolidate Debian install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,9 @@ For Debian-Based Linux:
 
 ```
 sudo apt update
-sudo apt install gcc
-sudo apt install make
-sudo apt install libmysqlclient-dev
+sudo apt install gcc make pkg-config
 sudo apt install autoconf bison build-essential libssl-dev libyaml-dev libreadline-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm-dev
-sudo apt install mysql-server
+sudo apt install mysql-server libmysqlclient-dev
 ```
 
 For Arch-Based Linux:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ If you haven't already got it, [download and install Redis](https://redis.io/dow
 ### 3. Install Imagemagick
 
 If you haven't already installed Imagemagick, you'll need to [install it for
-your system](https://imagemagick.org/script/download.php).
+your system](https://imagemagick.org/script/download.php). 
+
+If you install Imagemagick from APT on a Debian-Based system, you may need to also install the `libmagickwand-dev` package.
 
 ### 4. Download QPixel
 Clone the repository and `cd` into the directory:


### PR DESCRIPTION
This PR consolidates our install instructions for Debian installs to take less lines at a time. It also adds the `pkg-config` package, which isn't installed by default on Ubuntu and is required to build the `rmagick` gem.

**Note:** We don't mention that MySQL 8 is required in our README, and we should put a note to that effect somewhere in it.