### PR TITLE
Resize images

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -61,6 +61,7 @@
 
   img {
     width: 100%;
+    object-fit: contain;
   }
 }
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -4,7 +4,7 @@ module UsersHelper
     if deleted_user?(user)
       user_auto_avatar_url(letter: 'X', color: '#E73737FF', size: size, format: :png)
     elsif user&.avatar&.attached?
-      uploaded_url(user.avatar.blob.key)
+      url_for(user.avatar.variant(resize_to_fit: [size, size]).processed)
     else
       user_auto_avatar_url(user, size: size, format: :png)
     end


### PR DESCRIPTION
Images were not being resized, even when displayed as tiny 40x40 squares. For codidact, the image size limit is 2 MB which somewhat alleviates this problem, but for our self hosted instance we upped max image size to 10 MB for posts (which also affects avatars). As a result, if someone uploads a 6 MB avatar, any page which displays it loads the 6 MB giant avatar and then the browser has to scale it down to display it as a tiny image. This causes huge load times and server traffic for pages like the users overview.

In this PR, images are resized by ActiveStorage to the size matching the requested size (without altering aspect ratio). These resized images are created once when requested and are then cached on the storage provider (in your case, Amazon AWS) and not resized again.

As a bonus, images are also upscaled to the requested size if they are smaller, which should resolve #462 and ensure equal image size for all users.

Finally, the profile page would not maintain aspect ratio of the image (in contrast to all other locations which display the avatar). This is fixed in 879040d.

Fixes #462
Fixes #1133