### PR TITLE
Increase Co-Design version number to match upcoming release of 0.12.6

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -19,7 +19,7 @@
 <link rel="preconnect" href="https://cdnjs.cloudflare.com" />
 
 <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.11.2/css/all.min.css" %>
-<%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/@codidact/co-design@0.12.5/dist/codidact.css" %>
+<%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/@codidact/co-design@0.12.6/dist/codidact.css" %>
 <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/select2@4.0.12/dist/css/select2.min.css" %>
 <%= stylesheet_link_tag "/assets/community/#{@community.host.split('.')[0]}.css" %>
 <%= stylesheet_link_tag 'application', media: 'all' %>
@@ -33,7 +33,7 @@
 <%= javascript_include_tag "https://cdn.jsdelivr.net/npm/dompurify@2.2.9/dist/purify.min.js" %>
 <%= javascript_include_tag "/assets/community/#{@community.host.split('.')[0]}.js" %>
 <%= javascript_include_tag 'application' %>
-<script src="https://cdn.jsdelivr.net/npm/@codidact/co-design@0.12.5/js/co-design.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/@codidact/co-design@0.12.6/js/co-design.js" defer></script>
 
 <% if SiteSetting['SyntaxHighlightingEnabled'] %>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/default.min.css">

--- a/app/views/layouts/devise_mailer.html.erb
+++ b/app/views/layouts/devise_mailer.html.erb
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title><%= message.subject %></title>
-  <%= stylesheet_link_tag 'https://cdn.jsdelivr.net/npm/@codidact/co-design@0.12.5/dist/codidact.css' %>
+  <%= stylesheet_link_tag 'https://cdn.jsdelivr.net/npm/@codidact/co-design@0.12.6/dist/codidact.css' %>
   <%= stylesheet_link_tag 'application', media: 'all' %>
 </head>
 <body>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title><%= message.subject %></title>
-  <%= stylesheet_link_tag 'https://cdn.jsdelivr.net/npm/@codidact/co-design@0.12.5/dist/codidact.css' %>
+  <%= stylesheet_link_tag 'https://cdn.jsdelivr.net/npm/@codidact/co-design@0.12.6/dist/codidact.css' %>
   <%= stylesheet_link_tag 'application', media: 'all' %>
 </head>
 <body>


### PR DESCRIPTION
Once [Co-Design issue 80](https://github.com/codidact/co-design/issues/80) is completed, by releasing version 0.12.6 of Co-Design, this pull request can be merged to update those places in the QPixel codebase that refer to the version number of Co-Design.

This will then fix #923.