### PR TITLE
Upgrade codeql actions to v2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,10 +26,10 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: javascript, ruby
     
     # Actually perform an analysis
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
CodeQL v1 (which we use in GitHub actions) is deprecated per https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/.

This PR goes ahead and removes the deprecation warning by upgrading the action to version 2.