### PR TITLE
Only load stripe API if donations are enabled

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -27,7 +27,9 @@
 <%= javascript_include_tag "https://cdn.jsdelivr.net/npm/jquery@2.2.2/dist/jquery.min.js" %>
 <%= javascript_include_tag "https://cdn.jsdelivr.net/npm/moment@2.13.0/min/moment.min.js" %>
 <%= javascript_include_tag "https://cdn.jsdelivr.net/npm/select2@4.0.12/dist/js/select2.min.js" %>
-<%= javascript_include_tag "https://js.stripe.com/v3/" %>
+<% if SiteSetting['DonationsEnabled'] %>
+  <%= javascript_include_tag "https://js.stripe.com/v3/" %>
+<% end %>
 <%= javascript_include_tag "https://cdn.jsdelivr.net/npm/dompurify@2.2.9/dist/purify.min.js" %>
 <%= javascript_include_tag "/assets/community/#{@community.host.split('.')[0]}.js" %>
 <%= javascript_include_tag 'application' %>


### PR DESCRIPTION
Performance analysis shows that loading the Stripe API adds a significant delay to the loading of the page (see discord). This prevents loading of the Stripe API if donations are disabled.