### PR TITLE
SSO Multi Community - Add signing in through other community

### DIFF
--- a/app/controllers/users/saml_sessions_controller.rb
+++ b/app/controllers/users/saml_sessions_controller.rb
@@ -171,7 +171,8 @@ class Users::SamlSessionsController < Devise::SamlSessionsController
   # @param user [User]
   def encrypt_user_info(user)
     len = ActiveSupport::MessageEncryptor.key_len - 1
-    crypt = ActiveSupport::MessageEncryptor.new(Rails.application.secrets.secret_key_base[0..len])
+    key = Rails.application.secrets.secret_key_base || Rails.application.credentials.secret_key_base
+    crypt = ActiveSupport::MessageEncryptor.new(key[0..len])
     crypt.encrypt_and_sign(user.id, expires_in: 1.minute)
   end
 
@@ -179,7 +180,8 @@ class Users::SamlSessionsController < Devise::SamlSessionsController
   # @param data
   def decrypt_user_info(data)
     len = ActiveSupport::MessageEncryptor.key_len - 1
-    crypt = ActiveSupport::MessageEncryptor.new(Rails.application.secrets.secret_key_base[0..len])
+    key = Rails.application.secrets.secret_key_base || Rails.application.credentials.secret_key_base
+    crypt = ActiveSupport::MessageEncryptor.new(key[0..len])
     crypt.decrypt_and_verify(data)
   end
 

--- a/app/controllers/users/saml_sessions_controller.rb
+++ b/app/controllers/users/saml_sessions_controller.rb
@@ -4,8 +4,7 @@ class Users::SamlSessionsController < Devise::SamlSessionsController
     # If this is not the base community, then redirect them there for the sign in
     base = base_community
     if base.id != RequestContext.community_id
-      redirect_to "http#{'s' if Rails.env.production?}://#{base.host}" \
-                  "#{sign_in_request_from_other_path(RequestContext.community_id)}",
+      redirect_to "//#{base.host}#{sign_in_request_from_other_path(RequestContext.community_id)}",
                   allow_other_host: true
       return
     end
@@ -164,8 +163,7 @@ class Users::SamlSessionsController < Devise::SamlSessionsController
     # We signed in for a different community, we need to send them back to the original community with encrypted
     # info about who signed in.
     encrypted_user_info = encrypt_user_info(user)
-    redirect_to "http#{'s' if Rails.env.production?}://#{community.host}#{sign_in_return_from_base_path}" \
-                "?message=#{CGI.escape(encrypted_user_info)}",
+    redirect_to "//#{community.host}#{sign_in_return_from_base_path}?message=#{CGI.escape(encrypted_user_info)}",
                 allow_other_host: true
   end
 

--- a/app/controllers/users/saml_sessions_controller.rb
+++ b/app/controllers/users/saml_sessions_controller.rb
@@ -1,29 +1,126 @@
 class Users::SamlSessionsController < Devise::SamlSessionsController
+  # Called when someone is redirected to sign into the application using SSO/SAML.
+  def new
+    # If this is not the base community, then redirect them there for the sign in
+    base = base_community
+    if base.id != RequestContext.community_id
+      redirect_to "http#{'s' if Rails.env.production?}://#{base.host}" \
+                  "#{sign_in_request_from_other_path(RequestContext.community_id)}",
+                  allow_other_host: true
+      return
+    end
+
+    # If we are the base community, use normal behavior
+    super
+  end
+
   # This method is almost the same code as the Users::SessionsController#create, and any changes
   # made here should probably also be applied over there.
   def create
     super do |user|
-      if user.deleted? || user.community_user&.deleted?
-        # The IDP already confirmed the sign in, so we can't fool the user any more that their credentials were
-        # incorrect.
-        sign_out user
-        flash[:notice] = nil
-        flash[:danger] = 'We could not sign you in because of an issue with your account.'
-        redirect_to root_path
-        return
-      end
+      return unless post_sign_in(user)
 
-      # Enforce 2fa if enabled for SSO users
-      if SiteSetting['Enable2FAForSsoUsers'] && user.present? && user.enabled_2fa
-        handle_2fa_login(user)
-        return
-      end
+      # SSO Only - Redirect to filler endpoint to actually get the clients cookie values (not sent to us here).
+      # We need to check cookies because we may be signing in for another community.
+      redirect_to after_sign_in_check_path
+      return
     end
