### PR TITLE
collapse filter on search results page

### DIFF
--- a/app/views/search/_widget.html.erb
+++ b/app/views/search/_widget.html.erb
@@ -8,6 +8,4 @@
       <%= submit_tag 'Search', class: 'button is-medium is-outlined', name: nil %>
     </div>
   </div>
-  <h2>Filters</h2>
-  <%= render 'filters' %>
 <% end %>

--- a/app/views/search/_widget.html.erb
+++ b/app/views/search/_widget.html.erb
@@ -8,4 +8,20 @@
       <%= submit_tag 'Search', class: 'button is-medium is-outlined', name: nil %>
     </div>
   </div>
+
+  <div class="widget is-teal">
+    <div class="widget--header">
+      Advanced Search Options
+    </div>
+    <div class="widget--body">
+      <%= raw(sanitize(render_markdown(SiteSetting['JITAdvancedSearchHelp']), scrubber: scrubber)) %>
+      <p>Further help with searching is available <%= link_to 'in the help center', help_path('search') %>.</p>
+    </div>
+  </div>
+
+  <details>
+    <summary>Filters</summary>
+    <%= render 'filters' %>
+  </details>
+
 <% end %>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -4,21 +4,6 @@
 
 <%= render 'widget' %>
 
-<div class="widget is-teal">
-  <div class="widget--header">
-    Advanced Search Options
-  </div>
-  <div class="widget--body">
-    <%= raw(sanitize(render_markdown(SiteSetting['JITAdvancedSearchHelp']), scrubber: scrubber)) %>
-    <p>Further help with searching is available <%= link_to 'in the help center', help_path('search') %>.</p>
-  </div>
-</div>
-
-  <details>
-    <summary>Filters</summary>
-    <%= render 'filters' %>
-  </details>
-
 <% unless @posts.nil? %>
   <% post_count = @posts.count %>
   <div class="has-color-tertiary-500 flex-row jc-sb ai-c" title="<%= post_count %>">

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -14,6 +14,11 @@
   </div>
 </div>
 
+  <details>
+    <summary>Filters</summary>
+    <%= render 'filters' %>
+  </details>
+
 <% unless @posts.nil? %>
   <% post_count = @posts.count %>
   <div class="has-color-tertiary-500 flex-row jc-sb ai-c" title="<%= post_count %>">


### PR DESCRIPTION
https://meta.codidact.com/posts/288181

On search results, collapse the filter widget by default and also move it to right above the list of posts (for consistency).  This puts the guidance about search grammar right next to the textbox where you can type it, and puts the filters right next to the posts like on the category page.

Thanks to @MoshiKoi for helping me find the right place to update.

This is what that page looks like now:

![screenshot](https://github.com/codidact/qpixel/assets/5557942/ba514767-597e-4a29-9ab7-19d1b94c9b3e)
