### PR TITLE
Add warning to hidden revisions

### DIFF
--- a/app/views/post_history/post.html.erb
+++ b/app/views/post_history/post.html.erb
@@ -29,6 +29,22 @@
       <% end %>
     </summary>
     <% if event.allowed_to_see_details?(current_user) %>
+      <% if event.hidden? %>
+        <div class="notice is-warning is-filled">
+          <p><i class="fas fa-info-circle"></i> <strong>Hidden revision</strong></p>
+          <p>
+            This revision is hidden because of a redaction. You have access to the details because
+            <% if current_user == event.user %>
+              you performed the redaction,
+            <% elsif current_user == @post.user %>
+              you are the post author,
+            <% elsif current_user&.is_admin %>
+              you are an administrator,
+            <% end %>
+            but you should not share this revision with others.
+          </p>
+        </div>
+      <% end %>
       <% if (event.before_title.present? || event.after_title.present?) && event.before_title != event.after_title %>
         <%= render 'diff', before: event.before_title, after: event.after_title, post: @post %>
       <% end %>


### PR DESCRIPTION
Simple one. Revisions hidden by redaction aren't very visible - there's only a small italic note at the top to tell you they're not visible to the public.

This adds a warning notice to hidden revisions to make it clear that the details of that revision are not public and should not be shared.