### PR TITLE
Filters out pinned posts from hot posts

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -264,7 +264,7 @@ class ApplicationController < ActionController::Base
     # Post not pinned => NOT IN pinned_post_ids = NOT NULL = NULL => Not Selected
     # Post pinned => NOT IN pinned_post_ids = NOT TRUE = FALSE => Not Selected
     # I.e., if pinned_post_ids contains null, the selection will never return records
-    pinned_post_ids = @pinned_links.pluck(:post_id).select(&:present?)
+    pinned_post_ids = @pinned_links.map(&:post_id).reject(&:nil?)
   
     @hot_questions = Rails.cache.fetch('hot_questions', expires_in: 4.hours) do
       Rack::MiniProfiler.step 'hot_questions: cache miss' do


### PR DESCRIPTION
Fixes #812 

I'm not quite sure why pins with undefined post ids (i.e., featured links rather than featured posts) needed to be filtered as well, but it doesn't work if I don't.