### PR TITLE
Prevent duplicate preferences requests when signed in without localStorage

### DIFF
--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -178,7 +178,7 @@ window.QPixel = {
    * localStorage, or Redis via AJAX.
    * @returns {Promise<Object>} a JSON object containing user preferences
    */
-  preferences: async () => {
+  _getPreferences: async () => {
     // Early return for the most frequent case (local variable already contains the preferences)
     if (QPixel._preferences != null) {
       return QPixel._preferences;
@@ -209,7 +209,7 @@ window.QPixel = {
     if (document.body.dataset.userId === 'none') {
       return null;
     }
-    let prefs = await QPixel.preferences();
+    let prefs = await QPixel._getPreferences();
     let value = community ? prefs.community[name] : prefs.global[name];
 
     // Note that null is a valid value for a preference, but undefined means we haven't fetched it.
@@ -219,7 +219,7 @@ window.QPixel = {
     // If we haven't fetched a preference, that probably means it's new - run a full re-fetch.
     await QPixel._fetchPreferences();
 
-    prefs = await QPixel.preferences();
+    prefs = await QPixel._getPreferences();
     value = community ? prefs.community[name] : prefs.global[name];
     return value;
   },

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -179,10 +179,6 @@ window.QPixel = {
    * @returns {Promise<Object>} a JSON object containing user preferences
    */
   preferences: async () => {
-    // Do not attempt to access preferences if user is not signed in
-    if (document.body.dataset.userId === 'none') {
-      return null;
-    }
     // Early return for the most frequent case (local variable already contains the preferences)
     if (QPixel._preferences != null) {
       return QPixel._preferences;
@@ -209,6 +205,10 @@ window.QPixel = {
    * @returns {Promise<*>} the value of the requested preference
    */
   preference: async (name, community = false) => {
+    // Do not attempt to access preference if user is not signed in
+    if (document.body.dataset.userId === 'none') {
+      return null;
+    }
     let prefs = await QPixel.preferences();
     let value = community ? prefs.community[name] : prefs.global[name];
 


### PR DESCRIPTION
Fixes #974.

Promises, async, and await are new to me. Please let me know if there is a clearer or more effective way to do this.

## Problem
When the user is signed in the preferences are taken from localStorage. When there is no localStorage (first load in a new browser, private browsing / incognito mode, or after some browsers periodically drop localStorage) the preferences are fetched from the server. Although the *response* from this request is cached, that can't happen until the response arrives. Hundreds of requests can be sent before the first response comes back, defeating the benefit of caching.

## Fix
Instead of requesting preferences and then waiting for the response before caching, cache the promise that the first request makes. This way all subsequent calls await the response to the same initial request rather than sending new requests.