### PR TITLE
Add close reason as comment to history

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -271,13 +271,15 @@ class PostsController < ApplicationController
       end
 
       duplicate_of = Question.find(params[:other_post])
+      comment = "Closed as #{reason.name} of [Question ##{duplicate_of.id}](#{post_path(duplicate_of)})"
     else
       duplicate_of = nil
+      comment = "Closed as #{reason.name}"
     end
 
     if @post.update(closed: true, closed_by: current_user, closed_at: DateTime.now, last_activity: DateTime.now,
                     last_activity_by: current_user, close_reason: reason, duplicate_post: duplicate_of)
-      PostHistory.question_closed(@post, current_user)
+      PostHistory.question_closed(@post, current_user, comment: comment)
       render json: { status: 'success' }
     else
       render json: { status: 'failed', message: helpers.i18ns('posts.cant_close_post'),

--- a/app/helpers/post_history_scrubber.rb
+++ b/app/helpers/post_history_scrubber.rb
@@ -1,0 +1,11 @@
+class PostHistoryScrubber < Rails::Html::PermitScrubber
+  def initialize
+    super
+    self.tags = %w[a b i em strong s strike del sup sub]
+    self.attributes = %w[href title lang dir id class start]
+  end
+
+  def skip_node?(node)
+    node.text?
+  end
+end

--- a/app/views/post_history/post.html.erb
+++ b/app/views/post_history/post.html.erb
@@ -21,7 +21,7 @@
           <%= event.created_at.iso8601 %> (<%= time_ago_in_words(event.created_at) %> ago)
         </span>
         <% if event.comment.present? %>
-          <br/><em><%= event.comment %></em>
+          <br/><em><%= raw(sanitize(render_markdown(event.comment), scrubber: scrubber)) %></em>
         <% end %>
       </span>
       <%= link_to post_history_url(@post, anchor: @history.size - index), class: 'js-permalink' do %>

--- a/app/views/post_history/post.html.erb
+++ b/app/views/post_history/post.html.erb
@@ -21,7 +21,8 @@
           <%= event.created_at.iso8601 %> (<%= time_ago_in_words(event.created_at) %> ago)
         </span>
         <% if event.comment.present? %>
-          <br/><em><%= raw(sanitize(render_markdown(event.comment), scrubber: CommentScrubber.new)) %></em>
+          <br/><em><%= sanitize(render_markdown(event.comment), scrubber: PostHistoryScrubber.new) %></em>
+          &mdash;
         <% end %>
       </span>
       <%= link_to post_history_url(@post, anchor: @history.size - index), class: 'js-permalink' do %>

--- a/app/views/post_history/post.html.erb
+++ b/app/views/post_history/post.html.erb
@@ -21,7 +21,7 @@
           <%= event.created_at.iso8601 %> (<%= time_ago_in_words(event.created_at) %> ago)
         </span>
         <% if event.comment.present? %>
-          <br/><em><%= raw(sanitize(render_markdown(event.comment), scrubber: scrubber)) %></em>
+          <br/><em><%= raw(sanitize(render_markdown(event.comment), scrubber: CommentScrubber.new)) %></em>
         <% end %>
       </span>
       <%= link_to post_history_url(@post, anchor: @history.size - index), class: 'js-permalink' do %>


### PR DESCRIPTION
Comments are now rendered as markdown, to allow inclusion of e.g. links.

This MR was inspired by @MoshiKoi 's version (#863), with the main change relative to that version being that I added markdown support to be able to create links. This also means that markdown can be used when the user provides a comment themselves. However, most markdown is again filtered by the PostHistoryScrubber, which only accepts the absolute basics.

![image](https://github.com/codidact/qpixel/assets/668952/83d9e22e-abc1-4eac-9c57-75e690f5353e)

Fixes #215