### PR TITLE
Display post body in lists

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -40,6 +40,14 @@ h1 .badge.is-tag.is-master-tag {
   font-size: 14px;
 }
 
+.post-list--title {
+  font-size: 19px;
+}
+
+.post-list--content {
+  font-size: 14px;
+}
+
 .post--action-dialog {
   display: none;
 

--- a/app/views/posts/_list.html.erb
+++ b/app/views/posts/_list.html.erb
@@ -35,6 +35,11 @@
       <%= post.duplicate_post && post.post_type.is_closeable && post.closed ? "[duplicate]" : "" %>
       <% end %>
     </div>
+    <% if (SiteSetting['PostBodyListTruncateLength'] || 0) > 0 %>
+      <p class="post-list--content">
+        <%= strip_tags(post.body).truncate(SiteSetting['PostBodyListTruncateLength'] || 200) %>
+      </p>
+    <% end %>
     <p class="has-color-tertiary-600 has-float-right post-list--meta">
       <% if post.post_type.has_answers? %>
         <span class="answer-count <%= post.answer_count == 0 ? 'badge is-tag is-red is-small' : 'h-c-green-700' %>">

--- a/db/seeds/site_settings.yml
+++ b/db/seeds/site_settings.yml
@@ -507,3 +507,11 @@
   category: Tour
   description: >
     Displayed as the description for the tour's more page for where users can find additional information. Markdown allowed.
+
+- name: PostBodyListTruncateLength
+  value: 200
+  value_type: integer
+  category: Display
+  description: >
+    The content of a post is shown in short in lists (e.g. category post overview or in search).
+    This setting controls how many characters of a post are shown.


### PR DESCRIPTION
This PR adds a short preview of the body of a post to any list which displays posts (category index, search, user posts, etc.)

![image](https://user-images.githubusercontent.com/668952/186700505-2ef5ef5a-b395-4236-8ab7-ac74e6319931.png)

For this, the text size of the title was increased to give a better reading experience. The size matches the codesign standard for H3 tags. The content was set to slightly larger text of 14 px to avoid it getting too big.

The length of the preview is configurable as `PostBodyListTruncateLength` in the settings of each site.
