### PR TITLE
History redaction

### DIFF
--- a/app/controllers/post_history_controller.rb
+++ b/app/controllers/post_history_controller.rb
@@ -6,7 +6,7 @@ class PostHistoryController < ApplicationController
       return not_found
     end
 
-    @history = PostHistory.where(post_id: params[:id]).visible(current_user)
+    @history = PostHistory.where(post_id: params[:id])
                           .includes(:post_history_type, :user, post_history_tags: [:tag])
                           .order(created_at: :desc, id: :desc).paginate(per_page: 20, page: params[:page])
     render layout: 'without_sidebar'

--- a/app/controllers/post_history_controller.rb
+++ b/app/controllers/post_history_controller.rb
@@ -8,7 +8,7 @@ class PostHistoryController < ApplicationController
 
     @history = PostHistory.where(post_id: params[:id]).visible(current_user)
                           .includes(:post_history_type, :user, post_history_tags: [:tag])
-                          .order(created_at: :desc).paginate(per_page: 20, page: params[:page])
+                          .order(created_at: :desc, id: :desc).paginate(per_page: 20, page: params[:page])
     render layout: 'without_sidebar'
   end
 end

--- a/app/controllers/post_history_controller.rb
+++ b/app/controllers/post_history_controller.rb
@@ -6,7 +6,8 @@ class PostHistoryController < ApplicationController
       return not_found
     end
 
-    @history = PostHistory.where(post_id: params[:id]).includes(:post_history_type, :user, post_history_tags: [:tag])
+    @history = PostHistory.where(post_id: params[:id]).visible(current_user)
+                          .includes(:post_history_type, :user, post_history_tags: [:tag])
                           .order(created_at: :desc).paginate(per_page: 20, page: params[:page])
     render layout: 'without_sidebar'
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -196,7 +196,7 @@ class PostsController < ApplicationController
                                       after: @post.body_markdown, comment: params[:edit_comment],
                                       before_title: before[:title], after_title: @post.title,
                                       before_tags: before[:tags], after_tags: @post.tags)
-            PostHistory.history_hidden(self, current_user, after: body_markdown, after_title: title, after_tags: tags)
+            PostHistory.history_hidden(@post, current_user, after: @post.body_markdown, after_title: @post.title, after_tags: @post.tags)
           else
             PostHistory.post_edited(@post, current_user, before: before[:body],
                                     after: @post.body_markdown, comment: params[:edit_comment],

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -191,10 +191,18 @@ class PostsController < ApplicationController
         if @post.update(edit_post_params.merge(body: body_rendered,
                                                last_edited_at: DateTime.now, last_edited_by: current_user,
                                                last_activity: DateTime.now, last_activity_by: current_user))
-          PostHistory.post_edited(@post, current_user, before: before[:body],
-                                  after: @post.body_markdown, comment: params[:edit_comment],
-                                  before_title: before[:title], after_title: @post.title,
-                                  before_tags: before[:tags], after_tags: @post.tags)
+          if params[:redact]
+            PostHistory.post_redacted(@post, current_user, before: before[:body],
+                                      after: @post.body_markdown, comment: params[:edit_comment],
+                                      before_title: before[:title], after_title: @post.title,
+                                      before_tags: before[:tags], after_tags: @post.tags)
+            PostHistory.history_hidden(self, current_user, after: body_markdown, after_title: title, after_tags: tags)
+          else
+            PostHistory.post_edited(@post, current_user, before: before[:body],
+                                    after: @post.body_markdown, comment: params[:edit_comment],
+                                    before_title: before[:title], after_title: @post.title,
+                                    before_tags: before[:tags], after_tags: @post.tags)
+          end
           Rails.cache.delete "community_user/#{current_user.community_user.id}/metric/E"
           do_draft_delete(URI(request.referer || '').path)
           redirect_to post_path(@post)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -196,7 +196,8 @@ class PostsController < ApplicationController
                                       after: @post.body_markdown, comment: params[:edit_comment],
                                       before_title: before[:title], after_title: @post.title,
                                       before_tags: before[:tags], after_tags: @post.tags)
