### PR TITLE
Fix ImageMagick download location

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
 WORKDIR /opt
 RUN wget https://nodejs.org/dist/v12.18.3/node-v12.18.3-linux-x64.tar.xz && \
     tar xf node-v12.18.3-linux-x64.tar.xz && \
-    wget https://imagemagick.org/download/binaries/magick && \
+    wget https://imagemagick.org/archive/binaries/magick && \
     chmod +x magick && \
     mv magick /usr/local/bin/magick
 


### PR DESCRIPTION
Our Docker developer deployment is having issues because ImageMagick changed their download links.

This PR goes and fixes the download link so Docker builds don't exit with an error going forward.