### PR TITLE
Ping user if ping was added in edit

### DIFF
--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -77,7 +77,10 @@ $(() => {
     const $tgt = $(evt.target);
     const $comment = $tgt.parents('.comment');
     const $commentBody = $comment.find('.comment--body');
+    const $thread = $comment.parents('.thread');
     const commentId = $comment.attr('data-id');
+    const postId = $thread.attr('data-post');
+    const threadId = $thread.attr('data-thread');
     const originalComment = $commentBody.clone();
 
     const resp = await fetch(`/comments/${commentId}`, {
@@ -89,7 +92,7 @@ $(() => {
 
     const formTemplate = `<form action="/comments/${commentId}/edit" method="POST" class="comment-edit-form" data-remote="true">
       <label for="comment-content" class="form-element">Comment body:</label>
-      <textarea id="comment-content" rows="6" class="form-element is-small" data-character-count=".js-character-count-comment-body" name="comment[content]">${content}</textarea>
+      <textarea id="comment-content" rows="6" class="form-element is-small" data-thread="${threadId}" data-post="${postId}" data-character-count=".js-character-count-comment-body" name="comment[content]">${content}</textarea>
       <input type="submit" class="button is-muted is-filled" value="Update comment" />
       <input type="button" name="js-discard-edit" data-comment-id="${commentId}" value="Discard Edit" class="button is-danger is-outlined js-discard-edit" />
       <span class="has-float-right has-font-size-caption js-character-count-comment-body"
@@ -100,6 +103,8 @@ $(() => {
     </form>`;
 
     $commentBody.html(formTemplate);
+
+    $commentBody.find(`#comment-content`).on('keyup', pingable_popup);
 
     $(`.js-discard-edit[data-comment-id="${commentId}"]`).click(() => {
       $commentBody.html(originalComment.html());
@@ -195,7 +200,9 @@ $(() => {
   });
 
   const pingable = {};
-  $(document).on('keyup', '.js-comment-field', async ev => {
+  $(document).on('keyup', '.js-comment-field', pingable_popup);
+
+  async function pingable_popup(ev) {
     if (QPixel.Popup.isSpecialKey(ev.keyCode)) {
       return;
     }
@@ -242,7 +249,7 @@ $(() => {
     else {
       QPixel.Popup.destroyAll();
     }
-  });
+  }
 
   $('.js-new-thread-link').on('click', async ev => {
     ev.preventDefault();

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -101,6 +101,8 @@ class CommentsController < ApplicationController
   end
 
   def update
+    @post = @comment.post
+    @comment_thread = @comment.comment_thread
     before = @comment.content
     before_pings = check_for_pings @comment_thread, before
     if @comment.update comment_params
@@ -109,8 +111,8 @@ class CommentsController < ApplicationController
                                  comment: "from <<#{before}>>\nto <<#{@comment.content}>>")
       end
 
-      after_pings = check_for_pings @comment_thread, params[:content]
-      apply_pings(after_pings - before_pings)
+      after_pings = check_for_pings @comment_thread, @comment.content
+      apply_pings(after_pings - before_pings - @comment_thread.thread_follower.to_a)
 
       render json: { status: 'success',
                      comment: render_to_string(partial: 'comments/comment', locals: { comment: @comment }) }

--- a/app/views/comments/thread.html.erb
+++ b/app/views/comments/thread.html.erb
@@ -24,9 +24,9 @@
 <!-- THREAD STARTS BELOW -->
 <div class="<%= @comment_thread.deleted ? 'h-bg-red-050' : '' %> <%= params[:inline] == 'true' ? 'post--comments-thread is-embedded' : '' %>">
 
-<div class="widget <%= @comment_thread.deleted ? 'is-red' : '' %>" data-deleted="<%= @comment_thread.deleted %>"
+<div class="widget thread <%= @comment_thread.deleted ? 'is-red' : '' %>" data-deleted="<%= @comment_thread.deleted %>"
      data-archived="<%= @comment_thread.archived %>" data-thread="<%= @comment_thread.id %>"
-     data-comments="<%= @comment_thread.reply_count %>">
+     data-comments="<%= @comment_thread.reply_count %>" data-post="<%= @post.id %>">
   <div class="widget--header">
     <% if params[:inline] == 'true' %>
       <a href="<%= comment_thread_path(@comment_thread.id) %>" class="widget--header-link">


### PR DESCRIPTION
When a comment is updated to now include pings, those will be taken into consideration. If the "to-ping" user is also following, we don't retroactively ping (prevent double notification). Otherwise, a ping notification is sent.

The changes to the JavaScript are to make sure that the ping user suggestion popups also show up when editing a comment.

Fixes #319