### PR TITLE
check setting for minimum title length instead of hard-coding a value

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -65,7 +65,9 @@
     </div>
     <div>
       <span class="has-float-right has-font-size-caption js-character-count-post-title hide"
-            data-max="255" data-min="15" data-display-at="0.75">
+	    data-min="<%= category&.min_title_length %>"
+	    data-max="255"
+	    data-display-at="0.75">
         <i class="fas fa-ellipsis-h js-character-count__icon"></i>
         <span class="js-character-count__count">0 / 255</span>
       </span>


### PR DESCRIPTION
We changed the server to allow changing the minimum title and body lengths, but the UI code still hard-wires those values.  This change fixes the title.  I haven't found the right invocation to fix the body yet, but either I'll figure it out soon or we should at least fix titles, which directly affect proposals (and which we marked status-completed before realizing there was this additional piece).
