### PR TITLE
Move thread heading to top

### DIFF
--- a/app/views/comments/thread.html.erb
+++ b/app/views/comments/thread.html.erb
@@ -1,5 +1,9 @@
 <% pingable = get_pingable(@comment_thread) %>
 
+<h1>Comments on
+  <a href="<%= generic_share_link(@post) %>"><%= @post.title.blank? && @post.parent.present? ? @post.parent.title : @post.title %></a>
+</h1>
+
 <% if @post.parent.present? %>
   <details>
     <summary>Parent</summary>
@@ -11,10 +15,6 @@
   <summary>Post</summary>
   <%= render 'posts/expanded', post: @post %>
 </details>
-
-<h1>Comments on
-  <a href="<%= generic_share_link(@post) %>"><%= @post.title.blank? && @post.parent.present? ? @post.parent.title : @post.title %></a>
-</h1>
 
 <!-- THREAD STARTS BELOW -->
 <div class="<%= @comment_thread.deleted ? 'h-bg-red-050' : '' %> <%= params[:inline] == 'true' ? 'post--comments-thread is-embedded' : '' %>">


### PR DESCRIPTION
Redoing https://github.com/b-Istiak-s/qpixel/commit/776f01cd1400a0609737268d41517c31398c06f4, which was apparently orphaned somewhere along the way (thanks @b-Istiak-s).  On thread pages, the heading is now at the top, followed by the parent (if applicable) and post expanders, and then the thread.

![screenshot](https://user-images.githubusercontent.com/5557942/168928235-f3220ae6-7db2-4f4d-8edd-b4ccf937da84.png)

