### PR TITLE
Do not display closed posts in hot posts

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -268,7 +268,8 @@ class ApplicationController < ActionController::Base
 
     @hot_questions = Rails.cache.fetch('hot_questions', expires_in: 4.hours) do
       Rack::MiniProfiler.step 'hot_questions: cache miss' do
-        Post.undeleted.where(last_activity: (Rails.env.development? ? 365 : 7).days.ago..DateTime.now)
+        Post.undeleted.where(closed: false)
+            .where(last_activity: (Rails.env.development? ? 365 : 7).days.ago..DateTime.now)
             .where(post_type_id: [Question.post_type_id, Article.post_type_id])
             .joins(:category).where(categories: { use_for_hot_posts: true })
             .where('score >= ?', SiteSetting['HotPostsScoreThreshold'])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -269,6 +269,7 @@ class ApplicationController < ActionController::Base
     @hot_questions = Rails.cache.fetch('hot_questions', expires_in: 4.hours) do
       Rack::MiniProfiler.step 'hot_questions: cache miss' do
         Post.undeleted.where(closed: false)
+            .where(locked: false)
             .where(last_activity: (Rails.env.development? ? 365 : 7).days.ago..DateTime.now)
             .where(post_type_id: [Question.post_type_id, Article.post_type_id])
             .joins(:category).where(categories: { use_for_hot_posts: true })


### PR DESCRIPTION
We had some of our very old but closed posts (no longer relevant, relating to a previous academic year) show up in hot posts due to an edit, comment or something else. We believe that closed posts are never a good fit for hot posts, so that is what this PR changes.