### PR TITLE
Make voting tool sticky

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -12,6 +12,11 @@
   }
 }
 
+.vote-widget {
+  position: sticky;
+  top: 0;
+}
+
 .post--container {
   max-width: 100%;
 

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -12,9 +12,9 @@
   }
 }
 
-.vote-widget {
+.sticky {
   position: sticky;
-  top: 0;
+  top: 50px;
 }
 
 .post--container {

--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -150,9 +150,10 @@
         <% end %>
       <% end %>
 
-      <div class="post--body">
+      <article class="post--body">
         <%= raw(sanitize(post.body, scrubber: scrubber)) %>
-
+      </article>
+      <div>
         <% been_edited = post.last_edited_by_id != nil %>
         <% if been_edited then last_edited_by_self = post.user_id == post.last_edited_by_id end %>
 

--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -38,7 +38,8 @@
   <div class="post--container <%= 'deleted-content' if post.deleted? %> grid is-nowrap">
     <% if post_type.has_votes %>
       <div>
-        <div class="vote-widget">
+        <% sticky_votes = user_preference('sticky_vote_tool', community: false) == 'true' %>
+        <div <% if sticky_votes then %> class="sticky" <% end %>>
           <div class="post--votes has-text-align-center" title="Score : <%= post.score %>">
             <% existing_vote = my_vote(post) %>
             <% unless post.locked? %>

--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -38,44 +38,46 @@
   <div class="post--container <%= 'deleted-content' if post.deleted? %> grid is-nowrap">
     <% if post_type.has_votes %>
       <div>
-        <div class="post--votes has-text-align-center" title="Score : <%= post.score %>">
-          <% existing_vote = my_vote(post) %>
-          <% unless post.locked? %>
-            <button class="vote-button button is-icon-only-button <%= (existing_vote&.vote_type == 1) ? 'is-active' : '' %>"
-                    data-vote-type="1" data-vote-id="<%= existing_vote&.id %>" id="post-<%= post.id %>-up" aria-label="Upvote">
-                <svg width="2em" height="1.33em" viewbox="0 0 100 50">
-                  <path d="M50,0 L100,50 L0,50 Z" fill="currentColor" />
-                </svg>
-            </button>
-          <% end %>
-          <div class="score has-font-size-subheading js-upvote-count">
-            +<%= post.upvote_count %>
-          </div>
-          <div class="score has-font-size-subheading js-downvote-count">
-            &minus;<%= post.downvote_count %>
-          </div>
-          <% unless post.locked? %>
-            <button class="vote-button button is-icon-only-button <%= (existing_vote&.vote_type == -1) ? 'is-active' : '' %>"
-                    data-vote-type="-1" data-vote-id="<%= existing_vote&.id %>" id="post-<%= post.id %>-up" aria-label="Downvote">
-                <svg width="2em" height="1.33em" viewbox="0 0 100 50">
-                  <path d="M0,0 L100,0 L50,50 Z" fill="currentColor" />
-                </svg>
-            </button>
-          <% end %>
-        </div>
-        <% if user_signed_in? && post.post_type.has_reactions && post.post_type.reactions.any? %>
-          <div class="post--react has-text-align-center">
+        <div class="vote-widget">
+          <div class="post--votes has-text-align-center" title="Score : <%= post.score %>">
+            <% existing_vote = my_vote(post) %>
             <% unless post.locked? %>
-              <button class="react-button button is-muted is-icon-only-button h-fw-bold"
-                      id="post-<%= post.id %>-react" aria-label="Add Reaction"
-                      data-drop="#post-<%= post.id %>-reactions-panel"
-                      data-drop-self-class-toggle="is-active"
-                      data-drop-force-dir="down">
-                  react
+              <button class="vote-button button is-icon-only-button <%= (existing_vote&.vote_type == 1) ? 'is-active' : '' %>"
+                      data-vote-type="1" data-vote-id="<%= existing_vote&.id %>" id="post-<%= post.id %>-up" aria-label="Upvote">
+                  <svg width="2em" height="1.33em" viewbox="0 0 100 50">
+                    <path d="M50,0 L100,50 L0,50 Z" fill="currentColor" />
+                  </svg>
+              </button>
+            <% end %>
+            <div class="score has-font-size-subheading js-upvote-count">
+              +<%= post.upvote_count %>
+            </div>
+            <div class="score has-font-size-subheading js-downvote-count">
+              &minus;<%= post.downvote_count %>
+            </div>
+            <% unless post.locked? %>
+              <button class="vote-button button is-icon-only-button <%= (existing_vote&.vote_type == -1) ? 'is-active' : '' %>"
+                      data-vote-type="-1" data-vote-id="<%= existing_vote&.id %>" id="post-<%= post.id %>-up" aria-label="Downvote">
+                  <svg width="2em" height="1.33em" viewbox="0 0 100 50">
+                    <path d="M0,0 L100,0 L50,50 Z" fill="currentColor" />
+                  </svg>
               </button>
             <% end %>
           </div>
-        <% end %>
+          <% if user_signed_in? && post.post_type.has_reactions && post.post_type.reactions.any? %>
+            <div class="post--react has-text-align-center">
+              <% unless post.locked? %>
+                <button class="react-button button is-muted is-icon-only-button h-fw-bold"
+                        id="post-<%= post.id %>-react" aria-label="Add Reaction"
+                        data-drop="#post-<%= post.id %>-reactions-panel"
+                        data-drop-self-class-toggle="is-active"
+                        data-drop-force-dir="down">
+                    react
+                </button>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
       </div>
     <% end %>
 

--- a/config/config/preferences.yml
+++ b/config/config/preferences.yml
@@ -73,3 +73,9 @@ sticky_header:
   description: >
     Make the top navigation bar sticky.
   default: false
+
+sticky_vote_tool:
+  type: boolean
+  description: >
+    Make the up and downvote buttons scroll along with the post
+  default: false


### PR DESCRIPTION
Somewhat old thing that I just came across: https://meta.codidact.com/posts/279092/279096#answer-279096

This makes the voting tools sticky, so it will remain visible even after scrolling.

![image](https://user-images.githubusercontent.com/54333972/210329465-533b36e2-150a-4ce4-bad8-e4e766ce259e.png)

A minor issue: Due to the way the page is laid out, it will in fact go past the article and into the comments section. (That being said, why is the comment section part of the post body?)

![image](https://user-images.githubusercontent.com/54333972/210329724-6f268046-fb5b-41a2-b474-cba5df79d400.png)
