### PR TITLE
Improve subscriptions

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -14,12 +14,14 @@ class Subscription < ApplicationRecord
     case type
     when 'all'
       Question.unscoped.where(community: community, post_type_id: Question.post_type_id)
-              .where('created_at >= ?', last_sent_at)
+              .where(Question.arel_table[:created_at].gteq(last_sent_at || created_at))
     when 'tag'
       Question.unscoped.where(community: community, post_type_id: Question.post_type_id)
+              .where(Question.arel_table[:created_at].gteq(last_sent_at || created_at))
               .joins(:tags).where(tags: { name: qualifier })
     when 'user'
       Question.unscoped.where(community: community, post_type_id: Question.post_type_id)
+              .where(Question.arel_table[:created_at].gteq(last_sent_at || created_at))
               .where(user_id: qualifier)
     when 'interesting'
       RequestContext.community = community # otherwise SiteSetting#[] doesn't work
@@ -28,6 +30,7 @@ class Subscription < ApplicationRecord
               .order(Arel.sql('RAND()'))
     when 'category'
       Question.unscoped.where(community: community, post_type_id: Question.post_type_id)
+              .where(Question.arel_table[:created_at].gteq(last_sent_at || created_at))
               .where(category_id: qualifier)
     end&.order(created_at: :desc)&.limit(25)
   end

--- a/app/views/subscription_mailer/subscription.html.erb
+++ b/app/views/subscription_mailer/subscription.html.erb
@@ -3,6 +3,10 @@
   <% if @subscription.name.present? %>
     "<%= @subscription.name %>"
   <% end %>
+
+  <% if @questions.count == 25 %>
+    This e-mail only shows the 25 most recent items matching your filter.
+  <% end %>
 </h2>
 
 <% @questions.each do |question| %>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -78,6 +78,9 @@
   <div>
     <%= short_number_to_human post_count, precision: 1, significant: false %>
     <%= 'post'.pluralize(post_count) %>
+    <%= link_to 'Subscribe',
+                new_subscription_path(type: 'tag', qualifier: @tag.name, return_to: request.path),
+                class: 'button is-outlined' %>
   </div>
 
   <div class="button-list is-gutterless has-margin-2">


### PR DESCRIPTION
Changes by @MrHug 

* Add button to subscribe to a tag to the tag overview page (tag subscriptions were already implemented, but we could not find the supposed location where one could subscribe to a tag anywhere)
* Only include posts in subscriptions which were made since the last email was sent (or in case of first email, since the subscription was created)
  * This behavior is not present for interesting subscriptions, since those can get to interesting status well after they were posted. A better solution still needs to be "invented" to make those work well.
* Mention in the email that max 25 posts are included when the limit is reached, to avoid the idea that those 25 are all posts created since the last email.

Fixes #69
Fixes #269