-            PostHistory.history_hidden(@post, current_user, after: @post.body_markdown, after_title: @post.title, after_tags: @post.tags)
+            PostHistory.history_hidden(@post, current_user, after: @post.body_markdown,
+                                       after_title: @post.title, after_tags: @post.tags)
           else
             PostHistory.post_edited(@post, current_user, before: before[:body],
                                     after: @post.body_markdown, comment: params[:edit_comment],

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -191,18 +191,18 @@ class PostsController < ApplicationController
         if @post.update(edit_post_params.merge(body: body_rendered,
                                                last_edited_at: DateTime.now, last_edited_by: current_user,
                                                last_activity: DateTime.now, last_activity_by: current_user))
+
+          PostHistory.post_edited(@post, current_user, before: before[:body],
+                                  after: @post.body_markdown, comment: params[:edit_comment],
+                                  before_title: before[:title], after_title: @post.title,
+                                  before_tags: before[:tags], after_tags: @post.tags)
+
           if params[:redact]
-            PostHistory.post_redacted(@post, current_user, before: before[:body],
-                                      after: @post.body_markdown, comment: params[:edit_comment],
-                                      before_title: before[:title], after_title: @post.title,
-                                      before_tags: before[:tags], after_tags: @post.tags)
+            # Hide all previous history
+            PostHistory.where(post: @post).update_all(hidden: true)
             PostHistory.history_hidden(@post, current_user, after: @post.body_markdown,
-                                       after_title: @post.title, after_tags: @post.tags)
-          else
-            PostHistory.post_edited(@post, current_user, before: before[:body],
-                                    after: @post.body_markdown, comment: params[:edit_comment],
-                                    before_title: before[:title], after_title: @post.title,
-                                    before_tags: before[:tags], after_tags: @post.tags)
+                                       after_title: @post.title, after_tags: @post.tags,
+                                       comment: 'Detailed history before this event is hidden because of a redaction.')
           end
           Rails.cache.delete "community_user/#{current_user.community_user.id}/metric/E"
           do_draft_delete(URI(request.referer || '').path)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -208,13 +208,13 @@ class UsersController < ApplicationController
                                                                     posts: { deleted: false })
             when 'edits'
               SuggestedEdit.where(user: @user) + \
-              PostHistory.joins(:post).where(user: @user, posts: { deleted: false })
+              PostHistory.joins(:post).where(user: @user, posts: { deleted: false }).visible(current_user)
             else
               Post.undeleted.where(user: @user) + \
               Comment.joins(:comment_thread, :post).undeleted.where(user: @user, comment_threads: { deleted: false },
                                                                     posts: { deleted: false }) + \
               SuggestedEdit.where(user: @user).all + \
-              PostHistory.joins(:post).where(user: @user, posts: { deleted: false })
+              PostHistory.joins(:post).where(user: @user, posts: { deleted: false }).visible(current_user)
             end
 
     @items = items.sort_by(&:created_at).reverse
@@ -249,7 +249,7 @@ class UsersController < ApplicationController
               when 'flags'
                 Flag.where(user: @user).all
               when 'edits'
-                SuggestedEdit.where(user: @user).all + PostHistory.where(user: @user).all
+                SuggestedEdit.where(user: @user).all + PostHistory.where(user: @user).visible(current_user).all
               when 'warnings'
                 ModWarning.where(community_user: @user.community_user).all
               when 'interesting'
@@ -258,7 +258,7 @@ class UsersController < ApplicationController
                   Post.where(user: @user).where('score < 0.25 OR deleted=1').all
               else
                 Post.where(user: @user).all + Comment.where(user: @user).all + Flag.where(user: @user).all + \
-                  SuggestedEdit.where(user: @user).all + PostHistory.where(user: @user).all + \
+                  SuggestedEdit.where(user: @user).all + PostHistory.where(user: @user).visible(current_user).all + \
                   ModWarning.where(community_user: @user.community_user).all
               end).sort_by(&:created_at).reverse
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -208,17 +208,13 @@ class UsersController < ApplicationController
                                                                     posts: { deleted: false })
             when 'edits'
               SuggestedEdit.where(user: @user) + \
-              PostHistory.joins(Arel.sql('INNER JOIN `posts` ON `posts`.`id` = `post_histories`.`post_id`'))
-                         .where(user: @user).where(posts: { deleted: false })
-                         .visible(current_user).all
+              PostHistory.joins(:post).where(user: @user, posts: { deleted: false })
             else
               Post.undeleted.where(user: @user) + \
               Comment.joins(:comment_thread, :post).undeleted.where(user: @user, comment_threads: { deleted: false },
                                                                     posts: { deleted: false }) + \
               SuggestedEdit.where(user: @user).all + \
-              PostHistory.joins(Arel.sql('INNER JOIN `posts` ON `posts`.`id` = `post_histories`.`post_id`'))
-                         .where(user: @user).where(posts: { deleted: false })
-                         .visible(current_user).all
+              PostHistory.joins(:post).where(user: @user, posts: { deleted: false }).all
             end
 
     @items = items.sort_by(&:created_at).reverse
@@ -253,7 +249,7 @@ class UsersController < ApplicationController
               when 'flags'
                 Flag.where(user: @user).all
               when 'edits'
