### PR TITLE
Search tags in name and excerpt

### DIFF
--- a/app/assets/javascripts/tags.js
+++ b/app/assets/javascripts/tags.js
@@ -28,6 +28,11 @@ $(() => {
     const useIds = $tgt.attr('data-use-ids') === 'true';
     $tgt.select2({
       tags: $tgt.attr('data-create') !== 'false',
+      insertTag: function (data, tag) {
+        tag.desc = "(Create new tag)"
+        // Insert the tag at the end of the results
+        data.push(tag);
+      },
       ajax: {
         url: '/tags',
         data: function (params) {

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -17,6 +17,7 @@ class Tag < ApplicationRecord
 
   def self.search(term)
     where('name LIKE ?', "%#{sanitize_sql_like(term)}%")
+      .or(where('excerpt LIKE ?', "%#{sanitize_sql_like(term)}%"))
       .order(Arel.sql(sanitize_sql_array(['name LIKE ? DESC, name', "#{sanitize_sql_like(term)}%"])))
   end
 


### PR DESCRIPTION
This PR adds searching in tag excerpts when choosing tags for a post. Creating a new tag instead of a matched tag is moved to the bottom to prevent accidental creation of duplicate tags, and it is indicated with a footer.

![image](https://user-images.githubusercontent.com/668952/186699897-82d052c9-05d2-4719-8d0b-d3f887238658.png)

We added this feature because we found it useful for our instance, but please determine whether it fits in your vision for how tags are intended to be used.