### PR TITLE
Let only moderators (implicitly including admins) see who handled a flag

### DIFF
--- a/app/views/flags/_handled.html.erb
+++ b/app/views/flags/_handled.html.erb
@@ -20,7 +20,7 @@
       <% if flag.message.present? %>
         <strong>response:</strong> <%= flag.message %>
       <% end %>
-      <% if flag.handled_by_id.present? %>
+      <% if flag.handled_by_id.present? && current_user.is_moderator %>
         &mdash;
         <%= link_to user_path(flag.handled_by) do %>
           <span dir="ltr"><%= rtl_safe_username(flag.handled_by) %></span>


### PR DESCRIPTION
Fixes #913.

Checks if the current user is a moderator before allowing them to see who handled a flag. The method `is_moderator` implicitly includes `is_admin` so admins will also be able to see who handled a flag.