### PR TITLE
Decouple codidact from code

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -369,4 +369,9 @@ class ApplicationController < ActionController::Base
       end
     end
   end
+
+  # Whether this host is on the codidact network
+  def codidact?
+    helpers.codidact?
+  end
 end

--- a/app/helpers/codidact_helper.rb
+++ b/app/helpers/codidact_helper.rb
@@ -1,0 +1,11 @@
+# Provides helper methods to determine whether this site is part of the codidact network
+module CodidactHelper
+  # Whether this server is part of the codidact network.
+  def codidact?
+    Rails.cache.fetch 'is_codidact' do
+      Rails.env.development? ||
+        RequestContext.community.host.include?('.codidact.com') ||
+        RequestContext.community.host.include?('.codidact.org')
+    end
+  end
+end

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,4 +1,8 @@
-<p>Welcome to Codidact, <%= @resource.username %>! We're glad you're here.</p>
+<% if codidact? %>
+  <p>Welcome to Codidact, <%= @resource.username %>! We're glad you're here.</p>
+<% else %>
+  <p>Welcome, <%= @resource.username %>! We're glad you're here.</p>
+<% end %>
 
 <p>Please confirm your registration by clicking below (or copy and paste the URL into your browser).</p>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -7,10 +7,12 @@
   </div>
 <% end %>
 
-<div class="notice is-info">
-  <i class="fas fa-info-circle"></i> If you have an account on another <a href="https://codidact.com/">Codidact site</a>,
-  don't create a new account here - <%= link_to 'sign in', new_user_session_path %> with your existing details instead.
-</div>
+<% if codidact? %>
+  <div class="notice is-info">
+    <i class="fas fa-info-circle"></i> If you have an account on another <a href="https://codidact.com/">Codidact site</a>,
+    don't create a new account here - <%= link_to 'sign in', new_user_session_path %> with your existing details instead.
+  </div>
+<% end %>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -12,11 +12,13 @@
 </p>
 
 <p>This error has been logged. We even look at them sometimes.</p>
-<p>
-  You can also report this
-  <a href="https://meta.codidact.com/" target="_blank" rel="noopener noreferrer">on Meta</a>
-  to help us keep track of what's going wrong &mdash; quote error ID <code><%= @log.uuid %></code>.
-</p>
+<% if codidact? %>
+  <p>
+    You can also report this
+    <a href="https://meta.codidact.com/" target="_blank" rel="noopener noreferrer">on Meta</a>
+    to help us keep track of what's going wrong &mdash; quote error ID <code><%= @log.uuid %></code>.
+  </p>
+<% end %>
 
 <p>
   <%= link_to 'Go back', :back, class: 'button is-outlined' %>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -5,11 +5,16 @@
 
 <p class="is-lead">Your request couldn't be processed.</p>
 
-<p>
-  Our server's sulking today. Log out and back in, and if this keeps happening, let us know
-  <a href="https://meta.codidact.com/" target="_blank" rel="noopener noreferrer">on Meta</a>.
-</p>
-
+<% if codidact? %>
+  <p>
+    Our server's sulking today. Log out and back in, and if this keeps happening, let us know
+    <a href="https://meta.codidact.com/" target="_blank" rel="noopener noreferrer">on Meta</a>.
+  </p>
+<% else %>
+  <p>
+    Our server's sulking today. Log out and back in, and if this keeps happening, let us know.
+  </p>
+<% end %>
 
 <p>
   <%= link_to 'Go back', :back, class: 'button is-outlined' %>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -7,19 +7,23 @@
           <li><%= link_to 'Terms of Service', '/policy/tos' %></li>
           <li><%= link_to 'Privacy Policy', '/policy/privacy-policy' %></li>
           <li><%= link_to 'Code of Conduct', '/policy/code-of-conduct' %></li>