-                SuggestedEdit.where(user: @user).all + PostHistory.where(user: @user).visible(current_user).all
+                SuggestedEdit.where(user: @user).all + PostHistory.where(user: @user).all
               when 'warnings'
                 ModWarning.where(community_user: @user.community_user).all
               when 'interesting'
@@ -262,7 +258,7 @@ class UsersController < ApplicationController
                   Post.where(user: @user).where('score < 0.25 OR deleted=1').all
               else
                 Post.where(user: @user).all + Comment.where(user: @user).all + Flag.where(user: @user).all + \
-                  SuggestedEdit.where(user: @user).all + PostHistory.where(user: @user).visible(current_user).all + \
+                  SuggestedEdit.where(user: @user).all + PostHistory.where(user: @user).all + \
                   ModWarning.where(community_user: @user.community_user).all
               end).sort_by(&:created_at).reverse
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -208,13 +208,17 @@ class UsersController < ApplicationController
                                                                     posts: { deleted: false })
             when 'edits'
               SuggestedEdit.where(user: @user) + \
-              PostHistory.joins(:post).where(user: @user, posts: { deleted: false }).visible(current_user)
+              PostHistory.joins(Arel.sql('INNER JOIN `posts` ON `posts`.`id` = `post_histories`.`post_id`'))
+                         .where(user: @user).where(posts: { deleted: false })
+                         .visible(current_user).all
             else
               Post.undeleted.where(user: @user) + \
               Comment.joins(:comment_thread, :post).undeleted.where(user: @user, comment_threads: { deleted: false },
                                                                     posts: { deleted: false }) + \
               SuggestedEdit.where(user: @user).all + \
-              PostHistory.joins(:post).where(user: @user, posts: { deleted: false }).visible(current_user)
+              PostHistory.joins(Arel.sql('INNER JOIN `posts` ON `posts`.`id` = `post_histories`.`post_id`'))
+                         .where(user: @user).where(posts: { deleted: false })
+                         .visible(current_user).all
             end
 
     @items = items.sort_by(&:created_at).reverse

--- a/app/models/post_history.rb
+++ b/app/models/post_history.rb
@@ -10,8 +10,9 @@ class PostHistory < ApplicationRecord
     unless user.is_admin
       max_created_at = joins(:post_history_type)
                        .where(post_history_types: { name: 'post_redacted' })
-                       .order(created_at: :desc)
-                       .first.&created_at
+                       .where.not(user: user)
+                       .maximum(:created_at)
+
       if max_created_at
         joins(:post_history_type)
           .where(created_at: max_created_at...)

--- a/app/views/post_history/post.html.erb
+++ b/app/views/post_history/post.html.erb
@@ -28,14 +28,22 @@
         <span class="js-text">copy link</span>
       <% end %>
     </summary>
-    <% if (event.before_title.present? || event.after_title.present?) && event.before_title != event.after_title %>
-      <%= render 'diff', before: event.before_title, after: event.after_title, post: @post %>
-    <% end %>
-    <% if (event.before_state.present? || event.after_state.present?) && event.before_state != event.after_state %>
-      <%= render 'diff', before: event.before_state, after: event.after_state, post: @post %>
-    <% end %>
-    <% if (event.before_tags.present? || event.after_tags.present?) && event.before_tags != event.after_tags %>
-      <%= render 'diff', before: event.before_tags, after: event.after_tags, post: @post %>
+    <% if event.allowed_to_see_details?(current_user) %>
+      <% if (event.before_title.present? || event.after_title.present?) && event.before_title != event.after_title %>
+        <%= render 'diff', before: event.before_title, after: event.after_title, post: @post %>
+      <% end %>
+      <% if (event.before_state.present? || event.after_state.present?) && event.before_state != event.after_state %>
+        <%= render 'diff', before: event.before_state, after: event.after_state, post: @post %>
+      <% end %>
+      <% if (event.before_tags.present? || event.after_tags.present?) && event.before_tags != event.after_tags %>
+        <%= render 'diff', before: event.before_tags, after: event.after_tags, post: @post %>
+      <% end %>
+    <% elsif [event.before_title, event.after_title,
+              event.before_state, event.after_state,
+              event.before_tags, event.after_tags].any?(&:present?) %>
+      <p>
+      The detailed changes of this event are hidden because of a redaction.
+      </p>
     <% end %>
   </details>
 <% end %>

--- a/app/views/post_history/post.html.erb
+++ b/app/views/post_history/post.html.erb
@@ -42,7 +42,7 @@
               event.before_state, event.after_state,
               event.before_tags, event.after_tags].any?(&:present?) %>
       <p>
