### PR TITLE
prevent overflowing of user cards for long user names by wrapping them

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -2,8 +2,13 @@
 
 .user-list {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
   gap: 1em;
+
+  grid-template-columns: auto;
+
+  @media screen and (min-width: $screen-md) {
+    grid-template-columns: repeat(2, 1fr);
+  }
 
   @media screen and (min-width: $screen-lg) {
     grid-template-columns: repeat(3, 1fr);

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -100,7 +100,13 @@
     padding: 0 0.25rem;
 
     .user-card--link {
-      margin-bottom: 0.75rem;
+      display:inline-block;
+      max-width: 420px;
+
+      &-small {
+        display:inline-block;
+        max-width: 180px;
+      }
     }
 
     .user-card--meta {

--- a/app/views/users/_common_card.html.erb
+++ b/app/views/users/_common_card.html.erb
@@ -3,9 +3,11 @@
     Variables:
       user : the User instance to display
     ? ckb  : enable keyboard navigation on this usercard? Default false.
+    ? small : smaller max width of user card link in order to avoid long user names
 %>
 
 <% ckb ||= false %>
+<% small ||= false %>
 
 <% if user.nil? || deleted_user?(user) %>
   <div class="user-card deleted-content">
@@ -27,7 +29,7 @@
            data = {'ckb-item-link': ''}
          end
       %>
-      <%= link_to user_path(user), dir: 'ltr', class: 'user-card--link', data: data do %>
+      <%= link_to user_path(user), dir: 'ltr', class: small ? :'user-card--link-small' :'user-card--link', data: data do %>
         <%= rtl_safe_username(user) %>
         <% if user.is_admin && SiteSetting['AdminBadgeCharacter'] %>
           <span class="badge is-user-role" title="Administrator"><%= SiteSetting['AdminBadgeCharacter'] %></span>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,3 +1,3 @@
 <div class="user-list--user" data-ckb-list-item data-ckb-item-type="link">
-  <%= render 'users/common_card', user: user, ckb: true %>
+  <%= render 'users/common_card', user: user, ckb: true , small: true%>
 </div>


### PR DESCRIPTION
My solution to #146 as discussed there

- no truncation of user names (not clear where to set the cut and full user name read out by public/assets/community/codegolf.js might have unintended side consequences)
- biggest problem is overflow of layout, especially on the users list
- wrapping is a good solution for now (may be replaced by more sophisticated one in the future)
- however, wrapping must occur at different widths, depending whether the user card is shown on the users list (quite small) or below a post (relatively large)
- fixed widths are okay, because the whole layout is based on fixed values, values chosen here have been carefully optimized, they are the max values of what is possible within the solution
- changed CSS (user-card--link), templates common_card (additional parameter) and user (to indicate this is in the users list and a smaller max width is desired)

Might not fully solve the issue but it's not a simple problem. User names with 50 characters max length and potentially wide characters will take a lot of space. Most user names on StackOverflow (99.997%) are less than 30 characters long. I asked if there are [user names with more than 40 characters on Codidact](https://collab.codidact.org/posts/285625) but did not get an answer. I think we could safely reduce user name lengths to 40 characters though to alleviate the display problem (where is the sense in allowing longer names if we do not display them anyway).