### PR TITLE
Improved error messages about too few/too many tags

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -265,9 +265,9 @@ class Post < ApplicationRecord
 
   def maximum_tags
     if tags_cache.length > 5
-      errors.add(:tags, "can't have more than 5 tags")
+      errors.add(:base, "Post can't have more than 5 tags.")
     elsif tags_cache.empty?
-      errors.add(:tags, 'must have at least one tag')
+      errors.add(:base, 'Post must have at least one tag.')
     end
   end
 


### PR DESCRIPTION
Changed error messages to avoid 'tags can't have more than 5 tags' construct.  I realize that usually we want to attach an error to the field (:tags) not the post (:base), but I couldn't come up with wordings that were clear and the error messages point to tags as the problem, so I think this is ok.

I tested this locally.

Fixes: https://meta.codidact.com/posts/287036 