+  end
+
+  # On the initial return from the SSO the client does not send along its cookies (CORS/CSRF/XSS protections).
+  # Instead, we redirect the user after the sign-in to this endpoint, such that we get their cookies.
+  # Then we can check whether we were supposed to sign them in for a different community.
+  def after_sign_in_check
+    if cookies.encrypted[:signing_in_for].present? &&
+       cookies.encrypted[:signing_in_for] != RequestContext.community_id
+      handle_sign_in_for_other_community(current_user)
+      return
+    end
+
+    redirect_to after_sign_in_path_for(current_user)
+  end
+
+  # Another community requests to sign in via this community.
+  def sign_in_request_from_other
+    # Check whether the requested community actually exists
+    unless Community.exists?(params[:id])
+      raise ArgumentError, 'User is trying to sign in to non-existing community'
+    end
+
+    # Store in a cookie which community we are signing in for such that we can redirect back after the sign in.
+    cookies.encrypted[:signing_in_for] = {
+      value: params[:id],
+      httponly: true,
+      expires: 15.minutes.from_now
+    }
+
+    # If already signed in, sign them in in the other community as well. Otherwise redirect to SAML sign in.
+    if user_signed_in?
+      handle_sign_in_for_other_community(current_user)
+    else
+      redirect_to new_saml_user_session_path
+    end
+  end
+
+  # User was signed in at the base community, now sign in here.
+  def sign_in_return_from_base
+    # Figure out which user was signed in.
+    # If we get a blank result then the message is either too old or the user messed with it.
+    user_info = decrypt_user_info(params[:message])
+    if user_info.blank?
+      flash[:notice] = nil
+      flash[:danger] = 'Something went wrong signing in, please try again.'
+      redirect_to root_path
+    end
+
+    # Determine the user we are trying to sign in as and report error if we can't
+    user = User.find(user_info)
+    if user.nil?
+      flash[:notice] = nil
+      flash[:danger] = 'Something went wrong signing in, please contact support.'
+      redirect_to root_path
+    end
+
+    # Actually sign in the user and handle the post-sign-in behavior
+    sign_in(user)
+    return unless post_sign_in(user)
+
+    # Finish with default devise behavior for sign ins
+    redirect_to after_sign_in_path_for(user)
   end
 
   private
 
-  def handle_2fa_login(user)
+  # After a sign in, this method is called to check whether special conditions apply to the user.
+  # The user may be signed out by this method.
+  #
+  # In general, this method should have similar behavior to the Users::SessionsController#post_sign_in method.
+  # If you make changes here, you may also have to update that method.
+  #
+  # @param user [User]
+  # @return [Boolean] false if the user was redirected by this
+  def post_sign_in(user)
+    # If the user was banished, let them know non-specifically.
+    if user.deleted? || user.community_user&.deleted?
+      # The IDP already confirmed the sign in, so we can't fool the user any more that their credentials were incorrect.
+      sign_out user
+      flash[:notice] = nil
+      flash[:danger] = 'We could not sign you in because of an issue with your account.'
+      redirect_to root_path
+      return false
+    end
+
+    # Enforce 2fa if enabled for SSO users
+    if SiteSetting['Enable2FAForSsoUsers'] && user.enabled_2fa
+      handle_2fa_login(user)
+      return false
+    end
+
+    true
+  end
+
+  def handle_2fa_login(user, host = nil)
+    host ||= request.hostname
     sign_out user
     case user.two_factor_method
     when 'app'
@@ -31,10 +128,63 @@ class Users::SamlSessionsController < Devise::SamlSessionsController
       Users::SessionsController.first_factor << id
       redirect_to login_verify_2fa_path(uid: id)
     when 'email'
-      TwoFactorMailer.with(user: user, host: request.hostname).login_email.deliver_now
+      TwoFactorMailer.with(user: user, host: host).login_email.deliver_now
       flash[:notice] = nil
       flash[:info] = 'Please check your email inbox for a link to sign in.'
       redirect_to root_path
     end
+  end
+
+  # Handles a successful sign in at the base community when it was requested to do from another community.
+  # @param user [User]
+  def handle_sign_in_for_other_community(user)
+    # Determine which community we are signing in for, log out if not found (user messed with encrypted cookie/expired)
+    community = Community.find(cookies.encrypted[:signing_in_for])
+    if community.nil?
+      sign_out(user)
+      flash[:notice] = nil
+      flash[:danger] = 'Something went wrong trying to sign you in.'
+      redirect_to root_path
+      return
+    end
+
+    # Clear the cookie to prevent future issues
+    cookies.delete(:signing_in_for)
+
+    # We signed in for a different community, we need to send them back to the original community with encrypted
+    # info about who signed in.
+    encrypted_user_info = encrypt_user_info(user)
+    redirect_to "http#{'s' if Rails.env.production?}://#{community.host}#{sign_in_return_from_base_path}" \
+                "?message=#{CGI.escape(encrypted_user_info)}",
+                allow_other_host: true
+  end
+
+  # Encrypts user information for sending them to a different community.
+  # @param user [User]
+  def encrypt_user_info(user)
+    len = ActiveSupport::MessageEncryptor.key_len - 1
+    crypt = ActiveSupport::MessageEncryptor.new(Rails.application.secrets.secret_key_base[0..len])
+    crypt.encrypt_and_sign(user.id, expires_in: 1.minute)
+  end
+
+  # Decrypts the user information when received at a different community.
+  # @param data
+  def decrypt_user_info(data)
+    len = ActiveSupport::MessageEncryptor.key_len - 1
+    crypt = ActiveSupport::MessageEncryptor.new(Rails.application.secrets.secret_key_base[0..len])
+    crypt.decrypt_and_verify(data)
+  end
+
+  # @return [Community] the community to which the SSO is connected, and which must be used to sign in via.
+  def base_community
+    uri = URI.parse(Devise.saml_config.assertion_consumer_service_url)
+    host = if uri.port != 80 && uri.port != 443 && !uri.port.nil?
+             "#{uri.hostname}:#{uri.port}"
+           else
+             uri.hostname
+           end
+    Community.find_by(host: host) || Community.first
+  rescue
+    Community.first
   end
 end

