### PR TITLE
Bump co-design versions

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -19,7 +19,7 @@
 <link rel="preconnect" href="https://cdnjs.cloudflare.com" />
 
 <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.11.2/css/all.min.css" %>
-<%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/@codidact/co-design@0.12.0/dist/codidact.css" %>
+<%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/@codidact/co-design@0.12.5/dist/codidact.css" %>
 <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/select2@4.0.12/dist/css/select2.min.css" %>
 <%= stylesheet_link_tag "/assets/community/#{@community.host.split('.')[0]}.css" %>
 <%= stylesheet_link_tag 'application', media: 'all' %>
@@ -31,7 +31,7 @@
 <%= javascript_include_tag "https://cdn.jsdelivr.net/npm/dompurify@2.2.9/dist/purify.min.js" %>
 <%= javascript_include_tag "/assets/community/#{@community.host.split('.')[0]}.js" %>
 <%= javascript_include_tag 'application' %>
-<script src="https://cdn.jsdelivr.net/npm/@codidact/co-design@0.12.0/js/co-design.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/@codidact/co-design@0.12.5/js/co-design.js" defer></script>
 
 <% if SiteSetting['SyntaxHighlightingEnabled'] %>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/default.min.css">

--- a/app/views/layouts/devise_mailer.html.erb
+++ b/app/views/layouts/devise_mailer.html.erb
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title><%= message.subject %></title>
-  <%= stylesheet_link_tag 'https://cdn.jsdelivr.net/npm/@codidact/co-design@0.12.0/dist/codidact.css' %>
+  <%= stylesheet_link_tag 'https://cdn.jsdelivr.net/npm/@codidact/co-design@0.12.5/dist/codidact.css' %>
   <%= stylesheet_link_tag 'application', media: 'all' %>
 </head>
 <body>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title><%= message.subject %></title>
-  <%= stylesheet_link_tag 'https://cdn.jsdelivr.net/npm/@codidact/co-design@0.12.0/dist/codidact.css' %>
+  <%= stylesheet_link_tag 'https://cdn.jsdelivr.net/npm/@codidact/co-design@0.12.5/dist/codidact.css' %>
   <%= stylesheet_link_tag 'application', media: 'all' %>
 </head>
 <body>


### PR DESCRIPTION
A change was made in codidact/co-design@4300553a4212aa55c6249cac4b1cbd56fe9b988f which requires a new NPM release to implement.

This PR is preemptively filed to bump the co-design versions up to 0.12.4, which would be the next version of @codidact/co-design released to NPM, if and when that occurs: https://www.npmjs.com/package/@codidact/co-design.

It should be merged after the next npm release occurs for @codidact/co-design and before a production deployment.

This PR relates to codidact/co-design#43