### PR TITLE
Add caution to MSI page and hide QR code

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -58,9 +58,6 @@
           <% end %>
           <i class='fas fa-fw fa-inbox' title='Notifications'></i>
         </a>
-        <%= link_to qr_login_code_path, class: 'header--item' do %>
-          <i class="fas fa-fw fa-mobile-alt" aria-label="Mobile Sign In" title="Mobile Sign In"></i>
-        <% end %>
         <%= link_to user_path(current_user), class: 'header--item is-complex is-visible-on-mobile' do %>
           <img alt="user avatar" src="<%= avatar_url(current_user, 40) %>" class="header--item-image avatar-40">&nbsp;&nbsp;
           <span class="<%= SiteSetting['SiteHeaderIsDark'] ? 'has-color-white' : 'has-color-tertiary-600' %>"><%= current_user.reputation %></span>

--- a/app/views/users/qr_login_code.html.erb
+++ b/app/views/users/qr_login_code.html.erb
@@ -4,8 +4,20 @@
   follow the URL to log in there.
 </p>
 
-<div class="has-text-align-center">
-  <svg height="<%= @qr_code.qrcode.module_count * 4 %>" width="<%= @qr_code.qrcode.module_count * 4 %>">
-    <%= raw(@qr_code.as_svg(standalone: false, module_size: 4)) %>
-  </svg>
+<div class="notice is-warning">
+  <p><i class="fas fa-exclamation-triangle"></i> <strong>Caution</strong></p>
+  <p>
+    The QR code below, when scanned, provides immediate access to your <%= t 'platform.network_name' %> account,
+    without asking for your password again. This makes it easier to sign in on your phone, but make sure nobody's
+    looking over your shoulder! Take extra care in public places.
+  </p>
 </div>
+
+<details>
+  <summary>Show QR code</summary>
+  <div class="has-text-align-center">
+    <svg height="<%= @qr_code.qrcode.module_count * 4 %>" width="<%= @qr_code.qrcode.module_count * 4 %>">
+      <%= raw(@qr_code.as_svg(standalone: false, module_size: 4)) %>
+    </svg>
+  </div>
+</details>

--- a/config/locales/strings/en.g.yml
+++ b/config/locales/strings/en.g.yml
@@ -23,3 +23,6 @@ en:
     threshold: 'threshold'
     type: 'type'
     user: 'user'
+
+  platform:
+    network_name: 'Codidact network'


### PR DESCRIPTION
Fixes #1159

Adds a notice to the mobile sign in page and hides the QR code by default. Also removes the mobile sign in icon from the header on every page - the link remains in the user profile.