### PR TITLE
Hide initial revision from profile edits section

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -196,7 +196,7 @@ class UsersController < ApplicationController
     @comments = Comment.joins(:comment_thread, :post).undeleted.where(user: @user, comment_threads: { deleted: false },
                                                                       posts: { deleted: false }).count
     @suggested_edits = SuggestedEdit.where(user: @user).count
-    @edits = PostHistory.joins(:post).where(user: @user, posts: { deleted: false }).count
+    @edits = PostHistory.joins(:post).where(user: @user, posts: { deleted: false }, post_history_type: PostHistoryType.find_by(name: 'post_edited')).count
 
     @all_edits = @suggested_edits + @edits
 
@@ -208,7 +208,7 @@ class UsersController < ApplicationController
                                                                     posts: { deleted: false })
             when 'edits'
               SuggestedEdit.where(user: @user) + \
-              PostHistory.joins(:post).where(user: @user, posts: { deleted: false })
+              PostHistory.joins(:post).where(user: @user, posts: { deleted: false }, post_history_type: PostHistoryType.find_by(name: 'post_edited'))
             else
               Post.undeleted.where(user: @user) + \
               Comment.joins(:comment_thread, :post).undeleted.where(user: @user, comment_threads: { deleted: false },

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -196,7 +196,8 @@ class UsersController < ApplicationController
     @comments = Comment.joins(:comment_thread, :post).undeleted.where(user: @user, comment_threads: { deleted: false },
                                                                       posts: { deleted: false }).count
     @suggested_edits = SuggestedEdit.where(user: @user).count
-    @edits = PostHistory.joins(:post).where(user: @user, posts: { deleted: false }, post_history_type: PostHistoryType.find_by(name: 'post_edited')).count
+    @edits = PostHistory.joins(:post).where(user: @user, posts: { deleted: false },
+                                            post_history_type: PostHistoryType.find_by(name: 'post_edited')).count
 
     @all_edits = @suggested_edits + @edits
 
@@ -208,7 +209,8 @@ class UsersController < ApplicationController
                                                                     posts: { deleted: false })
             when 'edits'
               SuggestedEdit.where(user: @user) + \
-              PostHistory.joins(:post).where(user: @user, posts: { deleted: false }, post_history_type: PostHistoryType.find_by(name: 'post_edited'))
+              PostHistory.joins(:post).where(user: @user, posts: { deleted: false },
+                                             post_history_type: PostHistoryType.find_by(name: 'post_edited'))
             else
               Post.undeleted.where(user: @user) + \
               Comment.joins(:comment_thread, :post).undeleted.where(user: @user, comment_threads: { deleted: false },

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -196,8 +196,8 @@ class UsersController < ApplicationController
     @comments = Comment.joins(:comment_thread, :post).undeleted.where(user: @user, comment_threads: { deleted: false },
                                                                       posts: { deleted: false }).count
     @suggested_edits = SuggestedEdit.where(user: @user).count
-    @edits = PostHistory.joins(:post).where(user: @user, posts: { deleted: false },
-                                            post_history_type: PostHistoryType.find_by(name: 'post_edited')).count
+    @edits = PostHistory.joins(:post, :post_history_type).where(user: @user, posts: { deleted: false },
+                                                                post_history_types: { name: 'post_edited' }).count
 
     @all_edits = @suggested_edits + @edits
 


### PR DESCRIPTION
This PR hides the initial revision of posts from the edits tab on user profiles. This change is implemented via improved conditions passed to relevant database queries.

GitHub issue linking tag: fixes #1115