### PR TITLE
Fix DOMPurify

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -146,7 +146,6 @@ $(() => {
         const converter = window.converter;
         const unsafe_html = converter.render(text);
         const html = DOMPurify.sanitize(unsafe_html, {
-          USE_PROFILES: { html: true },
           ALLOWED_TAGS,
           ALLOWED_ATTR
         });


### PR DESCRIPTION
Resolves #724 

According to the documentation, USE_PROFILES overrides ALLOWED_TAGS and ALLOWED_ATTR and should not be used together. Basically, we weren't actually using the client sanitizer at all. This should fix basically all the preview issues.