### PR TITLE
Upgrade ruby to 2.7.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: circleci/ruby:2.6.6-node
+      - image: circleci/ruby:2.7.6-node
       - image: circleci/mysql:8.0.20
         command: [--default-authentication-plugin=mysql_native_password]
         environment:
@@ -66,7 +66,7 @@ jobs:
 
   rubocop:
     docker:
-      - image: circleci/ruby:2.6.6-node
+      - image: circleci/ruby:2.7.6-node
 
     working_directory: ~/qpixel
 
@@ -97,7 +97,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/ruby:2.6.6-node
+      - image: circleci/ruby:2.7.6-node
 
     working_directory: ~/qpixel
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.6.6'
+ruby '2.7.6'
 
 # Essential gems: servers, adapters, Rails + Rails requirements
 gem 'coffee-rails', '~> 4.2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -362,7 +362,7 @@ DEPENDENCIES
   will_paginate-bootstrap (~> 1.0)
 
 RUBY VERSION
-   ruby 2.6.6p146
+   ruby 2.7.6p219
 
 BUNDLED WITH
    2.2.3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6
+FROM ruby:2.7.6
 
 # docker build -f docker/Dockerfile -t qpixel_uwsgi .
 


### PR DESCRIPTION
We are currently running ruby `2.7.6` on our dev server. Currently, the auto-deploy job in CircleCI is failing because a ruby version mismatch error is thrown after git operations occur, as this repo expects ruby `2.6.6` to be running.

As dev has been moving along just fine with this bump, this PR goes ahead and upgrades ruby from `2.6.6` to `2.7.6`. An upgrade of the ruby version on prod will need to occur before this deploys.