### PR TITLE
Fix double bracketed footnotes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -145,22 +145,6 @@ hr {
   }
 }
 
-.footnote-ref a::before {
-  content: '[';
-}
-
-div.post-preview .footnote-ref a::before {
-  content: '';
-}
-
-.footnote-ref a::after {
-  content: ']';
-}
-
-div.post-preview .footnote-ref a::after {
-  content: '';
-}
-
 .footnotes-sep + .footnotes {
   border-top: 0;
 }


### PR DESCRIPTION
Fixes #259

Also re: https://meta.codidact.com/posts/287424

The footnote plugin automatically generates closing brackets, which means that adding it via. CSS is superfluous. See the [example output here](https://github.com/markdown-it/markdown-it-footnote).

Note: This will result in footnotes that currently only have one pair of brackets having none. Unfortunately, this is an inconsistency in the HTML itself which cannot be corrected except by editing. I believe that this is because in the past, we had inconsistency in whether the server-side or client-side code would render post's to markdown, as has been noted before. Since we have moved to client-side rendering, inconsistencies should no longer be an issue going forward.