### PR TITLE
Change passing of title/body length

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -16,6 +16,18 @@ module PostsHelper
   end
 
   # @param category [Category, Nil]
+  # @return [Integer] the minimum length for post bodies
+  def min_body_length(category)
+    category&.min_body_length || 30
+  end
+
+  # @param _category [Category, Nil]
+  # @return [Integer] the maximum length for post bodies
+  def max_body_length(_category)
+    30_000
+  end
+
+  # @param category [Category, Nil]
   # @return [Integer] the minimum length for post titles
   def min_title_length(category)
     category&.min_title_length || 15

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -15,6 +15,18 @@ module PostsHelper
     end
   end
 
+  # @param category [Category, Nil]
+  # @return [Integer] the minimum length for post titles
+  def min_title_length(category)
+    category&.min_title_length || 15
+  end
+
+  # @param _category [Category, Nil]
+  # @return [Integer] the maximum length for post titles
+  def max_title_length(_category)
+    [SiteSetting['MaxTitleLength'] || 255, 255].min
+  end
+
   class PostScrubber < Rails::Html::PermitScrubber
     def initialize
       super

--- a/app/models/concerns/post_validations.rb
+++ b/app/models/concerns/post_validations.rb
@@ -41,14 +41,14 @@ module PostValidations
   def stripped_minimum_body
     min_body = category.nil? ? 30 : category.min_body_length
     if (body_markdown&.gsub(/(?:^[\s\t\u2000-\u200F]+|[\s\t\u2000-\u200F]+$)/, '')&.length || 0) < min_body
-      errors.add(:body, 'must be more than 30 non-whitespace characters long')
+      errors.add(:body, "must be more than #{min_body} non-whitespace characters long")
     end
   end
 
   def stripped_minimum_title
     min_title = category.nil? ? 15 : category.min_title_length
     if (title&.gsub(/(?:^[\s\t\u2000-\u200F]+|[\s\t\u2000-\u200F]+$)/, '')&.length || 0) < min_title
-      errors.add(:title, 'must be more than 15 non-whitespace characters long')
+      errors.add(:title, "must be more than #{min_title} non-whitespace characters long")
     end
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -28,7 +28,7 @@ class Post < ApplicationRecord
 
   serialize :tags_cache, Array
 
-  validates :body, presence: true, length: { minimum: 30, maximum: 30_000 }
+  validates :body, presence: true, length: { maximum: 30_000 }
   validates :doc_slug, uniqueness: { scope: [:community_id], case_sensitive: false }, if: -> { doc_slug.present? }
   validates :title, presence: true
   validates :tags_cache, presence: true, if: -> { post_type.has_tags }

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -65,9 +65,10 @@
     </div>
     <div>
       <span class="has-float-right has-font-size-caption js-character-count-post-title hide"
-            data-max="255" data-min="15" data-display-at="0.75">
+            data-max="<%= max_title_length(category) %>" data-min="<%= min_title_length(category) %>"
+            data-display-at="0.75">
         <i class="fas fa-ellipsis-h js-character-count__icon"></i>
-        <span class="js-character-count__count">0 / 255</span>
+        <span class="js-character-count__count">0 / <%= max_title_length(category) %></span>
       </span>
     </div>
   <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -54,7 +54,8 @@
     </p>
   <% end %>
 
-  <%= render 'shared/body_field', f: f, field_name: :body_markdown, field_label: t('posts.body_label'), post: post %>
+  <%= render 'shared/body_field', f: f, field_name: :body_markdown, field_label: t('posts.body_label'), post: post,
+             min_length: min_body_length(category), max_length: max_body_length(category) %>
 
   <div class="post-preview"></div>
 

