### PR TITLE
Post history links

### DIFF
--- a/app/assets/javascripts/post_histories.js
+++ b/app/assets/javascripts/post_histories.js
@@ -1,0 +1,3 @@
+$(() => {
+  $(location.hash).parent('details').prop('open', true);
+});

--- a/app/views/post_history/_diff.html.erb
+++ b/app/views/post_history/_diff.html.erb
@@ -1,4 +1,4 @@
-<div class="diff">
+<div class="diff" id="<%= @history.size - index %>">
   <% if before.present? && after.present? %>
     <% if before.is_a?(String) && after.is_a?(String) %>
       <% diff = Diffy::SplitDiff.new(before, after, format: :html) %>

--- a/app/views/post_history/post.html.erb
+++ b/app/views/post_history/post.html.erb
@@ -24,15 +24,18 @@
           <br/><em><%= event.comment %></em>
         <% end %>
       </span>
+      <%= link_to post_history_url(@post, anchor: @history.size - index), class: 'js-permalink' do %>
+        <span class="js-text">copy link</span>
+      <% end %>
     </summary>
     <% if (event.before_title.present? || event.after_title.present?) && event.before_title != event.after_title %>
-      <%= render 'diff', before: event.before_title, after: event.after_title, post: @post %>
+      <%= render 'diff', index: index, before: event.before_title, after: event.after_title, post: @post %>
     <% end %>
     <% if (event.before_state.present? || event.after_state.present?) && event.before_state != event.after_state %>
-      <%= render 'diff', before: event.before_state, after: event.after_state, post: @post %>
+      <%= render 'diff', index: index, before: event.before_state, after: event.after_state, post: @post %>
     <% end %>
     <% if (event.before_tags.present? || event.after_tags.present?) && event.before_tags != event.after_tags %>
-      <%= render 'diff', before: event.before_tags, after: event.after_tags, post: @post %>
+      <%= render 'diff', index: index, before: event.before_tags, after: event.after_tags, post: @post %>
     <% end %>
   </details>
 <% end %>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/54333972/230822000-a4e4e43a-d472-45e6-aa60-102f4b0404fc.png)

Resolves #1024

Adds a button that copies a link to the post history with an anchor to the specific entry. Since I didn't really know what to use for it, it's just `#1`, `#2`, etc. if there are any specific ideas for it, let me know and I'll change it.