### PR TITLE
Only check for user preferences if signed in

### DIFF
--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -171,6 +171,11 @@ window.QPixel = {
 
   _preferences: null,
 
+  preferencesLocalStorageKey: async () => {
+    const user = await QPixel.user();
+    return `qpixel.user_${user.id}_preferences`;
+  }
+
   /**
    * Get an object containing the current user's preferences. Loads, in order of precedence, from local variable,
    * localStorage, or Redis via AJAX.
@@ -187,8 +192,9 @@ window.QPixel = {
       return QPixel._preferences;
     }
     // Early return the preferences from localStorage unless null or undefined
-    const localStoragePreferences = ('qpixel.user_preferences' in localStorage)
-                                    ? JSON.parse(localStorage['qpixel.user_preferences'])
+    const key = await preferencesLocalStorageKey();
+    const localStoragePreferences = (key in localStorage)
+                                    ? JSON.parse(localStorage[key])
                                     : null;
     if (localStoragePreferences != null) {
       QPixel._preferences = localStoragePreferences;
@@ -268,7 +274,8 @@ window.QPixel = {
 
   updatePreferencesLocally: data => {
     QPixel._preferences = data;
-    localStorage['qpixel.user_preferences'] = JSON.stringify(QPixel._preferences);
+    const key = await preferencesLocalStorageKey();
+    localStorage[key] = JSON.stringify(QPixel._preferences);
   }
 
   /**

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -177,7 +177,7 @@ window.QPixel = {
    * @returns {Promise<Object>} a JSON object containing user preferences
    */
   preferences: async () => {
-    // Early return for the most frequent case
+    // Early return for the most frequent case (local variable already contains the preferences)
     if (this._preferences != null) {
       return this._preferences;
     }

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -176,7 +176,7 @@ window.QPixel = {
   preferencesLocalStorageKey: async () => {
     const user = await QPixel.user();
     return `qpixel.user_${user.id}_preferences`;
-  }
+  },
 
   /**
    * Get an object containing the current user's preferences. Loads, in order of precedence, from local variable,
@@ -278,7 +278,7 @@ window.QPixel = {
     QPixel._preferences = data;
     const key = await preferencesLocalStorageKey();
     localStorage[key] = JSON.stringify(QPixel._preferences);
-  }
+  },
 
   /**
    * Get the word in a string that the given position is in, and the position within that word.

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -225,25 +225,23 @@ window.QPixel = {
     let prefs = await QPixel.preferences();
     let value = community ? prefs.community[name] : prefs.global[name];
 
-    // Deliberate === here: null is a valid value for a preference, but undefined means we haven't fetched it.
+    // Note that null is a valid value for a preference, but undefined means we haven't fetched it.
+    if (typeof(value) !== 'undefined') {
+      return value;
+    }
     // If we haven't fetched a preference, that probably means it's new - run a full re-fetch.
-    if (value === undefined) {
-      const resp = await fetch('/users/me/preferences', {
-        credentials: 'include',
-        headers: {
-          'Accept': 'application/json'
-        }
-      });
-      const data = await resp.json();
-      updatePreferencesLocally(data);
+    const resp = await fetch('/users/me/preferences', {
+      credentials: 'include',
+      headers: {
+        'Accept': 'application/json'
+      }
+    });
+    const data = await resp.json();
+    updatePreferencesLocally(data);
 
-      prefs = await QPixel.preferences();
-      value = community ? prefs.community[name] : prefs.global[name];
-      return value;
-    }
-    else {
-      return value;
-    }
+    prefs = await QPixel.preferences();
+    value = community ? prefs.community[name] : prefs.global[name];
+    return value;
   },
 
   /**

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -177,6 +177,10 @@ window.QPixel = {
    * @returns {Promise<Object>} a JSON object containing user preferences
    */
   preferences: async () => {
+    // Early return for the most frequent case
+    if (this._preferences != null) {
+      return this._preferences;
+    }
     if (this._preferences == null && !!localStorage['qpixel.user_preferences']) {
       this._preferences = JSON.parse(localStorage['qpixel.user_preferences']);
     }

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -177,6 +177,11 @@ window.QPixel = {
    * @returns {Promise<Object>} a JSON object containing user preferences
    */
   preferences: async () => {
+    const user = await QPixel.user();
+    // Do not attempt to access preferences if user is not signed in
+    if ('error' in user) {
+      return null;
+    }
     // Early return for the most frequent case (local variable already contains the preferences)
     if (QPixel._preferences != null) {
       return QPixel._preferences;

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -181,7 +181,7 @@ window.QPixel = {
     if (this._preferences != null) {
       return this._preferences;
     }
-    if (this._preferences == null && !!localStorage['qpixel.user_preferences']) {
+    if (!!localStorage['qpixel.user_preferences']) {
       this._preferences = JSON.parse(localStorage['qpixel.user_preferences']);
     }
     if (this._preferences == null) {

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -189,19 +189,17 @@ window.QPixel = {
       this._preferences = localStoragePreferences;
       return this._preferences;
     }
-    if (this._preferences == null) {
-      // If they're still null (or undefined) after loading from localStorage, we're probably on a site we haven't
-      // loaded them for yet. Load from Redis via AJAX.
-      const resp = await fetch('/users/me/preferences', {
-        credentials: 'include',
-        headers: {
-          'Accept': 'application/json'
-        }
-      });
-      const data = await resp.json();
-      localStorage['qpixel.user_preferences'] = JSON.stringify(data);
-      this._preferences = data;
-    }
+    // Preferences are still null (or undefined) after loading from localStorage, so we're probably on a site we
+    // haven't loaded them for yet. Load from Redis via AJAX.
+    const resp = await fetch('/users/me/preferences', {
+      credentials: 'include',
+      headers: {
+        'Accept': 'application/json'
+      }
+    });
+    const data = await resp.json();
+    localStorage['qpixel.user_preferences'] = JSON.stringify(data);
+    this._preferences = data;
     return this._preferences;
   },
 

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -158,7 +158,9 @@ window.QPixel = {
    * @returns {Promise<Object>} a JSON object containing user details
    */
   user: async () => {
-    if (QPixel._user) return QPixel._user;
+    if (QPixel._user != null) {
+      return QPixel._user;
+    }
     const resp = await fetch('/users/me', {
       credentials: 'include',
       headers: {

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -253,11 +253,19 @@ window.QPixel = {
     }
   },
 
+  /**
+   * Get the key to use for storing user preferences in localStorage, to avoid conflating users
+   * @returns {Promise<string>} the localStorage key
+   */
   _preferencesLocalStorageKey: async () => {
     const user = await QPixel.user();
     return `qpixel.user_${user.id}_preferences`;
   },
 
+  /**
+   * Update local variable _preferences and localStorage with an AJAX call for the user preferences
+   * @returns {Promise<void>}
+   */
   _fetchPreferences: async () => {
     const resp = await fetch('/users/me/preferences', {
       credentials: 'include',
@@ -269,6 +277,11 @@ window.QPixel = {
     await QPixel._updatePreferencesLocally(data);
   },
 
+  /**
+   * Set local variable _preferences and localStorage to new preferences data
+   * @param data an object, containing the new preferences data
+   * @returns {Promise<void>}
+   */
   _updatePreferencesLocally: async data => {
     QPixel._preferences = data;
     const key = await QPixel._preferencesLocalStorageKey();

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -178,16 +178,16 @@ window.QPixel = {
    */
   preferences: async () => {
     // Early return for the most frequent case (local variable already contains the preferences)
-    if (this._preferences != null) {
-      return this._preferences;
+    if (QPixel._preferences != null) {
+      return QPixel._preferences;
     }
     // Early return the preferences from localStorage unless null or undefined
     const localStoragePreferences = ('qpixel.user_preferences' in localStorage)
                                     ? JSON.parse(localStorage['qpixel.user_preferences'])
                                     : null;
     if (localStoragePreferences != null) {
-      this._preferences = localStoragePreferences;
-      return this._preferences;
+      QPixel._preferences = localStoragePreferences;
+      return QPixel._preferences;
     }
     // Preferences are still null (or undefined) after loading from localStorage, so we're probably on a site we
     // haven't loaded them for yet. Load from Redis via AJAX.
@@ -199,8 +199,8 @@ window.QPixel = {
     });
     const data = await resp.json();
     localStorage['qpixel.user_preferences'] = JSON.stringify(data);
-    this._preferences = data;
-    return this._preferences;
+    QPixel._preferences = data;
+    return QPixel._preferences;
   },
 
   /**
@@ -224,7 +224,7 @@ window.QPixel = {
       });
       const data = await resp.json();
       localStorage['qpixel.user_preferences'] = JSON.stringify(data);
-      this._preferences = data;
+      QPixel._preferences = data;
 
       prefs = await QPixel.preferences();
       value = community ? prefs.community[name] : prefs.global[name];
@@ -259,8 +259,8 @@ window.QPixel = {
       console.error(resp);
     }
     else {
-      this._preferences = data.preferences;
-      localStorage['qpixel.user_preferences'] = JSON.stringify(this._preferences);
+      QPixel._preferences = data.preferences;
+      localStorage['qpixel.user_preferences'] = JSON.stringify(QPixel._preferences);
     }
   },
 

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -203,8 +203,7 @@ window.QPixel = {
       }
     });
     const data = await resp.json();
-    localStorage['qpixel.user_preferences'] = JSON.stringify(data);
-    QPixel._preferences = data;
+    updatePreferencesLocally(data);
     return QPixel._preferences;
   },
 
@@ -228,8 +227,7 @@ window.QPixel = {
         }
       });
       const data = await resp.json();
-      localStorage['qpixel.user_preferences'] = JSON.stringify(data);
-      QPixel._preferences = data;
+      updatePreferencesLocally(data);
 
       prefs = await QPixel.preferences();
       value = community ? prefs.community[name] : prefs.global[name];
@@ -264,10 +262,14 @@ window.QPixel = {
       console.error(resp);
     }
     else {
-      QPixel._preferences = data.preferences;
-      localStorage['qpixel.user_preferences'] = JSON.stringify(QPixel._preferences);
+      updatePreferencesLocally(data.preferences);
     }
   },
+
+  updatePreferencesLocally: data => {
+    QPixel._preferences = data;
+    localStorage['qpixel.user_preferences'] = JSON.stringify(QPixel._preferences);
+  }
 
   /**
    * Get the word in a string that the given position is in, and the position within that word.

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -181,8 +181,13 @@ window.QPixel = {
     if (this._preferences != null) {
       return this._preferences;
     }
-    if (!!localStorage['qpixel.user_preferences']) {
-      this._preferences = JSON.parse(localStorage['qpixel.user_preferences']);
+    // Early return the preferences from localStorage unless null or undefined
+    const localStoragePreferences = ('qpixel.user_preferences' in localStorage)
+                                    ? JSON.parse(localStorage['qpixel.user_preferences'])
+                                    : null;
+    if (localStoragePreferences != null) {
+      this._preferences = localStoragePreferences;
+      return this._preferences;
     }
     if (this._preferences == null) {
       // If they're still null (or undefined) after loading from localStorage, we're probably on a site we haven't

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -186,7 +186,7 @@ window.QPixel = {
         this._preferences = null;
       }
     }
-    else if (this._preferences == null) {
+    if (this._preferences == null) {
       // If they're still null (or undefined) after loading from localStorage, we're probably on a site we haven't
       // loaded them for yet. Load from Redis via AJAX.
       const resp = await fetch('/users/me/preferences', {

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -179,12 +179,6 @@ window.QPixel = {
   preferences: async () => {
     if (this._preferences == null && !!localStorage['qpixel.user_preferences']) {
       this._preferences = JSON.parse(localStorage['qpixel.user_preferences']);
-
-      // If we don't have the global key, we're probably using an old preferences schema.
-      if (!this._preferences.global) {
-        delete localStorage['qpixel.user_preferences'];
-        this._preferences = null;
-      }
     }
     if (this._preferences == null) {
       // If they're still null (or undefined) after loading from localStorage, we're probably on a site we haven't


### PR DESCRIPTION
Addresses #947 and #948 plus some other things I noticed in the surrounding code.

Please let me know if there are any changes needed.

## Testing
I'm using Firefox so I refer to "private browsing". In Chromium based browsers this may instead be referred to as "incognito".

I have tested with a local installation of QPixel as follows, on both this branch and the `develop` branch. Behaviour differs in the final bullet point, as intended:

- Create a post in Q&A (preferences are only required if there are posts)
- Sign in from a private browsing window
- Click on "Posts"
- The network tab of the developer window shows 2 or 3 requests when filtered by "pref" as the preferences are not yet stored in localStorage
- Click on "Posts" again
- The network tab of the developer window shows no requests when filtered by "pref" as the preferences are now stored in localStorage
- Sign out
- Click on "Posts"
- The network tab of the developer window shows no requests when filtered by "pref" (on the `develop` branch this is because the preferences are still stored in localStorage and the `develop` branch looks in localStorage regardless of whether a user is signed in; on this branch this is because we no longer make the AJAX request for preferences when a user is not signed in)
- Close the private browsing window to forget the localStorage
- Open in a new private browsing window without signing in
- Click on "Posts"
    - On the `develop` branch the network tab of the developer window shows 2 or 3 requests when filtered by "pref", even though there is no user signed in
    - On this branch the network tab of the developer window shows no requests when filtered by "pref", because there is no user signed in

## JavaScript documentation comments
I've endeavoured to keep to the same style used for the comments on existing functions. Please let me know if anything should be different.

## Double exclamation marks
I've removed the use of double exclamation mark from the `preferences` function and instead explicitly checked for `null` and key presence (to avoid `undefined`). This is my personal preference for two reasons:

1. This explicit form makes the intention clear to future readers.
2. Double exclamation mark rejects any arbitrary falsy values, not just null and undefined, giving the possibility of subtle bugs.

I prefer to avoid double exclamation mark outside of code golf, but I understand that it is a widely used idiom, so let me know if it is to be preferred for QPixel code. Either way, would it be worth mentioning in the code standards whether double exclamation mark is encouraged, discouraged, or optional?

## Early returns
I've switched to using early returns in the `preferences` function to avoid some of the duplication in the `if` expressions. The previous function, `user`, already uses an early return, so I'm guessing this is acceptable, but I know that early returns can divide opinions. Would it be worth mentioning in the code standards whether early returns are encouraged, discouraged, or optional? I personally find early returns easier to reason about as they keep the reasoning more local, and I expect them to be slightly less bug prone.

## No longer use `this.`
I have changed all uses of `this.` in the `preferences` function to use `QPixel.` instead. This now matches the other functions in this file. The fact that `this.` does not refer to the same place as `QPixel.` could otherwise be confusing for future readers (as it was for me...). It meant that the `_preferences` property defined just before the `preferences` function was never accessed or overwritten, and was entirely redundant. `_preferences` was instead being created on the global `Window` object. I've also changed the references to `this._preferences` in the functions `preference` and `setPreference` so that they don't stop working now that `_preferences` is being read from `QPixel` rather than `Window`.

## Check if user is signed in
I've added in a check for whether the user is signed in so that we no longer make dozens of AJAX requests when loading a page. I've put the check at the beginning of the `preferences` function instead of only before the AJAX request, because currently the preferences are being fetched from localStorage even after the user signs out. I'm assuming that we do not want a user's preferences to continue to apply after they sign out.

Are there other places that should also check whether there is a logged in user before making a request? What about the request for `QPixel._user`? This only makes a single redundant AJAX request rather than dozens, but we could still avoid it. Would it be worth adding a `signed_in` data attribute somewhere in the HTML (maybe on `body`) so that the user data AJAX request is only made when signed in? Would any such changes be best raised as separate issues?

## Remove old schema check
Two years ago a check was added in case the localStorage preferences were using an old preferences schema. I've removed this as it seems redundant now. Let me know if you would prefer to keep it around just in case there is a user who hasn't visited the site in the last two years but still has a browser containing the old preferences schema in its localStorage. There will be no need to keep it around if the following change to the localStorage key is accepted.

## Unique localStorage key per user
I suspect the current code will still load the previous user's preferences from localStorage even if they sign out and a different user signs in, giving them the wrong preferences. To prevent this I have included the user id in the localStorage key name so multiple users don't clash and they always get their own preferences. Should we also check for an old style localStorage preferences key (without the user id) and delete it if found, to tidy up the user's machine? Possibly as temporary code that can be removed after enough time to have deleted all the old keys?

I have assumed here that the user id will be unique and consistent across all places the preferences apply to. I've checked that Collab on `codidact.org` uses the same id per user as the other communities on `codidact.com`. Is there anything else to consider that may make user id unsuitable for this purpose?