### PR TITLE
Add support for pasting images into post text

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -117,6 +117,14 @@ $(() => {
 
   const postFields = $('.post-field');
 
+  postFields.on('paste', async evt => {
+    if (evt.originalEvent.clipboardData.files.length > 0) {
+      const $fileInput = $uploadForm.find('input[type="file"]');
+      $fileInput[0].files = evt.originalEvent.clipboardData.files;
+      $fileInput.trigger('change');
+    }
+  });
+
   postFields.on('focus keyup paste change markdown', evt => {
     const $tgt = $(evt.target);
 


### PR DESCRIPTION
The title should be self explanatory, works the same as e.g. here on GitHub when pasting a screenshot.

On Github (or after checking out the code) you can try it.

Make screenshot of an area of you screen and paste in post box.
* Windows: press `Windows Key + Shift + S`
* Mac: press `Shift + Cmd + 4`
* Linux: try `Shift + Alt + Printscreen` (?)