### PR TITLE
Cellio/post count on user profile

### DIFF
--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -125,7 +125,7 @@
             </p>
           <% end %>
 
-          <p>Users with the Curate privilege may vote to undelete this post if it has been deleted incorrectly.</p>
+          <p>Users with the Curate privilege may vote to restore this post if it has been deleted incorrectly.</p>
         </div>
       <% end %>
 

--- a/app/views/users/posts.html.erb
+++ b/app/views/users/posts.html.erb
@@ -6,11 +6,20 @@
 
 <h1>Posts by <%= user_link @user %></h1>
 
-<div class="button-list is-gutterless">
-  <%= link_to 'Score', query_url(sort: 'score'), class: 'button is-muted is-outlined ' + (active_search?('score') ? 'is-active' : ''),
-              role: 'button', 'aria-label': 'Sort by score' %>
-  <%= link_to 'Age', query_url(sort: 'age'), class: 'button is-muted is-outlined ' + (active_search?('created_at') ? 'is-active' : ''),
-              role: 'button', 'aria-label': 'Sort by age' %>
+<div>
+  <% post_count = @posts.count %>
+  <div class="has-color-tertiary-500 category-meta" title="<%= post_count %>">
+    <div>
+      <%= short_number_to_human post_count, precision: 1, significant: false %>
+      <%= 'post'.pluralize(post_count) %> &middot;
+    </div>
+
+  <div class="button-list is-gutterless">
+    <%= link_to 'Score', query_url(sort: 'score'), class: 'button is-muted is-outlined ' + (active_search?('score') ? 'is-active' : ''),
+                role: 'button', 'aria-label': 'Sort by score' %>
+    <%= link_to 'Age', query_url(sort: 'age'), class: 'button is-muted is-outlined ' + (active_search?('created_at') ? 'is-active' : ''),
+                role: 'button', 'aria-label': 'Sort by age' %>
+  </div>
 </div>
 
 <div class="item-list">


### PR DESCRIPTION
Adds the total number of posts to the user profile's posts page, like on category lists and search results.  Addresses https://meta.codidact.com/posts/287868.

With my change: 

![screenshot](https://github.com/codidact/qpixel/assets/5557942/ff92ec1a-0950-4798-8a03-509cd81662fd)

Before:
![screenshot](https://github.com/codidact/qpixel/assets/5557942/0c2f1209-6dc4-49d8-bd72-502874673db4)

