### PR TITLE
removed redundant 'posts' heading from dashboard sections

### DIFF
--- a/app/views/application/dashboard.html.erb
+++ b/app/views/application/dashboard.html.erb
@@ -19,7 +19,6 @@
             <% end %>
           </div>
         </div>
-        <div class="widget--body h-fw-bold h-bg-tertiary-050"><i class="fa fa-file-alt"></i> Posts</div>
         <% categories.each do |cat| %>
           <% next if (cat.min_view_trust_level || -1) > (current_user&.trust_level || 0) %>
           <div class="widget--body">


### PR DESCRIPTION
Removed 'posts' heading from dashboard sections, which for most users is the only heading so looks unnecessary.  Resolves https://meta.codidact.com/posts/288139.

Ordinary users now see this:

![screenshot](https://github.com/codidact/qpixel/assets/5557942/da0e19e9-f52a-4076-b7cd-a04ce822bc3e)

Global mods/admins, a small group relative to users, see this, which seems fine:

![screenshot](https://github.com/codidact/qpixel/assets/5557942/b230b001-adf2-47f9-99ac-3830a0254537)