--- a/app/views/posts/_mdhint.html.erb
+++ b/app/views/posts/_mdhint.html.erb
@@ -1,9 +1,24 @@
+<%#
+  Widget displaying that we support markdown, linking to the help article. This also applies the min/max length for the
+  post body.
+
+  Variables:
+    min_length    : [Integer, Nil] optional, the minimum allowed length (default 30)
+    max_length    : [Integer, Nil] optional, the maximum allowed length (default 30_000)
+%>
+
+<%
+  # Defaults
+  min_length = (defined?(min_length) ? min_length : nil) || 30
+  max_length = (defined?(max_length) ? max_length : nil) || 30_000
+%>
+
 <div class="form-caption widget--footer js-post-field-footer">
   We <a href="/help/formatting">support Markdown</a> for posts:
   <strong>**bold**</strong>, <em>*italics*</em>, <code>`code`</code>, two newlines for paragraphs
   <span class="has-float-right has-font-size-caption js-character-count-post-body hide"
-        data-max="30000" data-min="30" data-display-at="0.75">
+        data-max="<%= max_length %>" data-min="<%= min_length %>" data-display-at="0.75">
     <i class="fas fa-ellipsis-h js-character-count__icon"></i>
-    <span class="js-character-count__count">0 / 30000</span>
+    <span class="js-character-count__count">0 / <%= max_length %></span>
   </span>
 </div>

--- a/app/views/shared/_body_field.html.erb
+++ b/app/views/shared/_body_field.html.erb
@@ -1,3 +1,18 @@
+<%#
+  Adds a markdown body form textarea.
+  Variables:
+    post          : [ApplicationRecord, Nil] the entity to which this body field belongs (a post, a tag, a user, ...)
+    field_name    : [Symbol] the name of the body field (for the given entity)
+    field_label   : [String] the label for the field
+    min_length    : [Integer, Nil] optional, the minimum allowed length
+    max_length    : [Integer, Nil] optional, the maximum allowed length
+%>
+
+<%
+  # Defaults
+  min_length = defined?(min_length) ? min_length : nil
+  max_length = defined?(max_length) ? max_length : nil
+%>
 <div class="form-group">
   <%= f.label field_name, field_label, class: "form-element" %>
   <% if block_given? %>
@@ -22,7 +37,7 @@
     <%= render 'shared/markdown_tools' %>
     <%= f.text_area field_name, **({ class: classes, rows: 15, placeholder: 'Start typing your post...' }).merge(value), 
                                 data: { character_count: ".js-character-count-post-body" } %>
-    <%= render 'posts/mdhint' %>
+    <%= render 'posts/mdhint', min_length: min_length, max_length: max_length %>
   </div>
   <%= hidden_field_tag "__html", nil, class: 'js-post-html' %>
 </div>

--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -37,7 +37,8 @@
     <%= f.text_field :username, class: 'form-element', autocomplete: 'off' %>
   </div>
 
-  <%= render 'shared/body_field', f: f, field_name: :profile_markdown, field_label: 'Profile', post: current_user %>
+  <%= render 'shared/body_field', f: f, field_name: :profile_markdown, field_label: 'Profile', post: current_user,
+             min_length: 0 %>
 
   <div class="post-preview"></div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -44,10 +44,11 @@
         <% end %>
       </p>
 
-      <% if @user.profile.nil? || @user.profile.blank? %>
+      <% effective_profile = raw(sanitize(@user.profile&.strip || '', scrubber: scrubber)) %>
+      <% if effective_profile.blank? %>
         <p class="is-lead">A quiet enigma. We don't know anything about <span dir="ltr"><%= rtl_safe_username(@user) %></span> yet.</p>
       <% else %>
-        <%= raw(sanitize(@user.profile, scrubber: scrubber)) %>
+        <%= effective_profile %>
       <% end %>
       </div>
 


### PR DESCRIPTION
Title and body of posts have customizable limits set. To deal with this (and to look ahead for future customization options), I have updated the templates where possible to use a category when passing and defined some helper methods which accept a category to determine the context specific min/max lengths (unused for maximums for now, but I think we may have it in the future).

For the body field, we actually use the same logic for non-posts as well. These do not have a category, and their min/max lengths also need not be the same.

For example, we enforce a minimum length on the user profile, while also allowing it to be completely empty. If you ever set a profile and wanted to clear it, that was impossible as an empty text field is not 30 characters long. In this PR that is also changed to now accept any length, also allowing one to clear their profile again. It also now keeps showing the "Quiet enigma" text in case the profile is effectively empty (only contains spaces, html comments, etc.)