-      The detailed changes of this event are hidden because of a redaction.
+        <em>The detailed changes of this event are hidden because of a redaction.</em>
       </p>
     <% end %>
   </details>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -176,6 +176,17 @@
       <%= label_tag :edit_comment, t('posts.edit_comment_label'), class: 'form-element' %>
       <%= text_field_tag :edit_comment, nil, class: 'form-element' %>
     </div>
+    <div class="form-group">
+      <div class="checkbox-setting">
+        <div class="checkbox-setting--desc">
+          <%= label_tag :redact, t('posts.redact_label'), class: 'form-element' %>
+          <span class="form-caption"><%= t('posts.redact_explanation') %></span>
+        </div>
+        <div class="checkbox-setting--value">
+          <%= check_box_tag :redact, true, false, class: 'form-checkbox-element' %>
+        </div>
+      </div>
+    </div>
   <% end %>
 
   <div class="actions">

--- a/config/locales/strings/en.posts.yml
+++ b/config/locales/strings/en.posts.yml
@@ -46,6 +46,10 @@ en:
       Requires at least one of
     edit_comment_label: >
       Edit Comment
+    redact_label: >
+      Redact
+    redact_explanation: >
+      Redact original content by hiding the previous versions from history?
     licence_label: >
       License
     unsaved_changes_confirmation: >

--- a/config/locales/strings/es.posts.yml
+++ b/config/locales/strings/es.posts.yml
@@ -46,6 +46,10 @@ es:
       Requiere al menos un/a de
     edit_comment_label: >
       Editar comentario
+    redact_label: >
+      Redactar
+    redact_explanation: >
+      Redactar el contenido original ocultando las versiones anteriores del historial
     licence_label: >
       Licencia
     unsaved_changes_confirmation: >

--- a/db/migrate/20230726143348_add_hidden_to_post_history.rb
+++ b/db/migrate/20230726143348_add_hidden_to_post_history.rb
@@ -1,0 +1,5 @@
+class AddHiddenToPostHistory < ActiveRecord::Migration[7.0]
+  def change
+    add_column :post_histories, :hidden, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_13_205236) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_26_143348) do
   create_table "abilities", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "community_id"
     t.string "name"
@@ -386,6 +386,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_13_205236) do
     t.bigint "community_id"
     t.string "before_title"
     t.string "after_title"
+    t.boolean "hidden", default: false, null: false
     t.index ["community_id"], name: "index_post_histories_on_community_id"
     t.index ["post_history_type_id"], name: "index_post_histories_on_post_history_type_id"
     t.index ["post_id"], name: "index_post_histories_on_post_type_and_post_id"

--- a/db/seeds/post_history_types.yml
+++ b/db/seeds/post_history_types.yml
@@ -1,5 +1,4 @@
 - name: post_edited
-- name: post_redacted
 - name: post_deleted
 - name: post_undeleted
 - name: question_closed

--- a/db/seeds/post_history_types.yml
+++ b/db/seeds/post_history_types.yml
@@ -1,4 +1,5 @@
 - name: post_edited
+- name: post_redacted
 - name: post_deleted
 - name: post_undeleted
 - name: question_closed
@@ -10,3 +11,4 @@
 - name: imported_from_external_source
 - name: nominated_for_promotion
 - name: promotion_removed
+- name: history_hidden


### PR DESCRIPTION
I had actually implemented this already 10 months ago for redacting full-blown answers to mandatory homework, but I did not feel like the feature would be something Codidact  could benefit from. While chatting with @superplane39 the topic came up and they indicated that the feature would actually be useful, so here it is.

UPDATE: I did completely rewrite it now.

### Details
When making an edit, you can tick a box to make that edit a redaction. If you do, it follows your edit up by a history hidden (replaces initial revision) and sets all previous history as hidden. When viewing history, details of hidden items are not shown, except if the user is the owner of the post, the person who made that history item or is an admin.

As such, all attribution is kept (as required by common licenses), but hides the diffs which could contain the redacted information.

Currently, all users who can make edits can make those edits redacting edits.
- This allows for quick responses to prevent impact of whatever info needed to be redacted.
- The potential for misuse is limited, as admins/post owners can see the history still and can then address the situation.

### Screenshots
Edit page (redaction at the bottom):
![Edit page](https://github.com/codidact/qpixel/assets/668952/c7f9f0b8-4cdd-4f7e-b11c-c7e26ffac155)

History for post owner/admin:
![History for post owner/admin](https://github.com/codidact/qpixel/assets/668952/3336236b-03d3-4cae-b566-57a0e2037740)

History for other users:
![History for other users](https://github.com/codidact/qpixel/assets/668952/4c81a65e-6386-4d88-933e-712a5c4d7cbe)


