### PR TITLE
Small  usability improvements to edit-review page

### DIFF
--- a/app/views/suggested_edit/show.html.erb
+++ b/app/views/suggested_edit/show.html.erb
@@ -10,7 +10,7 @@
     <i class="fas fa-info-circle"></i> You can't approve or reject suggested edits because you haven't
     yet earned the <%= link_to 'Edit Posts', ability_path('edit_posts') %> ability.
   </div>
-  <% end %>
+<% end %>
 
 <% if @edit.active? && may_decide %>
   <div class="notice is-info">

--- a/app/views/suggested_edit/show.html.erb
+++ b/app/views/suggested_edit/show.html.erb
@@ -70,8 +70,9 @@
     </div>
   </div>
   <div class="widget--body">
-    <p class="h-m-0">Suggested <%= time_ago_in_words(@edit.created_at) %> ago by
-      <%= user_link @edit.user %></p>
+    <p class="h-m-0">Suggested
+      <span title="<%= @edit.created_at.iso8601 %>" ><%= time_ago_in_words(@edit.created_at) %> ago</span>
+      by <%= user_link @edit.user %></p>
   </div>
   <% if @edit.active? && may_decide %>
     <div class="widget--footer">

--- a/app/views/suggested_edit/show.html.erb
+++ b/app/views/suggested_edit/show.html.erb
@@ -5,6 +5,13 @@
 
 <h1>Review Suggested Edit</h1>
 
+<% if params[:show_decided] != '1' && !current_user&.privilege?('edit_posts') %>
+  <div class="notice is-info has-color-teal-800">
+    <i class="fas fa-info-circle"></i> You can't approve or reject suggested edits because you haven't
+    yet earned the <%= link_to 'Edit Posts', ability_path('edit_posts') %> ability.
+  </div>
+  <% end %>
+
 <% if @edit.active? && may_decide %>
   <div class="notice is-info">
     <p>This edit was suggested by another user. Good edits: </p>


### PR DESCRIPTION
Add the 'you can't approve yet' notice for users who can't approve edits, in the place where users who can get the review guidance instead.  The block is copied from `app/views/suggested_edit/category_index.html.erb`.  Addresses https://meta.codidact.com/posts/287910.

![screenshot](https://github.com/codidact/qpixel/assets/5557942/f32a9bea-18c1-40c7-ad1c-f34123484547)

Also add the timestamp on hover (time when edit was submitted), like on the category page, addressing https://meta.codidact.com/posts/287912.