### PR TITLE
Add ability check on edit indicator

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -248,7 +248,7 @@
           <%= link_to suggested_edits_queue_path(current_cat),
                       class: "category-header--nav-item #{active?(current_cat) && controller_name == 'suggested_edit' ? 'is-active' : ''}" do %>
             Edits
-            <% if pending_suggestions? %>
+            <% if pending_suggestions?  && check_your_privilege('edit_posts') %>
               <span class="badge is-status" title="Suggested edits pending"></span>
             <% end %>
           <% end %>


### PR DESCRIPTION
This PR adds an ability check on the edits indicator shown in the site header.

Previously, an indicator appeared for all users (anonymous and logged in) if there was an unapproved suggested edit.

With this PR, the indicator is hidden from all users except those with the ability to approve the edit.

GitHub issue linking tag: resolves #995