### PR TITLE
Use the deleted_user? util instead of checking for nil.

### DIFF
--- a/app/views/post_history/post.html.erb
+++ b/app/views/post_history/post.html.erb
@@ -11,7 +11,7 @@
       <span class="has-color-tertiary-600 history-meta">
         <span>
           by
-          <% if event.user.nil? %>
+          <% if deleted_user? event.user %>
             (deleted user)
           <% else %>
             <img class="avatar-16" alt="user avatar" src="<%= avatar_url(event.user) %>" height="16" width="16" />


### PR DESCRIPTION
Fixes #732 

Formerly, that section of code was simply checking to see if the user was nil, but that misses the case where the user is deleted but not nil. The helper already exists and does a proper check.

https://github.com/codidact/qpixel/blob/e95bebb58959213411be88bcefecbbbbc1cd011c/app/helpers/users_helper.rb#L39-L41