### PR TITLE
Ensure user helper is available in subscription mailer

### DIFF
--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -1,4 +1,6 @@
 class SubscriptionMailer < ApplicationMailer
+  helper UsersHelper
+
   def subscription
     @subscription = params[:subscription]
     @questions = @subscription.questions&.includes(:user) || []


### PR DESCRIPTION
Fixes regression from 754c82a9 which broke subscription mailer.

Note that it seems that on Codidact production, the subscription emails are not working at all. This is likely because the scheduled tasks are not actually added to the server's crontab (scheduling utility), or because cron is itself not scheduled by the host OS. To add jobs to the crontab, run `bundle exec whenever --update-crontab`