### PR TITLE
Stop using broken query url in many places

### DIFF
--- a/app/views/admin/audit_log.html.erb
+++ b/app/views/admin/audit_log.html.erb
@@ -4,15 +4,15 @@
   <h3><%= pluralize(@logs.count, t('g.log')) %></h3>
   <div class="button-list is-gutterless">
     <% classes = 'button is-outlined is-muted' %>
-    <%= link_to t('g.age'), query_url(sort: 'age'),
+    <%= link_to t('g.age'), request.params.merge(sort: 'age'),
                 class: "#{classes} #{params[:sort] == 'age' || params[:sort].nil? ? 'is-active' : ''}" %>
-    <%= link_to t('g.type'), query_url(sort: 'type'),
+    <%= link_to t('g.type'), request.params.merge(sort: 'type'),
                 class: "#{classes} #{params[:sort] == 'type' ? 'is-active' : ''}" %>
-    <%= link_to t('g.event'), query_url(sort: 'event'),
+    <%= link_to t('g.event'), request.params.merge(sort: 'event'),
                 class: "#{classes} #{params[:sort] == 'event' ? 'is-active' : ''}" %>
-    <%= link_to t('g.related'), query_url(sort: 'related'),
+    <%= link_to t('g.related'), request.params.merge(sort: 'related'),
                 class: "#{classes} #{params[:sort] == 'related' ? 'is-active' : ''}" %>
-    <%= link_to t('g.user'), query_url(sort: 'user'),
+    <%= link_to t('g.user'), request.params.merge(sort: 'user'),
                 class: "#{classes} #{params[:sort] == 'user' ? 'is-active' : ''}" %>
   </div>
 </div>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -29,23 +29,23 @@
   </span>
       
   <div class="button-list is-gutterless has-margin-2">
-    <%= link_to 'Activity', query_url(sort: 'activity'),
+    <%= link_to 'Activity', request.params.merge(sort: 'activity'),
                 class: "button is-muted is-outlined #{(params[:sort].nil?) && !current_page?(questions_lottery_path) ||
                     params[:sort] == 'activity' ? 'is-active' : ''}",
                 title: 'most recent changes: new posts, edits, close/open, delete/undelete' %>
-    <%= link_to 'Age', query_url(sort: 'age'),
+    <%= link_to 'Age', request.params.merge(sort: 'age'),
                 class: "button is-muted is-outlined #{params[:sort] == 'age' ? 'is-active' : ''}",
                 title: 'newest posts (ignores other activity)' %>
-    <%= link_to 'Score', query_url(sort: 'score'),
+    <%= link_to 'Score', request.params.merge(sort: 'score'),
                 class: "button is-muted is-outlined #{params[:sort] == 'score' ? 'is-active' : ''}",
                 title: 'highest score first (not the same as net votes)' %>
     <% if SiteSetting['AllowContentTransfer'] %>
-      <%= link_to 'Native', query_url(sort: 'native'),
+      <%= link_to 'Native', request.params.merge(sort: 'native'),
                   class: "button is-muted is-outlined #{params[:sort] == 'native' ? 'is-active' : ''}",
                   title: 'exclude imported posts' %>
     <% end %>
     <% if @category.name == 'Q&A' %>
-      <%= link_to 'Random', query_url(sort: 'lottery'),
+      <%= link_to 'Random', request.params.merge(sort: 'lottery'),
                   class: "button is-muted is-outlined #{params[:sort] == 'lottery' ? 'is-active' : ''}",
                   title: 'random set of questions, usually older ones' %>
     <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -23,8 +23,8 @@
   <h2><%= pluralize(@post.children.where(deleted: false).count, 'answer') %></h2>
 
   <div class="button-list is-gutterless has-float-right">
-    <a href="<%= query_url(sort: 'score') %>" class="button is-muted is-outlined <%= params[:sort].nil? || params[:sort] == 'score' ? 'is-active' : '' %>">Score</a>
-    <a href="<%= query_url(sort: 'active') %>" class="button is-muted is-outlined <%= params[:sort] == 'active' ? 'is-active' : '' %>">Active</a>
+    <a href="<%= request.params.merge(sort: 'score') %>" class="button is-muted is-outlined <%= params[:sort].nil? || params[:sort] == 'score' ? 'is-active' : '' %>">Score</a>
+    <a href="<%= request.params.merge(sort: 'active') %>" class="button is-muted is-outlined <%= params[:sort] == 'active' ? 'is-active' : '' %>">Active</a>
   </div>
 
   <div class="has-clear-clear"></div>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -12,11 +12,11 @@
      <%= 'post'.pluralize(post_count) %>
     </span>
     <div class="button-list is-gutterless has-margin-2">
