### PR TITLE
Add close reason as a comment

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -276,7 +276,7 @@ class PostsController < ApplicationController
 
     if @post.update(closed: true, closed_by: current_user, closed_at: DateTime.now, last_activity: DateTime.now,
                     last_activity_by: current_user, close_reason: reason, duplicate_post: duplicate_of)
-      PostHistory.question_closed(@post, current_user)
+      PostHistory.question_closed(@post, current_user, comment: "Closed as #{reason.name}")
       render json: { status: 'success' }
     else
       render json: { status: 'failed', message: helpers.i18ns('posts.cant_close_post'),


### PR DESCRIPTION
Working on #215 

Right now, it just puts "Closed as <reason name>" in the history, which technically works but could be improved. For instance, it doesn't add in the link for close reasons that need a link. This is because the comment is technically the same as the comments for edits, which makes it easy to just patch in like this without extra work, but also limits formatting options since it's just plaintext.

![Closed as unclear in post history](https://user-images.githubusercontent.com/54333972/187612104-d2e47e45-d694-4a20-a1b0-d94c20ec968b.png)

A more sophisticated solution might be to add in "close reason" and "target link" fields to the `post_histories` schema, and do some logic (switch on `post_history_type_id`) to format closures differently from other history events.