### PR TITLE
Adds information about when comment was last edited to comment info

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,3 +1,10 @@
+<%#
+    Single comment view.
+    Variables:
+    ? with_post_link : includes share labelled post
+    ? pingable       : ???
+%>
+
 <% with_post_link ||= false %>
 <% pingable ||= nil %>
 
@@ -31,9 +38,11 @@
       </div>
     <% end %>
     <div class="comment--info">
-      <%= user_link comment.user %>
-      wrote
-      <span title="<%= comment.created_at.iso8601 %>"><%= time_ago_in_words(comment.created_at) %> ago:</span>
+      <%= user_link comment.user %> wrote
+      <span title="<%= comment.created_at.iso8601 %>"><%= time_ago_in_words(comment.created_at) %> ago</span>
+      <% if comment.updated_at > comment.created_at %>
+        · <span title="<%= comment.updated_at.iso8601 %>">edited <%= time_ago_in_words(comment.updated_at) %> ago</span>
+      <% end %>
     </div>
     <div class="comment--links">
       <%= link_to comment_link(comment), class: 'js-comment-permalink' do %>

--- a/app/views/comments/_new_thread_modal.html.erb
+++ b/app/views/comments/_new_thread_modal.html.erb
@@ -1,3 +1,7 @@
+<%#
+    Start new comment thread dialog.
+%>
+
 <div class="modal--container new-thread-modal" id="new-thread-modal-<%= post.id %>">
   <div class="modal--header">
     <b>Start a new comment thread</b>

--- a/app/views/comments/_post.html.erb
+++ b/app/views/comments/_post.html.erb
@@ -1,3 +1,7 @@
+<%#
+    List of comment threads below a post.
+%>
+
 <% comment_threads.each do |thread| %>
   <div class="post--comments-thread is-inline <%= thread.deleted ? 'is-deleted' : '' %> <%= thread.archived ? 'is-archived' : '' %>">
     <% if thread.deleted %>

--- a/app/views/comments/thread.html.erb
+++ b/app/views/comments/thread.html.erb
@@ -1,3 +1,8 @@
+<%#
+    Comment thread view.
+    params[:inline] : If true shown within the Q&A page, else shown as separate comment thread page
+%>
+
 <% pingable = get_pingable(@comment_thread) %>
 
 <% if @post.parent.present? %>


### PR DESCRIPTION
Related to #238

- adds "edited xxx ago" to comments in the comment info section
- separated by a dot from the "wrote xxx ago"
- removed the final ":"
- similar to what GitHub does in their comments to issues (see for example https://github.com/codidact/qpixel/issues/238#issuecomment-1036037183)
- a little bit of additional documentation (while finding out what is what)
- example look: https://imgur.com/6lOpC8c