### PR TITLE
Sticky navigation bar preference

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -112,6 +112,10 @@ header {
     position: relative;
     box-shadow: 0 3px 3px 0 rgba(0, 0, 0, 0.2);
   }
+  &.header.sticky {
+    position: sticky;
+    top: 0;
+  }
 }
 
 .notice a.has-font-size-larger {

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,7 +1,11 @@
 <% logo_path = SiteSetting['SiteLogoPath'] %>
 <% mobile_logo_path = SiteSetting['MobileLogoPath'] %>
+<% sticky_header = user_preference('sticky_header', community: false) == 'true' %>
 
-<header class="header is-small has-margin-0 <%= SiteSetting['SiteHeaderIsDark'] ? 'is-dark' : '' %>">
+<header class="header is-small has-margin-0 <%= SiteSetting['SiteHeaderIsDark'] ? 'is-dark' : '' %>"
+    <% if sticky_header %>
+      style="position:sticky;top:0;"
+    <% end %>>
   <div class="container header--container">
     <div class="header--brand">
       <% if mobile_logo_path.present? %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -2,10 +2,7 @@
 <% mobile_logo_path = SiteSetting['MobileLogoPath'] %>
 <% sticky_header = user_preference('sticky_header', community: false) == 'true' %>
 
-<header class="header is-small has-margin-0 <%= SiteSetting['SiteHeaderIsDark'] ? 'is-dark' : '' %>"
-    <% if sticky_header %>
-      style="position:sticky;top:0;"
-    <% end %>>
+<header class="header is-small has-margin-0<%=' is-dark' if SiteSetting['SiteHeaderIsDark'] %><%= ' sticky' if sticky_header %>">
   <div class="container header--container">
     <div class="header--brand">
       <% if mobile_logo_path.present? %>

--- a/config/config/preferences.yml
+++ b/config/config/preferences.yml
@@ -67,3 +67,9 @@ auto_follow_comment_threads:
   description: >
     Automatically follow any comment thread you participate in.
   default: 'true'
+
+sticky_header:
+  type: boolean
+  description: >
+    Make the Codidact navigation bar sticky
+  default: false

--- a/config/config/preferences.yml
+++ b/config/config/preferences.yml
@@ -71,5 +71,5 @@ auto_follow_comment_threads:
 sticky_header:
   type: boolean
   description: >
-    Make the Codidact navigation bar sticky
+    Make the top navigation bar sticky.
   default: false


### PR DESCRIPTION
Resolves #814 by adding a network preference to make the header navigation bar sticky.

I used inline styles because there doesn't seem to be anything in co-design for sticky items, but if there is then it should probably be changed to use that instead.