### PR TITLE
326 history diff does not show retagging

### DIFF
--- a/app/controllers/suggested_edit_controller.rb
+++ b/app/controllers/suggested_edit_controller.rb
@@ -30,6 +30,9 @@ class SuggestedEditController < ApplicationController
       return
     end
 
+    # The to_a / dup methods called on the tags for `opts` and `before` are necessary.
+    # We need to work on a copy of them, because we update the post before the edit, which will change their values.
+    # (We would otherwise be pointing to the same instance, and only see the updated version).
     opts = { before: @post.body_markdown, after: @edit.body_markdown, comment: @edit.comment,
              before_title: @post.title, after_title: @edit.title, before_tags: @post.tags.to_a, after_tags: @edit.tags }
 

--- a/app/controllers/suggested_edit_controller.rb
+++ b/app/controllers/suggested_edit_controller.rb
@@ -31,10 +31,10 @@ class SuggestedEditController < ApplicationController
     end
 
     opts = { before: @post.body_markdown, after: @edit.body_markdown, comment: @edit.comment,
-             before_title: @post.title, after_title: @edit.title, before_tags: @post.tags, after_tags: @edit.tags }
+             before_title: @post.title, after_title: @edit.title, before_tags: @post.tags.to_a, after_tags: @edit.tags }
 
-    before = { before_body: @post.body, before_body_markdown: @post.body_markdown, before_tags_cache: @post.tags_cache,
-               before_tags: @post.tags.to_a, before_title: @post.title }
+    before = { before_body: @post.body, before_body_markdown: @post.body_markdown,
+               before_tags_cache: @post.tags_cache.dup, before_tags: @post.tags.to_a, before_title: @post.title }
 
     if @post.update(applied_details)
       @edit.update(before.merge(active: false, accepted: true, rejected_comment: '', decided_at: DateTime.now,


### PR DESCRIPTION
The issue was as follows (was able to reproduce and confirm fix):

* When we set `before_tags: @post.tags`, we get THE activerecord tags array for the post. We store this instance in our Hash.
* Next we update the post to have the suggested tags, this ALTERS the tags array of the post.
* If we were to look in our hash, we would see that if we look at the value of `before_tags` it is no longer the before tags, but the current tags (Object Oriented Programming).
* Finally we save the suggested edit with the data in our hash.

The fix is to make actual copies such that we are pointing at different arrays rather than the same array. For ActiveRecord has_many relations (those are some custom object that essentially extends array), `to_a` will do this for us. The tags_cache is a true Array, so I use `dup` there to make a copy.

Let's hope this issue now remains forever closed.

Fixes #326