-          <li><%= link_to 'About us', 'https://codidact.org/' %></li>
-          <li><%= link_to 'Contact us', 'https://codidact.com/contact' %></li>
-          <li><%= link_to 'Other communities', 'https://codidact.com/' %></li>
-        </ul>
-      </div>
-      <div class="grid--cell is-6 is-12-md is-12-sm">
-        <h3>Other Codidact Communities</h3>
-        <ul>
-          <% Rails.cache.persistent('codidact_sites').each do |site| %>
-            <li><%= link_to site['name'], site['canonical_url'] %></li>
+          <% if codidact? %>
+            <li><%= link_to 'About us', 'https://codidact.org/' %></li>
+            <li><%= link_to 'Contact us', 'https://codidact.com/contact' %></li>
+            <li><%= link_to 'Other communities', 'https://codidact.com/' %></li>
           <% end %>
         </ul>
       </div>
+      <% if codidact? %>
+        <div class="grid--cell is-6 is-12-md is-12-sm">
+          <h3>Other Codidact Communities</h3>
+          <ul>
+            <% Rails.cache.persistent('codidact_sites').each do |site| %>
+              <li><%= link_to site['name'], site['canonical_url'] %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
     </div>
     <% commit = Rails.cache.persistent('current_commit') %>
     <p>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,7 +1,10 @@
 <meta charset="utf-8" />
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<% desc = "#{SiteSetting['SiteName']} on Codidact - open, community-run Q&A knowledge sharing" %>
+<% desc = codidact? ?
+            "#{SiteSetting['SiteName']} on Codidact - open, community-run Q&A knowledge sharing" :
+            "#{SiteSetting['SiteName']} - Q&A knowledge sharing"
+%>
 <meta name="description" content="<%= content_for?(:description) ? content_for(:description) : desc %>" />
 
 <% page_title = (Rails.env.development? ? '[DEV] ' : '') +
@@ -14,7 +17,7 @@
 <% icon_path = SiteSetting['IconPath'] %>
 <link rel="icon" href="<%= icon_path.present? ? icon_path : '/assets/favicon.ico' %>" />
 <link rel="search" type="application/opensearchdescription+xml"
-      title="Codidact <%= RequestContext.community.name %> search" href="<%= osd_url(format: :xml) %>" />
+      title="<%= "#{codidact? ? 'Codidact ' : ''}#{RequestContext.community.name}" %> search" href="<%= osd_url(format: :xml) %>" />
 <link rel="preconnect" href="https://cdn.jsdelivr.net" />
 <link rel="preconnect" href="https://cdnjs.cloudflare.com" />
 

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -106,14 +106,20 @@
 
   <div class="widget has-margin-4">
     <div class="widget--header">
-      <img src="/assets/codidact.png" alt="Codidact logo" class="codidact-logo" />
+      <% if codidact? %>
+        <img src="/assets/codidact.png" alt="Codidact logo" class="codidact-logo" />
+      <% else %>
+        <img src="<%= SiteSetting['SiteLogoPath'] %>" alt="Logo" class="codidact-logo" />
+      <% end %>
     </div>
     <div class="widget--body">
       <% chat = SiteSetting['ChatLink'] %>
-      <p>
-        This community is part of the <a href="https://codidact.com">Codidact network</a>.
-        We have other communities too &mdash; take a look!
-      </p>
+      <% if codidact? %>
+        <p>
+          This community is part of the <a href="https://codidact.com">Codidact network</a>.
+          We have other communities too &mdash; take a look!
+        </p>
+      <% end %>
       <% if chat.present? %>
         <p>
           You can also <%= link_to 'join us in chat', chat %>!

--- a/app/views/layouts/devise_mailer.html.erb
+++ b/app/views/layouts/devise_mailer.html.erb
@@ -10,8 +10,8 @@
   <div class="header">
     <div class="container header--container">
       <%= link_to root_url, class: 'header--site-name' do %>
-        <%= image_tag asset_path('codidact.png', host: 'meta.codidact.com', protocol: 'https'), height: 40, width: 167,
-                      alt: 'Codidact logo' %>
+        <%= image_tag "https://#{RequestContext.community.host}#{SiteSetting['SiteLogoPath']}", height: 40, width: 167,
+                      alt: "#{SiteSetting['SiteName']} logo" %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
This pull request decouples codidact from the codebase in various places. It does so by defining a helper function which checks the domain of the community for `.codidact.[com|org]`. It then disables or changes components on pages based on this setting.

#### TODO
* [ ] Email addresses as settings