### PR TITLE
Update rmagick to version 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem 'net-smtp', '~> 0.3'
 gem 'ruby-progressbar', '~> 1.11'
 
 # Image generation
-gem 'rmagick'
+gem 'rmagick', '~> 5.0'
 
 # Payments. Kinda important, y'know.
 gem 'stripe', '~> 5.55'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,6 +201,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.10-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
     omniauth (2.1.0)
@@ -211,6 +213,7 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
+    pkg-config (1.5.1)
     premailer (1.16.0)
       addressable
       css_parser (>= 1.6.0)
@@ -272,7 +275,8 @@ GEM
     reverse_markdown (2.1.1)
       nokogiri
     rexml (3.2.5)
-    rmagick (4.2.6)
+    rmagick (5.2.0)
+      pkg-config (~> 1.4)
     rotp (6.2.0)
     rqrcode (2.1.2)
       chunky_png (~> 1.0)
@@ -363,6 +367,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -401,7 +406,7 @@ DEPENDENCIES
   rails-html-sanitizer (~> 1.4)
   redis (~> 4.8)
   reverse_markdown (~> 2.1)
-  rmagick
+  rmagick (~> 5.0)
   rotp (~> 6.2)
   rqrcode (~> 2.1)
   rubocop (~> 1)
@@ -426,4 +431,4 @@ RUBY VERSION
    ruby 2.7.6p219
 
 BUNDLED WITH
-   2.3.21
+   2.3.24

--- a/app/helpers/advertisements/article_helper.rb
+++ b/app/helpers/advertisements/article_helper.rb
@@ -21,8 +21,8 @@ module Advertisements::ArticleHelper
       answer.font = './app/assets/imgfonts/Roboto-Bold.ttf'
       answer.pointsize = 40
       answer.gravity = CenterGravity
-      answer.annotate ad, 600, 120, 0, 10, 'Check out this article' do
-        self.fill = 'white'
+      answer.annotate ad, 600, 120, 0, 10, 'Check out this article' do |s|
+        s.fill = 'white'
       end
 
       icon_path = SiteSetting.find_by(name: 'SiteLogoPath', community: article.community).typed
@@ -37,8 +37,8 @@ module Advertisements::ArticleHelper
         community_name.font = './app/assets/imgfonts/Roboto-Bold.ttf'
         community_name.pointsize = 25
         community_name.gravity = SouthWestGravity
-        community_name.annotate ad, 0, 0, 20, 20, article.community.name do
-          self.fill = '#4B68FF'
+        community_name.annotate ad, 0, 0, 20, 20, article.community.name do |s|
+          s.fill = '#4B68FF'
         end
       end
 
@@ -48,8 +48,8 @@ module Advertisements::ArticleHelper
       community_url.font = './app/assets/imgfonts/Roboto-Bold.ttf'
       community_url.pointsize = 20
       community_url.gravity = SouthEastGravity
-      community_url.annotate ad, 0, 0, 20, 20, article.community.host do
-        self.fill = '#666666'
+      community_url.annotate ad, 0, 0, 20, 20, article.community.host do |s|
+        s.fill = '#666666'
       end
 
       title = Draw.new
@@ -62,15 +62,15 @@ module Advertisements::ArticleHelper
       if article.title.length > 60
         title.pointsize = 35
         wrap_text(do_rtl_witchcraft(article.title), 500, 35).split("\n").each do |line|
-          title.annotate ad, 500, 100, 50, 135 + (position * 55), line do
-            self.fill = '#333333'
+          title.annotate ad, 500, 100, 50, 135 + (position * 55), line do |s|
+            s.fill = '#333333'
           end
           position += 1
         end
       else
         wrap_text(do_rtl_witchcraft(article.title), 500, 55).split("\n").each do |line|
-          title.annotate ad, 500, 100, 50, 160 + (position * 70), line do
-            self.fill = '#333333'
+          title.annotate ad, 500, 100, 50, 160 + (position * 70), line do |s|
+            s.fill = '#333333'
           end
           position += 1
         end

--- a/app/helpers/users/avatar_helper.rb
+++ b/app/helpers/users/avatar_helper.rb
@@ -35,8 +35,8 @@ module Users::AvatarHelper
       let.font = './app/assets/imgfonts/Roboto.ttf'
       let.pointsize = size * 0.75
       let.gravity = CenterGravity
-      let.annotate ava, size, size * 1.16, 0, 0, letter.upcase do
-        self.fill = text_color
+      let.annotate ava, size, size * 1.16, 0, 0, letter.upcase do |s|
+        s.fill = text_color
       end
 
       ava.format = 'PNG'


### PR DESCRIPTION
Rmagick was not locked to version 4 in the Gemfile, and it broke when version 5 was released. This explicitly locks the version to version 5 and updates the code to support a minor syntax change.