### PR TITLE
Include recovery codes

### DIFF
--- a/app/mailers/two_factor_mailer.rb
+++ b/app/mailers/two_factor_mailer.rb
@@ -16,4 +16,10 @@ class TwoFactorMailer < ApplicationMailer
     user.update(login_token: @token, login_token_expires_at: 5.minutes.from_now)
     mail to: user.email, subject: 'Your sign in link for Codidact'
   end
+
+  def backup_code
+    @user = params[:user]
+    @host = params[:host]
+    mail to: @user.email, subject: 'Your 2FA backup code for Codidact'
+  end
 end

--- a/app/views/two_factor/enable_code.html.erb
+++ b/app/views/two_factor/enable_code.html.erb
@@ -1,5 +1,16 @@
 <h1>Confirm your code</h1>
-<p>Last step: to confirm that you're all correctly set up, enter the code shown in your mobile authenticator below.</p>
+<p>
+  First, save your two-factor <strong>backup code</strong> somewhere safe. You can use it to log in and reset
+  two-factor authentication if you lose access to your app.
+</p>
+
+<div class="notice is-danger has-color-red-900">
+  <p><i class="fas fa-exclamation-triangle"></i> You will not be shown this code again once you leave this page &mdash; save it somewhere safe now.</p>
+
+  <input class="form-element" type="text" readonly value="<%= current_user.backup_2fa_code %>" />
+</div>
+
+<p>Last step: to confirm that you're all correctly set up, enter the code shown in your authenticator app below.</p>
 
 <%= form_tag two_factor_confirm_enable_path, autocomplete: 'off' do %>
   <div class="field">

--- a/app/views/two_factor_mailer/backup_code.html.erb
+++ b/app/views/two_factor_mailer/backup_code.html.erb
@@ -1,0 +1,24 @@
+<p>Hi <%= @user&.username %>,</p>
+
+<h3>Your two-factor authentication backup code</h3>
+
+<p>
+  You're receiving this email because you have two-factor authentication enabled on your Codidact network account. We've
+  recently added backup codes for every account using 2FA, so that you can still log in if you lose access to your
+  authenticator app.
+</p>
+
+<p>
+  Your backup code is shown below. Please save it somewhere safe. Please note that logging in using this backup code
+  will disable 2FA on your account so that you can reconfigure it using a new app or device &mdash; this will also
+  reset your backup code.
+</p>
+
+<p>
+  Your backup code: <strong><code><%= @user&.backup_2fa_code %></code></strong>
+</p>
+
+<p>
+  Thanks,<br/>
+  The Codidact Team
+</p>

--- a/app/views/two_factor_mailer/backup_code.text.erb
+++ b/app/views/two_factor_mailer/backup_code.text.erb
@@ -1,0 +1,17 @@
+Hi <%= @user&.username %>,
+
+Re: Your two-factor authentication backup code
+
+
+You're receiving this email because you have two-factor authentication enabled on your Codidact network account. We've
+recently added backup codes for every account using 2FA, so that you can still log in if you lose access to your
+authenticator app.
+
+Your backup code is shown below. Please save it somewhere safe. Please note that logging in using this backup code
+will disable 2FA on your account so that you can reconfigure it using a new app or device - this will also
+reset your backup code.
+
+Your backup code: <%= @user&.backup_2fa_code %>
+
+Thanks,
+The Codidact Team

--- a/db/migrate/20230803191600_add_backup_2fa_code_to_users.rb
+++ b/db/migrate/20230803191600_add_backup_2fa_code_to_users.rb
@@ -1,0 +1,5 @@
+class AddBackup2faCodeToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :backup_2fa_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_26_143348) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_03_191600) do
   create_table "abilities", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "community_id"
     t.string "name"
@@ -715,6 +715,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_26_143348) do
     t.boolean "deleted", default: false, null: false
     t.datetime "deleted_at", precision: nil
     t.bigint "deleted_by_id"
+    t.string "backup_2fa_code"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["deleted_by_id"], name: "index_users_on_deleted_by_id"
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/scripts/create_backup_2fa_codes.rb
+++ b/scripts/create_backup_2fa_codes.rb
@@ -1,0 +1,4 @@
+User.where(enabled_2fa: true).each do |user|
+  user.update(backup_2fa_code: SecureRandom.alphanumeric(24))
+  TwoFactorMailer.with(user: user, host: 'meta.codidact.com').backup_code.deliver_later
+end

--- a/test/controllers/users/sessions_controller_test.rb
+++ b/test/controllers/users/sessions_controller_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class Users::SessionsControllerTest < ActionController::TestCase
+  include Devise::Test::ControllerHelpers
+  include ApplicationHelper
+
+  test 'should sign in with 2fa backup code' do
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+    Users::SessionsController.first_factor << users(:enabled_2fa).id
+    post :verify_code, params: { uid: users(:enabled_2fa).id, code: 'M8lENyehyCvo9F9MbyTl1aOL' }
+    assert_response 302
+    assert_not_nil flash[:warning]
+    assert_not_nil current_user
+    assert_nil current_user.backup_2fa_code
+    assert_not current_user.enabled_2fa
+  end
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -111,3 +111,13 @@ deleted_profile:
   sign_in_count: 1337
   username: deleted_profile
   confirmed_at: 2020-01-01T00:00:00.000000Z
+
+enabled_2fa:
+  email: 2fa@qpixel-test.net
+  encrypted_password: '$2a$11$roUHXKxecjyQ72Qn7DWs3.9eRCCoRn176kX/UNb/xiue3aGqf7xEW'
+  sign_in_count: 1337
+  username: enabled_2fa
+  confirmed_at: 2020-01-01T00:00:00.000000Z
+  enabled_2fa: true
+  two_factor_token: WT65ANYXBB2SBR7III7IVWNJDS4PQF2T
+  backup_2fa_code: M8lENyehyCvo9F9MbyTl1aOL

--- a/test/mailers/previews/two_factor_mailer_preview.rb
+++ b/test/mailers/previews/two_factor_mailer_preview.rb
@@ -7,4 +7,8 @@ class TwoFactorMailerPreview < ActionMailer::Preview
   def login_email_preview
     TwoFactorMailer.with(user: User.last, host: 'testhost.codidact.com').login_email
   end
+
+  def backup_code_preview
+    TwoFactorMailer.with(user: User.last, host: 'testhost.codidact.com').backup_code
+  end
 end


### PR DESCRIPTION
Fixes #266 

Adds recovery codes for 2FA accounts. This instructs the user to save their recovery code before enabling 2FA.

Signing in with a recovery code disables 2FA on the account so the user can reconfigure it with a new app.

Also includes an email and script to set recovery codes on existing 2FA accounts, which can be manually run.