-      <%= link_to 'Relevance', query_url(sort: 'relevance'), class: "button is-outlined is-muted #{params[:sort] == 'relevance' || params[:sort].nil? ? 'is-active' : ''}",
+      <%= link_to 'Relevance', request.params.merge(sort: 'relevance'), class: "button is-outlined is-muted #{params[:sort] == 'relevance' || params[:sort].nil? ? 'is-active' : ''}",
                   role: 'button', 'aria-label': 'Sort by relevance' %>
-      <%= link_to 'Score', query_url(sort: 'score'), class: "button is-outlined is-muted #{params[:sort] == 'score' ? 'is-active' : ''}",
+      <%= link_to 'Score', request.params.merge(sort: 'score'), class: "button is-outlined is-muted #{params[:sort] == 'score' ? 'is-active' : ''}",
                   role: 'button', 'aria-label': 'Sort by score' %>
-      <%= link_to 'Age', query_url(sort: 'age'), class: "button is-outlined is-muted #{params[:sort] == 'age' ? 'is-active' : ''}",
+      <%= link_to 'Age', request.params.merge(sort: 'age'), class: "button is-outlined is-muted #{params[:sort] == 'age' ? 'is-active' : ''}",
                   role: 'button', 'aria-label': 'Sort by age' %>
     </div>
   </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -15,10 +15,10 @@
 <% end %>
 
 <div class="button-list is-gutterless has-margin-bottom-4">
-  <%= link_to 'Reputation', query_url(sort: 'reputation'),
+  <%= link_to 'Reputation', request.params.merge(sort: 'reputation'),
       class: "button is-muted is-outlined #{params[:sort] == 'reputation' || (params[:sort].nil? && params[:search].nil?) ? 'is-active' : ''}",
       role: 'button', 'aria-label': 'Sort by reputation' %>
-  <%= link_to 'Age', query_url(sort: 'age'), class: "button is-muted is-outlined #{params[:sort] == 'age' ? 'is-active' : ''}",
+  <%= link_to 'Age', request.params.merge(sort: 'age'), class: "button is-muted is-outlined #{params[:sort] == 'age' ? 'is-active' : ''}",
               role: 'button', 'aria-label': 'Sort by age' %>
 </div>
 

--- a/app/views/users/posts.html.erb
+++ b/app/views/users/posts.html.erb
@@ -14,9 +14,9 @@
   </span>
 
   <div class="button-list is-gutterless has-margin-2">
-    <%= link_to 'Score', query_url(sort: 'score'), class: 'button is-muted is-outlined ' + (active_search?('score') ? 'is-active' : ''),
+    <%= link_to 'Score', request.params.merge(sort: 'score'), class: 'button is-muted is-outlined ' + (active_search?('score') ? 'is-active' : ''),
                 role: 'button', 'aria-label': 'Sort by score' %>
-    <%= link_to 'Age', query_url(sort: 'age'), class: 'button is-muted is-outlined ' + (active_search?('created_at') ? 'is-active' : ''),
+    <%= link_to 'Age', request.params.merge(sort: 'age'), class: 'button is-muted is-outlined ' + (active_search?('created_at') ? 'is-active' : ''),
                 role: 'button', 'aria-label': 'Sort by age' %>
   </div>
 </div>


### PR DESCRIPTION
The way the url is laid out is in the way Rails/Rack handles by default for array fields.

The fix in this MR is to rather than try to construct the current url in full with some parameters changed/added (that is what query_url attempts to do), make use of the fact you can just pass a hash (HashMap/dictionary/JSON) with your parameters and Rails will construct a url for the current page with your given parameters in the correct format. We take `request.params`, which is the hash of parameters on the current page and merge onto that all the parameters we want to add/change (merge overrides previous bindings with new values).

Fixes #1052
Fixes #1053 