### PR TITLE
Add search instructions in search slide

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -111,6 +111,33 @@
 </div>
 
 <div class="header-slide is-large" id="search-slide">
+  <div class="grid has-padding-bottom-2">
+    <div class="grid--cell is-6 is-12-sm">
+      <span>tag:snake</span> <span class="has-color-tertiary-600">search within a tag</span>
+    </div>
+    <div class="grid--cell is-6 is-12-sm">
+      <span>answers:0</span> <span class="has-color-tertiary-600">unanswered questions</span>
+    </div>
+    <div class="grid--cell is-6 is-12-sm">
+      <span>user:xxxx</span> <span class="has-color-tertiary-600">search by author id</span>
+    </div>
+    <div class="grid--cell is-6 is-12-sm">
+      <span>score:0.5</span> <span class="has-color-tertiary-600">posts with 0.5+ score</span>
+    </div>
+    <div class="grid--cell is-6 is-12-sm">
+      <span>"snake oil"</span> <span class="has-color-tertiary-600">exact phrase</span>
+    </div>
+    <div class="grid--cell is-6 is-12-sm">
+      <span>votes:4</span> <span class="has-color-tertiary-600">posts with 4+ votes</span>
+    </div>
+    <div class="grid--cell is-6 is-12-sm">
+      <span>created:<1w</span> <span class="has-color-tertiary-600">created < 1 week ago</span>
+    </div>
+    <div class="grid--cell is-6 is-12-sm">
+      <span>post_type:xxxx</span> <span class="has-color-tertiary-600">type of post</span>
+    </div>
+  </div>
+
   <%= form_tag search_path, method: :get do %>
     <div class="grid is-nowrap">
         <%= text_field_tag :search, params[:search], class: 'form-element' %>
@@ -121,6 +148,9 @@
         </div>
     </div>
   <% end %>
+  <div class="has-padding-top-2 has-padding-right-1 has-float-right">
+    <a href="<%= help_path('search') %>">Search help</a>
+  </div>
 </div>
 
 <div class="header-slide inbox h-p-0" id="js-inbox">


### PR DESCRIPTION
I've put some search instructions in the search slide:
![image](https://user-images.githubusercontent.com/668952/184509945-62550ffb-b5fe-49f1-a9d1-30afc7be6e4f.png)

Please note: this is styled very similarly to how it appears on Stack Overflow / Stack Exchange (see #830). Please review whether such a similar design is okay.

Closes #830