### PR TITLE
Add doc to storage.sample.yml

### DIFF
--- a/app/assets/javascripts/markdown.js
+++ b/app/assets/javascripts/markdown.js
@@ -117,7 +117,7 @@ $(() => {
 
   QPixel.addPrePostValidation(text => {
     // This regex catches Markdown images with no or default alt text.
-    const altRegex = /!\[(?:Image alt text)?\](?:\(.+(?!\\\))\)|\[.+(?!\\\])\])/gi;
+    const altRegex = /!\[(?:Image_alt_text)?\](?:\(.+(?!\\\))\)|\[.+(?!\\\])\])/gi;
     if (text.match(altRegex)) {
       const message = `It looks like you're posting an image with no alt text. Alt text is important for ` +
                       `accessibility. Consider adding alt text to the images in your post - ` +

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -63,7 +63,7 @@ $(() => {
 
     const $postField = $('.js-post-field');
     const postText = $postField.val();
-    $postField.val(postText.replace(placeholder, `![Image alt text](${data.link})`));
+    $postField.val(postText.replace(placeholder, `![Image_alt_text](${data.link})`));
     $tgt.parents('.modal').removeClass('is-active');
   });
 

--- a/config/storage.sample.yml
+++ b/config/storage.sample.yml
@@ -1,3 +1,8 @@
+# To use external files (such as image upload), you need a storage.yml file.
+# If you are using only the local disk (such as in a development environment),
+# you can just copy this file. If you are using an S3 bucket, copy this
+# file and then edit the settings.
+
 test:
   service: Disk
   root: <%= Rails.root.join('tmp/storage') %>


### PR DESCRIPTION
Per https://github.com/codidact/qpixel/pull/1041#issuecomment-1545849997 -- added some comments explaining how to use this in a non-S3 environment.

I tested these instructions in my dev environment.
