### PR TITLE
Use same badge as elsewhere on the site

### DIFF
--- a/app/views/users/_common_card.html.erb
+++ b/app/views/users/_common_card.html.erb
@@ -32,9 +32,9 @@
       <%= link_to user_path(user), dir: 'ltr', class: small ? :'user-card--link-small' :'user-card--link', data: data do %>
         <%= rtl_safe_username(user) %>
         <% if user.is_admin && SiteSetting['AdminBadgeCharacter'] %>
-          <span class="badge is-user-role" title="Administrator"><%= SiteSetting['AdminBadgeCharacter'] %></span>
+          <span class="badge is-user-role" title="Administrator"><i class="fas fa-<%= SiteSetting['AdminBadgeCharacter'] %>"></i></span>
         <% elsif user.is_moderator && SiteSetting['ModBadgeCharacter'] %>
-          <span class="badge is-user-role" title="Moderator"><%= SiteSetting['ModBadgeCharacter'] %></span>
+          <span class="badge is-user-role" title="Moderator"><i class="fas fa-<%= SiteSetting['ModBadgeCharacter'] %>"></i></span>
         <% end %>
         <% if user.staff? %>
           <span class="badge is-tag is-filled is-green staff-badge">staff</span>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -102,9 +102,13 @@
       <div class="widget--body h-ta-center" title="This user is an official Staff member.">
         <i class="fas fa-users-cog"></i> Staff
       </div>
-      <% elsif @user.is_moderator || @user.is_admin %>
+      <% elsif @user.is_admin %>
+      <div class="widget--body h-ta-center" title="This user is an administrator of the <%= SiteSetting['SiteName'] %> community.">
+        <i class="fas fa-<%= SiteSetting['AdminBadgeCharacter'] %>"></i> Administrator
+      </div>
+      <% elsif @user.is_moderator %>
       <div class="widget--body h-ta-center" title="This user is a moderator of the <%= SiteSetting['SiteName'] %> community.">
-        <i class="fas fa-shield-alt"></i> Moderator
+        <i class="fas fa-<%= SiteSetting['ModBadgeCharacter'] %>"></i> Moderator
       </div>
       <% end %>
     </div>

--- a/db/seeds/site_settings.yml
+++ b/db/seeds/site_settings.yml
@@ -74,18 +74,18 @@
     How many "hot" questions to display in the sidebar.
 
 - name: AdminBadgeCharacter
-  value: ""
+  value: "shield-alt"
   value_type: string
   category: Display
   description: >
-    A character to display after an admin's username to distinguish their role.
+    The fontawesome v5 icon (e.g. shield-alt, hammer, ...) to display after an admin's username to distinguish their role.
 
 - name: ModBadgeCharacter
-  value: ""
+  value: "shield-alt"
   value_type: string
   category: Display
   description: >
-    A character to display after a moderator's username to distinguish their role.
+    The fontawesome v5 icon (e.g. shield-alt, hammer, ...) to display after a moderator's username to distinguish their role.
 
 - name: SoftDeleteTransferUser
   value: -1


### PR DESCRIPTION
* Replaces the mod character with a fontawesome icon.
* Also display admin separate from Moderator on the user profile (was already done for the name).

Example with `shield-alt`:
Profile:
![image](https://user-images.githubusercontent.com/668952/186776883-550ca67b-ea58-41d4-9dce-93dae68a9581.png)

Post:
![image](https://user-images.githubusercontent.com/668952/186777000-7fe7f531-adf6-45c3-99b1-bd915cb87134.png)

Fixes #816