--- a/app/controllers/users/saml_sessions_controller.rb
+++ b/app/controllers/users/saml_sessions_controller.rb
@@ -36,7 +36,7 @@ class Users::SamlSessionsController < Devise::SamlSessionsController
       return
     end
 
-    return unless post_sign_in(user, true)
+    return unless post_sign_in(current_user, true)
 
     redirect_to after_sign_in_path_for(current_user)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
   devise_scope :user do
     get  'users/2fa/login',                to: 'users/sessions#verify_2fa', as: :login_verify_2fa
     post 'users/2fa/login',                to: 'users/sessions#verify_code', as: :login_verify_code
+    get  'users/saml/sign_in_request_from_other/:id', to: 'users/saml_sessions#sign_in_request_from_other', as: :sign_in_request_from_other
+    get  'users/saml/sign_in_return_from_base',       to: 'users/saml_sessions#sign_in_return_from_base', as: :sign_in_return_from_base
+    get  'users/saml/after_sign_in_check',            to: 'users/saml_sessions#after_sign_in_check', as: :after_sign_in_check
   end
 
   root                                     to: 'categories#homepage'


### PR DESCRIPTION
For the way SSO integration was previously set up, all SSO requests will end up back at the same community. However, if there are multiple communities and they are not hosted on the same domain (common), this will only allow one community to actually use SSO sign in (due to how devise_saml is configured and designed / due to common restrictions on SAML requests).

The changes in this PR allows a user on one community to sign in through an SSO linked to a different community. The community to which the SSO is linked is defined as the "base community", and is determined based on the assertion consumer service url (`base_community` in `SamlSessionsController`). If this is unsuccessful, the first community is considered as the base.

The authentication flow is as follows:
1. (Requesting) User clicks on a SSO Sign in button -> goes to (GET) `/users/saml/new` (`SamlSessionsController#new`)
2. (Requesting) If user at base community, go to step 6.
3. (Requesting) Otherwise -> redirect to (GET) `{base_community}/users/saml/sign_in_request_from_other/{requesting_community_id}` (`SamlSessionsController#sign_in_request_from_other`)
4. (Base) Add cookie `signing_in_for` which holds (encrypted) the community id where the user came from and is trying to sign into.
5. (Base) If already signed in, go to step 9
6. (Base) (Otherwise) redirect to SAML IDP (actual SSO login)
7. (Base) User is redirected from SSO Login to POST `{base_community}/users/saml/new` (`SamlSessionsController#create`)
8. (Base) User is redirected to `{base_community}/users/saml/after_sign_in_check` (`SamlSessionsController#after_sign_in_check`)
9. (Base) If no `signing_in_for` cookie is present, go to step 12
10. (Base) Otherwise (`signing_in_for` cookie is present) redirect to `{requesting_community}/users/saml/sign_in_return_from_base` (`SamlSessionsController#sign_in_return_from_base`) with encrypted info about the user who signed in
11. (Requesting) Decrypt user info and sign in the user
12. (Requesting) redirect user to whatever location they should go to after a normal sign in.
  
Some additional notes:
- The `after_sign_in_check` endpoint exists only because clients don't like sending cookies whenever they are doing a cross-origin request. So after logging in on the SSO, they are redirected back to the application. At this moment, the client does not send cookies. According to the specification it is possible by setting some attributes, but only when using https (i.e. won't work in development). Additionally, some browsers just don't do this (to prevent tracking across sites?), so it is not reliable. The second endpoint thus exists to do a redirection within the same origin to get the client cookies.
- While this seems convoluted, the user should notice very little of the extra redirects. With low latency it is not noticeable. With higher latency, the sign-in procedure may just take a little longer.
- Previous flow was steps 1, 6, 7 and 12.
- When only using one community, we skip steps 3, 4, 5, 10 and 11 (So only 2, 8 and 9 are new)
- When a user is already signed in on the base community, devise_saml normally just redirects the user to the root rather than bringing them to the SSO. To work around this, step 5 exists. This means that a user can sign in on another community without authentication as long as they are signed in at the base, which is potentially unwanted. An alternative is to sign the user out at the base community, then let devise redirect them to the SSO, and then they will be signed in at the base community and the target community. Issue with that is that if the user does not sign in, they will be "suddenly" signed out at the base community.