### PR TITLE
Fix regression from !839: profile editing

### DIFF
--- a/app/views/users/edit_profile.erb
+++ b/app/views/users/edit_profile.erb
@@ -18,6 +18,8 @@
   </div>
 <% end %>
 
+<%= render 'posts/image_upload' %>
+
 <%= form_for current_user, url: update_user_profile_path do |f| %>
   <div class="form-group has-padding-2">
     <img alt="user avatar" class="has-float-right has-margin-2 avatar-64" title="Current avatar" src="<%= avatar_url(current_user, 64) %>" height="64" width="64" />
@@ -34,8 +36,6 @@
     <div class="form-caption">What other people call you.</div>
     <%= f.text_field :username, class: 'form-element', autocomplete: 'off' %>
   </div>
-
-  <%= render 'posts/image_upload' %>
 
   <%= render 'shared/body_field', f: f, field_name: :profile_markdown, field_label: 'Profile', post: current_user %>
 


### PR DESCRIPTION
The form was no longer able to be submitted for the profile due to some unexpected interaction between the post upload field and the profile form. By moving it to a different location in the file (outside the form), this issue is fixed.

Apologies for the mistake.