### PR TITLE
added some of the pre-search 'hints' to the results page 

### DIFF
--- a/app/views/search/_widget.html.erb
+++ b/app/views/search/_widget.html.erb
@@ -16,7 +16,7 @@
     <div class="widget--body">
       <%= raw(sanitize(render_markdown(SiteSetting['JITAdvancedSearchHelp']), scrubber: scrubber)) %>
       <p>Further help with searching is available <%= link_to 'in the help center', help_path('search') %>.</p>
-      <p>Quick hints: <code>tag:tagname</code>, <code>user:xxx</code>, <code>"exact phrase"</code>, <code>post_type:xxx</code>, <code>created:&lt;N{d,w,mo,y}</code></p>
+      <p>Quick hints: <code>tag:tagname</code>, <code>user:xxx</code>, <code>"exact phrase"</code>, <code>post_type:xxx</code>, <code>created:&lt;N{d,w,mo,y}</code>, <code>score:&gt;=0.5</code></p>
     </div>
   </div>
 

--- a/app/views/search/_widget.html.erb
+++ b/app/views/search/_widget.html.erb
@@ -16,6 +16,7 @@
     <div class="widget--body">
       <%= raw(sanitize(render_markdown(SiteSetting['JITAdvancedSearchHelp']), scrubber: scrubber)) %>
       <p>Further help with searching is available <%= link_to 'in the help center', help_path('search') %>.</p>
+      <p>Quick hints: <code>tag:tagname</code>, <code>user:xxx</code>, <code>"exact phrase"</code>, <code>post_type:xxx</code>, <code>created:&lt;N{d,w,m}</code></p>
     </div>
   </div>
 

--- a/app/views/search/_widget.html.erb
+++ b/app/views/search/_widget.html.erb
@@ -16,7 +16,7 @@
     <div class="widget--body">
       <%= raw(sanitize(render_markdown(SiteSetting['JITAdvancedSearchHelp']), scrubber: scrubber)) %>
       <p>Further help with searching is available <%= link_to 'in the help center', help_path('search') %>.</p>
-      <p>Quick hints: <code>tag:tagname</code>, <code>user:xxx</code>, <code>"exact phrase"</code>, <code>post_type:xxx</code>, <code>created:&lt;N{d,w,m}</code></p>
+      <p>Quick hints: <code>tag:tagname</code>, <code>user:xxx</code>, <code>"exact phrase"</code>, <code>post_type:xxx</code>, <code>created:&lt;N{d,w,mo,y}</code></p>
     </div>
   </div>
 


### PR DESCRIPTION
Before you start a search, the pop-up gives you a summary of some common search operations.  When you get your search results and want to refine your search, though, it's not also on the results page (though you could go up to the "search" button again to get it, but that would mean starting over).

Adding the entire block would add too much stuff to get through before you get to the results, particularly on a phone.  I considered making it collapsible, but that's easier to miss.  I opted for a terse summary in a paragraph (rather than the mult-line layout) -- enough to jog memory, and the link to the full help is right there.

![screenshot](https://github.com/codidact/qpixel/assets/5557942/082e852b-ecb9-49f6-92e8-fd4ccd460841)


Requested in https://meta.codidact.com/posts/288175.
