### PR TITLE
Better Notifications

### DIFF
--- a/app/assets/javascripts/notifications.js
+++ b/app/assets/javascripts/notifications.js
@@ -67,8 +67,6 @@ $(() => {
         const item = $(makeNotification(notification));
         $inboxContainer.append(item);
       });
-  
-      $inboxContainer.append(`<a href="/users/me/notifications" class="button is-muted is-small">See all your notifications &raquo;</a>`);
     }
   });
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -167,6 +167,7 @@
   <div class="h-p-2 h-bg-tertiary-050 h-fw-bold">Notifications</div>
   <div class="h-p-2 h-bg-tertiary-050 h-fw-bold">
     <a class="no-unread js-read-all-notifs" href="#"><i class="fas fa-envelope-open"></i> Mark all as read</a>
+    <a href="/users/me/notifications" class="button is-muted is-small">See all your notifications &raquo;</a>
   </div>
   <div class="inbox--container h-p-2"></div>
 </div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,3 +1,5 @@
+<%= render 'users/tabs', user: current_user %>
+
 <h1>Your Inbox</h1>
 <p>You'll find all your inbox messages here, as far back as your account goes.</p>
 

--- a/app/views/users/_tabs.html.erb
+++ b/app/views/users/_tabs.html.erb
@@ -18,5 +18,8 @@
     <%= link_to user_preferences_path, class: "tabs--item #{current_page?(user_preferences_path) ? 'is-active' : ''}" do %>
       Preferences
     <% end %>
+    <%= link_to notifications_path, class: "tabs--item #{current_page?(notifications_path) ? 'is-active' : ''}" do %>
+      Notifications
+    <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
Fixes #930 

 - Moves the "See all notifications" button to the top for visibility
   ![image](https://user-images.githubusercontent.com/54333972/210307859-40fe9dd7-5bf8-4b25-b857-d60515094628.png)
 - Adds a "Notifications" tab to the profile page
   ![image](https://user-images.githubusercontent.com/54333972/210307930-30b89785-9b09-48c4-a301-2615101490df.png)
