### PR TITLE
Clarify fields on password-change form

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -41,7 +41,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.label :password, class: "form-element" %>
+    <%= f.label :password, "New password", class: "form-element" %>
     <div class="form-caption">
       Leave blank if you don't want to change it.
       <% if @minimum_password_length %>
@@ -52,7 +52,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.label :password_confirmation, class: "form-element" %>
+    <%= f.label :password_confirmation, "Confirm new password", class: "form-element" %>
     <%= f.password_field :password_confirmation, class: 'form-element', autocomplete: "new-password", disabled: sso %>
   </div>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -34,6 +34,13 @@
   <% end %>
 
   <div class="form-group">
+    <%= f.label :current_password, class: "form-element" %>
+    <div class="form-caption">We need your current password to confirm your changes.</div>
+    <%= f.password_field :current_password, class: 'form-element', autocomplete: "current-password", required: true,
+                         disabled: sso %>
+  </div>
+
+  <div class="form-group">
     <%= f.label :password, class: "form-element" %>
     <div class="form-caption">
       Leave blank if you don't want to change it.
@@ -47,13 +54,6 @@
   <div class="form-group">
     <%= f.label :password_confirmation, class: "form-element" %>
     <%= f.password_field :password_confirmation, class: 'form-element', autocomplete: "new-password", disabled: sso %>
-  </div>
-
-  <div class="form-group">
-    <%= f.label :current_password, class: "form-element" %>
-    <div class="form-caption">We need your current password to confirm your changes.</div>
-    <%= f.password_field :current_password, class: 'form-element', autocomplete: "current-password", required: true,
-                         disabled: sso %>
   </div>
 
   <%= f.submit "Update", class: 'button is-filled is-very-large', disabled: sso %>


### PR DESCRIPTION
Re: https://meta.codidact.com/posts/287649

Changes the order to: current pwd, new pwd, confirm new pwd, and also clarifies some labels.

![screenshot](https://user-images.githubusercontent.com/5557942/210273875-3eb31f89-76ba-4ff4-b147-d7b8ff8b64fd.png)

While looking for the right source file, I also came across app/views/devise/passwords/edit.html.erb, which doesn't match any page I can find from the user profile on a live site.  Is that file used?  Where?
