### PR TITLE
Include deleted comments in inline thread

### DIFF
--- a/app/views/comments/thread.html.erb
+++ b/app/views/comments/thread.html.erb
@@ -67,7 +67,7 @@
   <% if params[:inline] == 'true' %>
     <% count = 0 %>
     <% comments = comments.take_while do |comment| %>
-      <% count += 1 if !comment.deleted %>
+      <% count += 1 unless comment.deleted %>
       <% count <= 5 %>
     <% end %>
   <% end %>

--- a/app/views/comments/thread.html.erb
+++ b/app/views/comments/thread.html.erb
@@ -65,7 +65,7 @@
   <% skipped_deleted = 0 %>
   <% comments = @comment_thread.comments %>
   <% if params[:inline] == 'true' %>
-    <% comments = comments.where(deleted: false).take 5 %>
+    <% comments = comments.take 5 %>
   <% end %>
   <% comments.each do |comment| %>
     <% if comment.deleted && !(current_user&.is_moderator && params[:show_deleted_comments] == "1") %>

--- a/app/views/comments/thread.html.erb
+++ b/app/views/comments/thread.html.erb
@@ -65,7 +65,11 @@
   <% skipped_deleted = 0 %>
   <% comments = @comment_thread.comments %>
   <% if params[:inline] == 'true' %>
-    <% comments = comments.take 5 %>
+    <% count = 0 %>
+    <% comments = comments.take_while do |comment| %>
+      <% count += 1 if !comment.deleted %>
+      <% count <= 5 %>
+    <% end %>
   <% end %>
   <% comments.each do |comment| %>
     <% if comment.deleted && !(current_user&.is_moderator && params[:show_deleted_comments] == "1") %>


### PR DESCRIPTION
Resolves #696

While it shows deleted comments (as "Skipping n deleted" comments), it only counts undeleted comments, so if there are 1 deleted and 1 undeleted comment, it show "Showing 1 comment" at the bottom. Not sure whether it's better like this or not though.

If it's better to include the deleted comments in the count, then it would render #783 moot