### PR TITLE
Fix seeding

### DIFF
--- a/db/seeds/categories.yml
+++ b/db/seeds/categories.yml
@@ -6,7 +6,7 @@
     - <%= PostType['Question'].id %>
     - <%= PostType['Answer'].id %>
   is_homepage: true
-  tag_set_id: <%= TagSet.unscoped.where(name: 'Main').first %>
+  tag_set_id: <%= TagSet.unscoped.where(name: 'Main').first.id %>
   use_for_hot_posts: true
   use_for_advertisement: true
 
@@ -17,7 +17,7 @@
   post_type_ids:
     - <%= PostType['Question'].id %>
     - <%= PostType['Answer'].id %>
-  tag_set_id: <%= TagSet.unscoped.where(name: 'Meta').first %>
+  tag_set_id: <%= TagSet.unscoped.where(name: 'Meta').first.id %>
   use_for_hot_posts: true
   use_for_advertisement: false
   color_code: bluegray

--- a/db/seeds/post_types.yml
+++ b/db/seeds/post_types.yml
@@ -1,19 +1,5 @@
-- name: Question
-  description: ~
-  has_answers: true
-  has_votes: true
-  has_tags: true
-  has_parent: false
-  has_category: true
-  has_license: true
-  is_public_editable: true
-  is_closeable: true
-  is_top_level: true
-  is_freely_editable: false
-  has_reactions: false
-  has_only_specific_reactions: true
-
-- name: Answer
+- id: 2
+  name: Answer
   description: ~
   has_answers: false
   has_votes: true
@@ -27,6 +13,23 @@
   is_freely_editable: false
   has_reactions: true
   has_only_specific_reactions: false
+
+- id: 1
+  name: Question
+  description: ~
+  has_answers: true
+  answer_type_id: 2
+  has_votes: true
+  has_tags: true
+  has_parent: false
+  has_category: true
+  has_license: true
+  is_public_editable: true
+  is_closeable: true
+  is_top_level: true
+  is_freely_editable: false
+  has_reactions: false
+  has_only_specific_reactions: true
 
 - name: PolicyDoc
   description: ~

--- a/db/seeds/users.yml
+++ b/db/seeds/users.yml
@@ -11,3 +11,4 @@
     content from deleted users, among other things.</p>
   is_global_moderator: true
   is_global_admin: true
+  confirmed_at: 1990-01-01 12:00


### PR DESCRIPTION
Previously, seeding the database runs into multiple issues.

1. It does not seed models in the correct order, so some don't get added because their dependencies were not seeded yet.
2. It does not create a "Question" post type because it fails validations. "Question" post type sets `has_answer` to true, and needs to refer to the "Answer" post type, so we need to first create the answer post type before we can create the "Question" post type.
3. Creating a user succeeds, but an error is reported.
4. The initially seeded categories do not have tag sets associated with them.

For the first, I have added a bit of code to prioritize models on which others depend.

For the second, I have flipped the order of the Post types in the file and added ids. The import scripts (and potentially some code) rely on the fact that id for the "Question" post type is 1 and that the id for the "Answer" post type is 2, therefore I added the ids to ensure they are set that way.

For the third point, I added a confirmed at date for the admin user to ensure that devise does not try to send a confirmation mail. Otherwise it crashes in `devise/mailer/confirmation_instructions.html.erb` on line 11 since there is no `RequestContext` while seeding.

For the last point, I added `.id` such that it actually gets the ids and not the instances.

Fixes #638