### PR TITLE
Cellio/272 mod tools backlink

### DIFF
--- a/app/views/close_reasons/index.html.erb
+++ b/app/views/close_reasons/index.html.erb
@@ -1,4 +1,7 @@
 <% content_for :title, "Close Reasons" %>
+<%= link_to moderator_path, class: 'has-font-size-small' do %>
+  &laquo; Return to moderator tools
+<% end %>
 
 <h1>Close Reasons</h1>
 

--- a/app/views/comments/thread.html.erb
+++ b/app/views/comments/thread.html.erb
@@ -1,5 +1,9 @@
 <% pingable = get_pingable(@comment_thread) %>
 
+<h1>Comments on
+  <a href="<%= generic_share_link(@post) %>"><%= @post.title.blank? && @post.parent.present? ? @post.parent.title : @post.title %></a>
+</h1>
+
 <% if @post.parent.present? %>
   <details>
     <summary>Parent</summary>
@@ -11,10 +15,6 @@
   <summary>Post</summary>
   <%= render 'posts/expanded', post: @post %>
 </details>
-
-<h1>Comments on
-  <a href="<%= generic_share_link(@post) %>"><%= @post.title.blank? && @post.parent.present? ? @post.parent.title : @post.title %></a>
-</h1>
 
 <!-- THREAD STARTS BELOW -->
 <div class="<%= @comment_thread.deleted ? 'h-bg-red-050' : '' %> <%= params[:inline] == 'true' ? 'post--comments-thread is-embedded' : '' %>">

--- a/app/views/moderator/promotions.html.erb
+++ b/app/views/moderator/promotions.html.erb
@@ -1,4 +1,8 @@
 <% content_for :title, 'Promoted Posts' %>
+<%= link_to moderator_path, class: 'has-font-size-small' do %>
+  &laquo; Return to moderator tools
+<% end %>
+
 <h1>Promoted Posts</h1>
 <p>
   These posts have all been nominated for network-wide promotion by users with the Curate ability.

--- a/app/views/moderator/recent_comments.html.erb
+++ b/app/views/moderator/recent_comments.html.erb
@@ -1,4 +1,7 @@
 <% content_for :title, 'Recent Comments' %>
+<%= link_to moderator_path, class: 'has-font-size-small' do %>
+  &laquo; Return to moderator tools
+<% end %>
 
 <h1>Recent Comments</h1>
 <p>

--- a/app/views/moderator/recently_deleted_posts.html.erb
+++ b/app/views/moderator/recently_deleted_posts.html.erb
@@ -1,4 +1,7 @@
 <% content_for :title, "Recently Deleted Posts" %>
+<%= link_to moderator_path, class: 'has-font-size-small' do %>
+  &laquo; Return to moderator tools
+<% end %>
 
 <h1>Recently Deleted Posts</h1>
 <div class="item-list">

--- a/app/views/pinned_links/index.html.erb
+++ b/app/views/pinned_links/index.html.erb
@@ -1,3 +1,7 @@
+<%= link_to moderator_path, class: 'has-font-size-small' do %>
+  &laquo; Return to moderator tools
+<% end %>
+
 <h1>Featured Links</h1>
 <p class="is-lead">Featured links allow you as a moderator to draw attention to issues or posts of importance to the community. Use them sparingly and only when needed, because they tend to get ignored if used too often.</p>
 

--- a/app/views/reactions/index.html.erb
+++ b/app/views/reactions/index.html.erb
@@ -1,4 +1,9 @@
+<%= link_to moderator_path, class: 'has-font-size-small' do %>
+  &laquo; Return to moderator tools
+<% end %>
+
 <h1>Reactions</h1>
+
 <p class="is-lead">Reactions can be used to give feedback to post authors and to give hints to readers regarding the usefulness, safety, ... of an post. Use them sparely and only when necessary</p>
 
 <table>

--- a/app/views/reports/_tabs.html.erb
+++ b/app/views/reports/_tabs.html.erb
@@ -1,3 +1,7 @@
+<%= link_to moderator_path, class: 'has-font-size-small' do %>
+  &laquo; Return to moderator tools
+<% end %>
+
 <% global = current_page?(global_users_report_path) ||
             current_page?(global_subs_report_path) ||
             current_page?(global_posts_report_path) %>


### PR DESCRIPTION
Add a "return to mod tools" link to the mod-tool pages, based on the link that already existed on the flag-queue page.  Two noteworthy cases:

1. I added it to the Reports page along with the rest, but that page produces a 500 error in my dev environment (with or without my change) so I can't test it.  The error seems to be about time zones.  (Of course.  It's always time zones.  Let's abolish them.)
2. The mod-tools page includes a link to create a new help topic.  This goes to the regular "create post" page.  I couldn't quite figure out how to check there for the help-specific case, so I didn't change anything there.  It's probably a rare mod action, so I'm proceeding with the rest anyway.

Fixes https://github.com/codidact/qpixel/issues/272.