### PR TITLE
Same sort of categories for categories page as for general nav header

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -5,7 +5,7 @@ class CategoriesController < ApplicationController
   before_action :verify_view_access, except: [:index, :homepage, :new, :create, :post_types]
 
   def index
-    @categories = Category.all.order(:sequence, :name)
+    @categories = Category.all.order(sequence: :asc, id: :asc)
     respond_to do |format|
       format.html
       format.json do


### PR DESCRIPTION
Very small PR, should fix #300, sort order of categories was by id in nav header bar and by name on the categories page. Switched to id in both cases.