### PR TITLE
Access user id and signed in status from HTML to avoid requests

### DIFF
--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -260,7 +260,7 @@ window.QPixel = {
     const id = document.body.dataset.userId;
     const key = `qpixel.user_${id}_preferences`;
     QPixel._preferencesLocalStorageKey = () => key;
-    return QPixel._preferencesLocalStorageKey();
+    return key;
   },
 
   /**

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -281,7 +281,6 @@ window.QPixel = {
   /**
    * Set local variable _preferences and localStorage to new preferences data
    * @param data an object, containing the new preferences data
-   * @returns {Promise<void>}
    */
   _updatePreferencesLocally: data => {
     QPixel._preferences = data;

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -180,8 +180,7 @@ window.QPixel = {
    */
   preferences: async () => {
     // Do not attempt to access preferences if user is not signed in
-    const user = await QPixel.user();
-    if ('error' in user) {
+    if (document.body.dataset.signedIn === 'false') {
       return null;
     }
     // Early return for the most frequent case (local variable already contains the preferences)

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -158,7 +158,7 @@ window.QPixel = {
    * @returns {Promise<Object>} a JSON object containing user details
    */
   user: async () => {
-    if (QPixel._user != null) {
+    if (QPixel._user != null || document.body.dataset.signedIn === 'false') {
       return QPixel._user;
     }
     const resp = await fetch('/users/me', {

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -188,7 +188,7 @@ window.QPixel = {
       return QPixel._preferences;
     }
     // Early return the preferences from localStorage unless null or undefined
-    const key = await QPixel._preferencesLocalStorageKey();
+    const key = QPixel._preferencesLocalStorageKey();
     const localStoragePreferences = (key in localStorage)
                                     ? JSON.parse(localStorage[key])
                                     : null;
@@ -248,17 +248,19 @@ window.QPixel = {
       console.error(resp);
     }
     else {
-      await QPixel._updatePreferencesLocally(data.preferences);
+      QPixel._updatePreferencesLocally(data.preferences);
     }
   },
 
   /**
    * Get the key to use for storing user preferences in localStorage, to avoid conflating users
-   * @returns {Promise<string>} the localStorage key
+   * @returns string the localStorage key
    */
-  _preferencesLocalStorageKey: async () => {
-    const user = await QPixel.user();
-    return `qpixel.user_${user.id}_preferences`;
+  _preferencesLocalStorageKey: () => {
+    const id = document.body.dataset.userId;
+    const key = `qpixel.user_${id}_preferences`;
+    QPixel._preferencesLocalStorageKey = () => key;
+    return QPixel._preferencesLocalStorageKey();
   },
 
   /**
@@ -273,7 +275,7 @@ window.QPixel = {
       }
     });
     const data = await resp.json();
-    await QPixel._updatePreferencesLocally(data);
+    QPixel._updatePreferencesLocally(data);
   },
 
   /**
@@ -281,9 +283,9 @@ window.QPixel = {
    * @param data an object, containing the new preferences data
    * @returns {Promise<void>}
    */
-  _updatePreferencesLocally: async data => {
+  _updatePreferencesLocally: data => {
     QPixel._preferences = data;
-    const key = await QPixel._preferencesLocalStorageKey();
+    const key = QPixel._preferencesLocalStorageKey();
     localStorage[key] = JSON.stringify(QPixel._preferences);
   },
 

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -158,7 +158,7 @@ window.QPixel = {
    * @returns {Promise<Object>} a JSON object containing user details
    */
   user: async () => {
-    if (QPixel._user != null || document.body.dataset.signedIn === 'false') {
+    if (QPixel._user != null || document.body.dataset.userId === 'none') {
       return QPixel._user;
     }
     const resp = await fetch('/users/me', {
@@ -180,7 +180,7 @@ window.QPixel = {
    */
   preferences: async () => {
     // Do not attempt to access preferences if user is not signed in
-    if (document.body.dataset.signedIn === 'false') {
+    if (document.body.dataset.userId === 'none') {
       return null;
     }
     // Early return for the most frequent case (local variable already contains the preferences)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,6 @@
   <%= render 'layouts/head' %>
 </head>
 <body class="<%= Rails.env.development? ? 'development' : '' %>"
-      data-signed-in="<%= user_signed_in? ? 'true' : 'false' %>"
       data-user-id="<%= user_signed_in? ? current_user.id : 'none' %>" >
   <%= render 'layouts/header' %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,9 @@
 <head>
   <%= render 'layouts/head' %>
 </head>
-<body class="<%= Rails.env.development? ? 'development' : '' %>">
+<body class="<%= Rails.env.development? ? 'development' : '' %>"
+      data-signed-in="<%= user_signed_in? ? 'true' : 'false' %>"
+      data-user-id="<%= user_signed_in? ? current_user.id : 'none' %>" >
   <%= render 'layouts/header' %>
 
   <main class="container">


### PR DESCRIPTION
My previous attempt at avoiding redundant requests when a user is not signed in was #951. This stopped the requests to `users/me/preferences`, but I overlooked the fact that it instead resulted in the same number of requests to `users/me`, as [pointed out on Discord](https://discord.com/channels/634104110131445811/634104110131445815/1065679094924189707). Lesson I learned: don't forget to take the 'preferences' filter off the network tab before concluding there are no requests being made.

The reason is that avoiding making a request to `users/me/preferences` required knowing that the user is not signed in. This check used a request to `users/me`, but instead of just making the request once and then remembering the result, as expected, a large number of checks were made before the request had time to return, resulting in a new request for each check.

## Solution using an HTML data attribute
I have added a data attribute called `data-user-id` to the `<body>` tag of the HTML. This is the user id if there is a user signed in, or otherwise the string 'none'.

The requests to `users/me` for the user data and to `users/me/preferences` for the user preferences now only happen if the `data-user-id` attribute is not set to 'none'.

The unique localStorage key per user is now also constructed using the `data-user-id` attribute, so this also no longer needs to request the user id from the server.

## Replacing a function after its first call
The function `QPixel._preferencesLocalStorageKey` is no longer `async` because it no longer needs to request the user id. I have made it replace itself so that after the first call it will return the previously calculated key, rather than constructing the key each time. This pattern is already in use in `QPixel.csrfToken` so I have assumed this is acceptable. Please let me know if it presents any problem.

## Testing
I have tested with a local installation of QPixel as follows, on both this branch and the `develop` branch:

- Create 1 post in Q&A (preferences are only required if there are posts)
- Sign in from a private browsing / incognito window
- The network tab of the developer window shows 3 requests when filtered by "pref" as the preferences are not yet stored in localStorage
- The network tab filtered by "/me" shows differently for this branch and the `develop` branch:
  - On the `develop` branch there are 3 requests to `users/me` because checking that the user is signed in before requesting preferences requires first requesting the user data to get the user id
  - On this branch there are none as the requests for preferences data do not depend on fetching user data as the user id is in the HTML
- Click on "Posts"
- The network tab of the developer window shows no requests when filtered by "pref" as the preferences are now stored in localStorage
- The network tab filtered by "/me" shows differently for this branch and the `develop` branch:
  - On the `develop` branch there are 3 requests to `users/me` because accessing localStorage requires fetching the user data to get the user id for the unique localStorage key
  - On this branch there are none as the user id is now available from the HTML
- Sign out
- Click on "Posts"
- The network tab of the developer window shows no requests when filtered by "pref"
- The network tab filtered by "/me" shows differently for this branch and the `develop` branch:
  - On the `develop` branch there are 3 requests because checking that the user is not signed in requires fetching the user data
  - On this branch there are none because checking that the user is not signed in only requires looking at the HTML
- Close the private browsing window to forget the localStorage
- Open in a new private browsing window without signing in
- Click on "Posts"
- On each branch, the results are the same as they were immediately after signing out, as the localStorage preferences are not used by either branch when signed out:
  - On the `develop` branch there are 3 requests because checking that the user is not signed in requires fetching the user data
  - On this branch there are no requests because checking that the user is not signed in only requires looking at the HTML
