### PR TITLE
Add 5 minutes to prevent timing issues with subscriptions

### DIFF
--- a/scripts/send_subscription_emails.rb
+++ b/scripts/send_subscription_emails.rb
@@ -1,6 +1,6 @@
 # SQL for selecting subscriptions due for sending.
 # DO NOT USE USER INPUT IN THIS CLAUSE, IT GETS PASSED DIRECTLY TO Arel.sql
-select_clause = 'last_sent_at IS NULL OR DATE_ADD(last_sent_at, INTERVAL frequency DAY) <= CURRENT_TIMESTAMP'
+select_clause = 'last_sent_at IS NULL OR DATE_ADD(last_sent_at, INTERVAL frequency DAY) <= DATE_ADD(CURRENT_TIMESTAMP, INTERVAL 5 MINUTE)'
 
 Subscription.unscoped.where(Arel.sql(select_clause)).includes(:community).each do |sub|
   SubscriptionMailer.with(subscription: sub).subscription.deliver_now


### PR DESCRIPTION
The formula was:
last_sent + frequency*(1 day) <= now

The formula becomes
last_sent + frequency*(1 day) <= now + 5 * (1 minute)

Related to conversation in #425