### PR TITLE
Improve the docker-compose setup and instructions

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -138,6 +138,14 @@ It is also possible to open up a rails console to do more complicated things:
 $ docker compose exec uwsgi rails c
 ```
 
+Please keep in mind that for database related actions to work as expected, you first need to run the following in the rails console.
+
+```ruby
+RequestContext.community = Community.first
+```
+
+This correctly scopes all database actions to the first (and probably only) community in your system.
+
 ### 10. Stop Containers
 
 When you are finished, don't forget to clean up.

--- a/docker/README.md
+++ b/docker/README.md
@@ -125,7 +125,7 @@ Running in this docker-compose setup, the system does not actually send emails. 
 This is especially useful to confirm other accounts that you make in the container.
 
 ### 9. Running commands in the docker container
-Often, it may be useful to run some ruby/rails code directly, e.g. for debugging purposes. YOu can do so with the following command:
+Often, it may be useful to run some ruby/rails code directly, e.g. for debugging purposes. You can do so with the following command:
 
 ```bash
 $ docker compose exec uwsgi rails runner "<ruby code here>"

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,6 +2,14 @@
 
 A [docker-compose.yml](../docker-compose.yml) file is provided for deployment with Docker compose, if you choose.
 
+To use docker compose, you need to install the docker-compose-plugin. For a system like debian or ubuntu, you can use the following command.
+
+```bash
+sudo apt-get install docker-compose-plugin
+```
+
+Depending on your setup, you may need to prefix every docker command with sudo.
+
 ## 1. Setup and Secrets
 
 The `docker-compose.yml` file uses a `.env` file in the same directory to load dynamic values used when the docker containers are initialized.
@@ -30,15 +38,15 @@ the `COMMUNITY_ADMIN_USERNAME`, `COMMUNITY_ADMIN_PASSWORD` and `COMMUNITY_ADMIN_
 Next, you should build the images.
 
 ```bash
-docker-compose build
+docker compose build
 ```
 
 If you need to just rebuild one container, you can do that too.
 
 ```bash
-docker-compose build uwsgi
-docker-compose build db
-docker-compose build redis
+docker compose build uwsgi
+docker compose build db
+docker compose build redis
 ```
 
 ## 4. Start Containers
@@ -46,7 +54,7 @@ docker-compose build redis
 Then start your containers! 
 
 ```bash
-docker-compose up # append -d if you want to detach the processes, although it can be useful to see output into the terminal
+docker compose up # append -d if you want to detach the processes, although it can be useful to see output into the terminal
 Creating qpixel_redis_1 ... done
 Creating qpixel_db_1    ... done
 Creating qpixel_uwsgi_1 ... done
@@ -120,14 +128,14 @@ This is especially useful to confirm other accounts that you make in the contain
 Often, it may be useful to run some ruby/rails code directly, e.g. for debugging purposes. YOu can do so with the following command:
 
 ```bash
-$ docker exec qpixel_uwsgi_1 rails runner "<ruby code here>"
+$ docker compose exec uwsgi rails runner "<ruby code here>"
 Running via Spring preloader in process 111
 ```
 
 It is also possible to open up a rails console to do more complicated things:
 
 ```bash
-$ docker exec qpixel_uwsgi_1 rails c
+$ docker compose exec uwsgi rails c
 ```
 
 ### 10. Stop Containers
@@ -135,8 +143,8 @@ $ docker exec qpixel_uwsgi_1 rails c
 When you are finished, don't forget to clean up.
 
 ```bash
-docker-compose stop
-docker-compose rm
+docker compose stop
+docker compose rm
 ```
 
 ### 11. Next steps

--- a/docker/create_admin_and_community.rb
+++ b/docker/create_admin_and_community.rb
@@ -9,6 +9,4 @@ password = ENV['COMMUNITY_ADMIN_PASSWORD'] || 'password'
 email = ENV['COMMUNITY_ADMIN_EMAIL'] || 'codadict@noreply.com'
 
 User.create(username: username, password: password, email: email, is_global_admin: true, is_global_moderator: true,
-            staff: true)
-# You'll need to manually set confirmation for this user
-# $ docker exec qpixel_uwsgi_1 rails runner "User.second.update(confirmed_at: DateTime.now)"
+            staff: true, confirmed_at: DateTime.now)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,8 +10,8 @@ if [ ! -f "/db-created" ]; then
     rails r db/scripts/create_tags_path_view.rb
     rails db:migrate
     rails db:migrate RAILS_ENV=development
-    rails db:seed
     rails r docker/create_admin_and_community.rb
+    UPDATE_POSTS=true rails db:seed
     touch /db-created
 fi
 


### PR DESCRIPTION
* Automatically confirm account in creation script to remove the need for a manual step
* Fix instruction steps to something that actually works
* Add information on how to access emails that were sent
* Add information on how to access a rails console / run commands in the container
* Update commands to the new docker compose v2 commands (v1 is no longer supported, Ubuntu 20.04 and up uses the new version)
* Fix seeding and also seed help posts to ensure proper working in the container