### PR TITLE
Remove excess whitespace around post titles

### DIFF
--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -13,11 +13,10 @@
 <div class="post <%= post.meta? ? 'is-meta' : '' %> <%= is_top_level ? '' : 'has-border-bottom-style-solid has-border-bottom-width-1 has-border-color-tertiary-100' %>" data-post-id="<%= post.id %>" id="<%= (is_question ? 'question-' : 'answer-') + post.id.to_s %>" data-ckb-list-item data-ckb-item-type="post" data-ckb-post-id="<%= post.id %>">
   <% if is_top_level %>
     <h1 class="post--title has-border-top-width-4 has-border-top-style-solid has-border-color-<%= post.meta? ? 'tertiary' : 'primary' %>-400 has-padding-2">
-      <span class="post--title-text">
-        <%= post.title %>
-        <%= post_type.is_closeable && post.closed && !post.duplicate_post ? "[closed]" : "" %>
-        <%= post.duplicate_post && post_type.is_closeable && post.closed ? "[duplicate]" : "" %>
-      </span>
+      <% title = post.title +
+                 (post.closed && !post.duplicate_post ? " [closed]" : "") +
+                 (post.duplicate_post ? " [duplicate]" : "") %>
+      <span class="post--title-text"><%= title %></span>
       <% if category.display_post_types.reject { |e| e.to_s.empty? }.size > 1 %>
         <%= post_type_badge(post_type) %>
       <% end %>


### PR DESCRIPTION
Fixes #701 by setting the title to a variable rather than doing it in the element itself.