### PR TITLE
Move edit history ids up a level and close all but the relevant edit

### DIFF
--- a/app/assets/javascripts/post_histories.js
+++ b/app/assets/javascripts/post_histories.js
@@ -1,7 +1,7 @@
 $(() => {
   const openRelevantEditOnly = () => {
-    $("details.history-event").attr('open', false);
-    $(location.hash).attr('open', true);
+    $("details.history-event").prop('open', false);
+    $(location.hash).prop('open', true);
   }
 
   window.addEventListener("hashchange", openRelevantEditOnly);

--- a/app/assets/javascripts/post_histories.js
+++ b/app/assets/javascripts/post_histories.js
@@ -1,3 +1,9 @@
 $(() => {
-  $(location.hash).parent('details').prop('open', true);
+  const openRelevantEditOnly = () => {
+    $("details.history-event").attr('open', false);
+    $(location.hash).attr('open', true);
+  }
+
+  window.addEventListener("hashchange", openRelevantEditOnly);
+  openRelevantEditOnly();
 });

--- a/app/views/post_history/_diff.html.erb
+++ b/app/views/post_history/_diff.html.erb
@@ -1,4 +1,4 @@
-<div class="diff" id="<%= @history.size - index %>">
+<div class="diff">
   <% if before.present? && after.present? %>
     <% if before.is_a?(String) && after.is_a?(String) %>
       <% diff = Diffy::SplitDiff.new(before, after, format: :html) %>

--- a/app/views/post_history/post.html.erb
+++ b/app/views/post_history/post.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 <% @history.each.with_index do |event, index| %>
-  <details class="history-event">
+  <details class="history-event" id="<%= @history.size - index %>">
     <summary>
       <strong>#<%= @history.size - index %>: <%= event.post_history_type.name.humanize %></strong>
       <span class="has-color-tertiary-600 history-meta">
@@ -29,13 +29,13 @@
       <% end %>
     </summary>
     <% if (event.before_title.present? || event.after_title.present?) && event.before_title != event.after_title %>
-      <%= render 'diff', index: index, before: event.before_title, after: event.after_title, post: @post %>
+      <%= render 'diff', before: event.before_title, after: event.after_title, post: @post %>
     <% end %>
     <% if (event.before_state.present? || event.after_state.present?) && event.before_state != event.after_state %>
-      <%= render 'diff', index: index, before: event.before_state, after: event.after_state, post: @post %>
+      <%= render 'diff', before: event.before_state, after: event.after_state, post: @post %>
     <% end %>
     <% if (event.before_tags.present? || event.after_tags.present?) && event.before_tags != event.after_tags %>
-      <%= render 'diff', index: index, before: event.before_tags, after: event.after_tags, post: @post %>
+      <%= render 'diff', before: event.before_tags, after: event.after_tags, post: @post %>
     <% end %>
   </details>
 <% end %>


### PR DESCRIPTION
Fixes #1056.

- Moves the edit history ids up to the `<details>` tags
- Amends the JavaScript to expand the relevant edit in the edit history every time the URL hash changes, rather than only on page load
- Amends the JavaScript to collapse all the other edits in the edit history every time the URL hash changes

Behaviour is now consistent between Firefox and Chromium.