### PR TITLE
Create markdown-it plugin to escape LaTeX

### DIFF
--- a/app/assets/javascripts/latex_escape.js
+++ b/app/assets/javascripts/latex_escape.js
@@ -108,6 +108,6 @@ latexEscape.blockDelimiters = {
     match: /\\\[[^]+?\\\]$/my   // \[...\]
   },
   'begin-end': {
-    match: /\\begin\{(.+)\}[^]+\\end\{\1\}$/my // \begin{...}...\end{...}
+    match: /\\begin\{(.+?)\}[^]+?\\end\{\1\}$/my // \begin{...}...\end{...}
   }
 }

--- a/app/assets/javascripts/latex_escape.js
+++ b/app/assets/javascripts/latex_escape.js
@@ -1,0 +1,109 @@
+// markdown-it plugin to escape LaTeX
+
+function latexEscape(md, options) {
+  // Load all the rules
+  for (const [rule, ruleset] of Object.entries(latexEscape.inlineDelimiters)) {
+    md.inline.ruler.before('escape', rule, latexEscape.inlineRule(ruleset));
+  }
+
+  for (const [rule, ruleset] of Object.entries(latexEscape.blockDelimiters)) {
+    md.block.ruler.before('fence', rule, latexEscape.blockRule(ruleset));
+  }
+
+  // We just need to escape it for the MathJax parser,
+  // so we can just return the contents as-is
+  md.renderer.rules['inline_math'] =
+    md.renderer.rules['block_math'] =
+    md.renderer.rules['math_open'] =
+    md.renderer.rules['math_close'] = (tokens, idx) => tokens[idx].content;
+}
+
+latexEscape.inlineRule = ruleset => (state, silent) => {
+  const start = state.pos;
+
+  ruleset.open.lastIndex = start;
+  const open_match = ruleset.open.exec(state.src);
+  if (!open_match) { return false; }
+
+  ruleset.close.lastIndex = start + open_match[0].length;
+  const close_match = ruleset.close.exec(state.src);
+  if (!close_match) { return false; }
+
+  const end = ruleset.close.lastIndex + close_match[0].length
+
+  if (!silent) {
+    const token = state.push('inline_math', 'math', 0);
+    token.content = state.src.substring(start, end);
+  }
+
+  state.pos = end;
+
+  return true;
+}
+
+latexEscape.blockRule = ruleset => (state, startLine, endLine, silent) => {
+  const start = state.bMarks[startLine] + state.tShift[startLine]
+
+  if (!state.src.startsWith(ruleset.open, start)) { return false; }
+
+  let nextLine = startLine + 1;
+
+  while (nextLine < endLine && !state.src.endsWith(ruleset.close, state.eMarks[nextLine])) {
+    ++nextLine;
+  }
+
+  // no ending found
+  if (nextLine === endLine) {
+    return false;
+  }
+  const parentType = state.parentType;
+
+  state.push('math_open', 'math', 1);
+
+  state.parentType = 'math';
+
+  const block_token = state.push('block_math', 'math', 0)
+  block_token.content = state.src.substring(start, state.eMarks[nextLine]);
+
+  state.push('math_close', 'math', -1);
+
+  state.parentType = parentType;
+  state.line = nextLine + 1;
+
+  return true;
+}
+
+// open: opening delimiter
+// close: closing delimiter
+latexEscape.inlineDelimiters = {
+  '$': {
+    open: /\$(?!\$)/y,   // $ not followed by a $
+    close: /(?<!\\)\$/g, // $ not escaped by a \
+  },
+  '\\(': {
+    open: /\\\(/y,       // \(
+    close: /\\\(/g,      // \)
+  },
+  // Block-level delimiters work inline too!
+  '$$': {
+    open: /\$\$/y,       // $$
+    close: /\$\$/g,      // $$
+  },
+  '\\[': {
+    open: /\\\[/y,       // \[
+    close: /\\\]/g,      // \]
+  }
+};
+
+// Similar format to the above
+// Regexes aren't really necessary, since blocks can only match whole lines anyway
+latexEscape.blockDelimiters = {
+  '$$': {
+    open: '$$',
+    close: '$$',
+  },
+  '\\[': {
+    open: '\\[',
+    close: '\\]',
+  }
+}

--- a/app/assets/javascripts/latex_escape.js
+++ b/app/assets/javascripts/latex_escape.js
@@ -21,15 +21,11 @@ function latexEscape(md, options) {
 latexEscape.inlineRule = ruleset => (state, silent) => {
   const start = state.pos;
 
-  ruleset.open.lastIndex = start;
-  const open_match = ruleset.open.exec(state.src);
-  if (!open_match) { return false; }
+  ruleset.match.lastIndex = start;
+  const match = ruleset.match.exec(state.src);
+  if (!match) { return false; }
 
-  ruleset.close.lastIndex = start + open_match[0].length;
-  const close_match = ruleset.close.exec(state.src);
-  if (!close_match) { return false; }
-
-  const end = ruleset.close.lastIndex + close_match[0].length
+  const end = start + match[0].length
 
   if (!silent) {
     const token = state.push('inline_math', 'math', 0);
@@ -73,25 +69,20 @@ latexEscape.blockRule = ruleset => (state, startLine, endLine, silent) => {
   return true;
 }
 
-// open: opening delimiter
-// close: closing delimiter
+// match: Sticky regex matching the LaTeX
 latexEscape.inlineDelimiters = {
   '$': {
-    open: /\$(?!\$)/y,   // $ not followed by a $
-    close: /(?<!\\)\$/g, // $ not escaped by a \
+    match: /\$.+\$/y       // $...$
   },
   '\\(': {
-    open: /\\\(/y,       // \(
-    close: /\\\(/g,      // \)
+    match: /\\\(.+\\\)/y   // \(...\)
   },
   // Block-level delimiters work inline too!
   '$$': {
-    open: /\$\$/y,       // $$
-    close: /\$\$/g,      // $$
+    match: /\$\$.+\$\$/y   // $$...$$
   },
   '\\[': {
-    open: /\\\[/y,       // \[
-    close: /\\\]/g,      // \]
+    match: /\\\[.+\\\]/y   // \[...\]
   }
 };
 

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -127,6 +127,7 @@ $(() => {
         linkify: true
       });
       window.converter.use(window.markdownitFootnote);
+      window.converter.use(window.latexEscape);
     }
     window.setTimeout(() => {
       const converter = window.converter;


### PR DESCRIPTION
Should fix #435. However, I haven't fully tested this yet, so feedback is welcome.