### PR TITLE
change alt-text placeholder to single token

### DIFF
--- a/app/assets/javascripts/markdown.js
+++ b/app/assets/javascripts/markdown.js
@@ -117,7 +117,7 @@ $(() => {
 
   QPixel.addPrePostValidation(text => {
     // This regex catches Markdown images with no or default alt text.
-    const altRegex = /!\[(?:Image alt text)?\](?:\(.+(?!\\\))\)|\[.+(?!\\\])\])/gi;
+    const altRegex = /!\[(?:Image_alt_text)?\](?:\(.+(?!\\\))\)|\[.+(?!\\\])\])/gi;
     if (text.match(altRegex)) {
       const message = `It looks like you're posting an image with no alt text. Alt text is important for ` +
                       `accessibility. Consider adding alt text to the images in your post - ` +

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -63,7 +63,7 @@ $(() => {
 
     const $postField = $('.js-post-field');
     const postText = $postField.val();
-    $postField.val(postText.replace(placeholder, `![Image alt text](${data.link})`));
+    $postField.val(postText.replace(placeholder, `![Image_alt_text](${data.link})`));
     $tgt.parents('.modal').removeClass('is-active');
   });
 


### PR DESCRIPTION
I'm attempting to make the small change requested in https://meta.codidact.com/posts/287653, to make the placeholder for image alt text after upload a single token so you can double-click to select it.  (We want people to replace that string; let's make it a little easier.  As someone who's sometimes picked up a bracket while selecting by click and drag, I sympathize.)

I tried to test this change locally but the upload fails so I don't get as far as generating this text.  I think the upload fails because it assumes S3.  I remember that someone else ran into this problem and added `storage.sample.yml`, which implies I need a `storage.yml`, but I wasn't clear on what to put in it for "test this on my local machine".  (Should we add comments to that file?  Does YAML support comments?)
