### PR TITLE
Only create the tour tagset for the first community

### DIFF
--- a/db/seeds/tag_sets.yml
+++ b/db/seeds/tag_sets.yml
@@ -2,3 +2,4 @@
 - name: Meta
 - name: Tour
   id: -1
+  community_id: 1


### PR DESCRIPTION
Fixes issue with seeding whenever there are multiple communities.