### PR TITLE
Add missing time strings

### DIFF
--- a/config/locales/time.en_abbrev.yml
+++ b/config/locales/time.en_abbrev.yml
@@ -11,4 +11,6 @@ en_abbrev:
       about_x_months: '%{count}mo'
       x_months: '%{count}mo'
       about_x_years: '%{count}y'
+      almost_x_years: '%{count}y'
       x_years: '%{count}y'
+      over_x_years: '%{count}y'

--- a/config/locales/time.es_abbrev.yml
+++ b/config/locales/time.es_abbrev.yml
@@ -11,8 +11,8 @@ es_abbrev:
         one: '1min'
         other: '%{count}mins'
       about_x_hours:
-        one: '~1h'
-        other: '~%{count}hs'
+        one: '1h'
+        other: '%{count}hs'
       x_hours:
         one: '1h'
         other: '%{count}hs'
@@ -21,12 +21,12 @@ es_abbrev:
         one: '1sem'
         other: '%{count}sems'
       about_x_months:
-        one: '~1mes'
-        other: '~%{count}meses'
+        one: '1mes'
+        other: '%{count}meses'
       x_months:
         one: '1mes'
         other: '%{count}meses'
-      about_x_years: '~%{count}a'
+      about_x_years: '%{count}a'
       almost_x_years: '%{count}a'
       x_years: '%{count}a'
       over_x_years: '%{count}a'

--- a/config/locales/time.es_abbrev.yml
+++ b/config/locales/time.es_abbrev.yml
@@ -27,4 +27,6 @@ es_abbrev:
         one: '1mes'
         other: '%{count}meses'
       about_x_years: '~%{count}a'
+      almost_x_years: '%{count}a'
       x_years: '%{count}a'
+      over_x_years: '%{count}a'


### PR DESCRIPTION
We have noticed errors about missing time span translations on some of our older imported posts. This PR fixes those.

In addition, this updates the spanish translations to unify it with the english translations (though I don't think they are used).