### PR TITLE
239 after login redirect to the original page

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,7 +43,7 @@ Metrics/BlockLength:
 Metrics/BlockNesting:
   Max: 5
 Metrics/ClassLength:
-  Max: 300
+  Max: 350
 Metrics/CyclomaticComplexity:
   Max: 30
 Metrics/MethodLength:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -383,11 +383,14 @@ class ApplicationController < ActionController::Base
   #    infinite redirect loop.
   # - The request is an Ajax request as this can lead to very unexpected behaviour.
   # - The request is to a location we dont want to store, such as:
-  #   - Anything trying to fetch for the current user (filters, preferences, etc)
-  #   - Uploaded files (these appear in posts and are not the main route we would want to store)
+  #   - Anything trying to fetch for the current user (filters, preferences, etc) as it is not the actual page
+  #   - The mobile login, as it would redirect to the code url after the sign in
+  #   - Uploaded files, as these appear in posts and are not the main route we would want to store
   def storable_location?
     request.get? && is_navigational_format? && !devise_controller? && !request.xhr? &&
-      !request.path.start_with?('/users/me') && !request.path.start_with?('/uploads/')
+      !request.path.start_with?('/users/me') &&
+      !request.path.start_with?('/users/mobile-login') &&
+      !request.path.start_with?('/uploads/')
   end
 
   # Stores the location in the system for the current session, such that after login we send them back to the same page.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,11 @@ class ApplicationController < ActionController::Base
   before_action :check_if_warning_or_suspension_pending
   before_action :distinguish_fake_community
   before_action :stop_the_awful_troll
+
+  # Before checking 2fa enforcing or access, store the location that the user is trying to access.
+  # In case re-authentication is necessary / the user signs in, we can direct back to this location directly.
+  before_action :store_user_location!, if: :storable_location?
+
   before_action :enforce_2fa
   before_action :block_write_request, if: :read_only_mode?
 
@@ -368,5 +373,25 @@ class ApplicationController < ActionController::Base
         end
       end
     end
+  end
+
+  # Checks if the requested location should be stored.
+  #
+  # Its important that the location is NOT stored if:
+  # - The request method is not GET (non idempotent)
+  # - The request is handled by a Devise controller such as Devise::SessionsController as that could cause an
+  #    infinite redirect loop.
+  # - The request is an Ajax request as this can lead to very unexpected behaviour.
+  # - The request is to a location we dont want to store, such as:
+  #   - Anything trying to fetch for the current user (filters, preferences, etc)
+  #   - Uploaded files (these appear in posts and are not the main route we would want to store)
+  def storable_location?
+    request.get? && is_navigational_format? && !devise_controller? && !request.xhr? &&
+      !request.path.start_with?('/users/me') && !request.path.start_with?('/uploads/')
+  end
+
+  # Stores the location in the system for the current session, such that after login we send them back to the same page.
+  def store_user_location!
+    store_location_for(:user, request.fullpath)
   end
 end

--- a/app/controllers/users/saml_sessions_controller.rb
+++ b/app/controllers/users/saml_sessions_controller.rb
@@ -34,7 +34,7 @@ class Users::SamlSessionsController < Devise::SamlSessionsController
       TwoFactorMailer.with(user: user, host: request.hostname).login_email.deliver_now
       flash[:notice] = nil
       flash[:info] = 'Please check your email inbox for a link to sign in.'
-      redirect_to root_path
+      redirect_to after_sign_in_path_for(user)
     end
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -83,7 +83,7 @@ class Users::SessionsController < Devise::SessionsController
       TwoFactorMailer.with(user: user, host: request.hostname).login_email.deliver_now
       flash[:notice] = nil
       flash[:info] = 'Please check your email inbox for a link to sign in.'
-      redirect_to root_path
+      redirect_to after_sign_in_path_for(user)
     end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -518,7 +518,7 @@ class UsersController < ApplicationController
       sign_in user
       remember_me user
       AuditLog.user_history(event_type: 'mobile_login', related: user)
-      redirect_to root_path
+      redirect_to after_sign_in_path_for(user)
     else
       flash[:danger] = "That login link isn't valid. Codes expire after 5 minutes - if it's been longer than that, " \
                        'get a new code and try again.'


### PR DESCRIPTION
The way this works is by always storing the last url the user visited, expect if that was any URL we want to ignore (AJAX, file/image, edits, sign-in pages, ...). If a user then presses sign in and signs in, they are redirected back to the last stored location. (It makes use of the fact that Rails uses session cookies also for non-signed-in users to identify them across different requests.)

Normal devise sign ins already make use of the location, thus I only had to edit the redirects for our customized sign-in endpoints (mobile sign in and 2FA).

When doing a 2FA sign in (email based), you first sign in with email and password, then it sends you back to the page you were looking at before going to the sign in, while asking you to check your mail. The link in the email will again send you to that same page when used.

Fixes #239