### PR TITLE
Generalized wording on vote-summary page

### DIFF
--- a/app/views/users/vote_summary.html.erb
+++ b/app/views/users/vote_summary.html.erb
@@ -2,7 +2,7 @@
 
 <h1>Vote summary for <%= user_link @user %></h1>
 
-<p class="is-lead">A daily summary of votes you have received for your posts.</p>
+<p class="is-lead">A daily summary of votes received for posts.</p>
 
 <% @votes.each do |day, vote_list| %>
 <details class="user-vote-summary" <%= 'open' unless day < SiteSetting['VoteSummaryAutoExpandLastNrOfDays'].days.ago%>>


### PR DESCRIPTION
Fixes https://github.com/codidact/qpixel/issues/899 .  Not a critical change or anything, but easy.  New wording is: "A daily summary of votes received for posts."  The user name is already shown immediately above, so no need to repeat it here.

![screenshot showing change](https://user-images.githubusercontent.com/5557942/193171313-44742b0b-ce74-4446-bf7d-55d811fced4e.png)
