### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,15 +2,15 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: circleci/ruby:2.7.6-node
-      - image: circleci/mysql:8.0.20
+      - image: cimg/ruby:2.7.6-node
+      - image: cimg/mysql:8.0.20
         command: [--default-authentication-plugin=mysql_native_password]
         environment:
           MYSQL_ROOT_HOST: '%'
           MYSQL_USER: 'root'
           MYSQL_ROOT_PASSWORD: 'root'
           MYSQL_DATABASE: 'qpixel_test'
-      - image: circleci/redis:6.0.0
+      - image: cimg/redis:6.0.0
 
     working_directory: ~/qpixel
 
@@ -66,7 +66,7 @@ jobs:
 
   rubocop:
     docker:
-      - image: circleci/ruby:2.7.6-node
+      - image: cimg/ruby:2.7.6-node
 
     working_directory: ~/qpixel
 
@@ -97,7 +97,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/ruby:2.7.6-node
+      - image: cimg/ruby:2.7.6-node
 
     working_directory: ~/qpixel
 


### PR DESCRIPTION
We were using legacy CI images, for which the updated ruby 2.7 image does not exist (any more?), and these are being phased out. We need to use the tag `cimg` instead to switch to the new images (which should be faster but do the same).