### PR TITLE
Add instructions for using MariaDB

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -99,6 +99,8 @@ You'll also need to fill in details for the Redis connection. If you've followed
 the sample file should already contain the correct values for you, but if you've customised your
 setup you'll need to correct them.
 
+If you are using MariaDB instead of MySQL, you will need to replace all occurrences of
+`utf8mb4_0900_ai_ci` with `utf8mb4_unicode_ci` in `db/schema.rb`.
 
 Set up the database:
 


### PR DESCRIPTION
The schema.rb file is so specific that for some tables it uses a collation that is available in MySQL 8, but not in MariaDB.

Fun information that is not really necessary to know or to review this PR:

`utfmb4_0900_ai_ci` is an implementation of the unicode 9.0 (2016) standard. For the database, it mainly describes how special unicode characters should be sorted and rules for casing (upper/lower case). `utf8mb4_unicode_ci` does the same, but for the unicode 4.0 standard (2003). 

* MySQL has the 4.0 version (general) and the 9.0 version.
* MariaDB has the 4.0 version (general) and the 5.2 version (2009).
* MariaDB  "just" (10.10) released an encoding based on unicode 14.0 (2021): `utf8mb4_uca1400_as_ci`. However, the version of MariaDB which adds it is not yet present on most systems, not even on the just (this month) released Ubuntu 22.04 LTS release.

Long story short: if you want to support both MySQL and MariaDB with one configuration, the 4.0 version is the common denominator. However, this does mean that ordering and case insensitivity for supplementary characters that were introduced or updated since 2003 will not be correct. This means that we might have unprecedentedly strange sorting where 😀 comes before 🙂. (Joking aside, for some languages which use non-latin alphabets this may actually matter). For a development instance, it does not really matter, for a production environment, you should use the newest version you can.

For MySQL, you can use the 9.0 version to move from 2003 to 2016, and for MariaDB you can use the 5.2 version to move from 2003 to 2009 or (if you can install such a new version) you can use the 14.0 version to move all the way to 2021.

In the end, the sorting/case sensitivity of these very specific characters is almost never relevant (we don't sort anything by alphabet as far as I know). The only thing I could think of to be slightly inconvenient is that a tag may get duplicated with a different-casing version of a character.