### PR TITLE
Allow lists in comments

### DIFF
--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -81,8 +81,8 @@ end
 class CommentScrubber < Rails::Html::PermitScrubber
   def initialize
     super
-    self.tags = %w[a b i em strong s strike del pre code p blockquote span sup sub br]
-    self.attributes = %w[href title lang dir id class]
+    self.tags = %w[a b i em strong s strike del pre code p blockquote span sup sub br ul ol li]
+    self.attributes = %w[href title lang dir id class start]
   end
 
   def skip_node?(node)


### PR DESCRIPTION
Resolves #941 

Just expands the tags allowed by `CommentScrubber` to permit `ul`, `ol`, and `li` like `PostScrubber`