### PR TITLE
Configurable email senders

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -8,7 +8,10 @@ class AdminMailer < ApplicationMailer
             "INNER JOIN community_users cu ON cu.user_id = u.id WHERE s.type = 'moderators' AND " \
             '(u.is_global_admin = 1 OR u.is_global_moderator = 1 OR cu.is_admin = 1 OR cu.is_moderator = 1)'
     emails = ActiveRecord::Base.connection.execute(query).to_a.flatten
-    mail subject: "Codidact Moderators: #{@subject}", to: 'moderators-noreply@codidact.org', bcc: emails
+    from = "#{SiteSetting['ModeratorDistributionListSenderName']} " \
+           "<#{SiteSetting['ModeratorDistributionListSenderEmail']}>"
+    to = SiteSetting['ModeratorDistributionListReceiverEmail']
+    mail subject: "Codidact Moderators: #{@subject}", to: to, from: from, bcc: emails
   end
 
   def to_all_users

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -9,6 +9,8 @@ class SubscriptionMailer < ApplicationMailer
       return
     end
 
+    # Load request community to ensure we can access the settings/posts of the correct community
+    RequestContext.community = @subscription.community
     site_name = @subscription.community.name
     subject = if @subscription.name.present?
                 "Latest questions from your '#{@subscription.name}' subscription on #{site_name}"
@@ -17,6 +19,7 @@ class SubscriptionMailer < ApplicationMailer
               end
 
     @subscription.update(last_sent_at: DateTime.now)
-    mail from: 'Codidact Subscriptions <subscriptions@codidact.com>', to: @subscription.user.email, subject: subject
+    from = "#{SiteSetting['SubscriptionSenderName']} <#{SiteSetting['SubscriptionSenderEmail']}>"
+    mail from: from, to: @subscription.user.email, subject: subject
   end
 end

--- a/app/views/admin/all_email.html.erb
+++ b/app/views/admin/all_email.html.erb
@@ -1,17 +1,24 @@
 <%= render 'posts/markdown_script' %>
 
+<div class="notice is-danger">
+  <p>
+    <i class="fas fa-exclamation-triangle"></i> Please be careful, as this tool sends a lot of emails.
+  </p>
+</div>
+
 <h1><%= t 'admin.tools.email_all' %></h1>
 <p><%= t 'admin.email_all_blurb' %></p>
 
 <%= form_with url: send_all_email_path do |f| %>
   <div class="form-group">
     <%= f.label :subject, t('g.subject').capitalize, class: 'form-element' %>
-    <%= f.text_field :subject,  class: 'form-element' %>
+    <%= f.text_field :subject,  class: 'form-element', required: true %>
   </div>
 
   <%= render 'shared/body_field', f: f, field_name: :body_markdown, field_label: t('g.body').capitalize, post: nil %>
 
   <div class="post-preview"></div>
 
-  <%= f.submit t('g.send').capitalize, class: 'button is-filled' %>
+  <%= f.submit t('g.send').capitalize, class: 'button is-filled',
+               onclick: "return confirm('Are you sure you want to send this email to all users?')" %>
 <% end %>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -30,17 +30,28 @@
     <div class="grid--cell is-4-lg is-6-md is-12-sm" data-ckb-list-item data-ckb-item-type="link">
       <div class="widget">
         <div class="widget--body">
-          <i class="fas fa-globe has-color-red-700"></i> <i class="fas fa-envelope"></i>
-          <%= link_to t('admin.tools.email_moderators'), moderator_email_path, 'data-ckb-item-link' => '' %>
+          <i class="fas fa-globe has-color-red-700"></i> <i class="fas fa-mail-bulk"></i>
+          <%= link_to t('admin.tools.post_types'), post_types_path, 'data-ckb-item-link' => '' %>
         </div>
       </div>
     </div>
 
+    <% if current_user.developer? %>
+      <div class="grid--cell is-4-lg is-6-md is-12-sm" data-ckb-list-item data-ckb-item-type="link">
+        <div class="widget">
+          <div class="widget--body">
+            <i class="fas fa-globe has-color-red-700"></i> <i class="fas fa-folder-plus"></i>
+            <%= link_to 'Email All Users', email_all_path, 'data-ckb-item-link' => '' %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+
     <div class="grid--cell is-4-lg is-6-md is-12-sm" data-ckb-list-item data-ckb-item-type="link">
       <div class="widget">
         <div class="widget--body">
-          <i class="fas fa-globe has-color-red-700"></i> <i class="fas fa-mail-bulk"></i>
-          <%= link_to t('admin.tools.post_types'), post_types_path, 'data-ckb-item-link' => '' %>
+          <i class="fas fa-globe has-color-red-700"></i> <i class="fas fa-envelope"></i>
+          <%= link_to t('admin.tools.email_moderators'), moderator_email_path, 'data-ckb-item-link' => '' %>
         </div>
       </div>
     </div>
@@ -124,17 +135,6 @@
         <div class="widget--body">
           <i class="fas fa-user-plus"></i>
           <%= link_to 'New Site', new_site_path, 'data-ckb-item-link' => '' %>
-        </div>
-      </div>
-    </div>
-  <% end %>
-
-  <% if current_user.developer? %>
-    <div class="grid--cell is-4-lg is-6-md is-12-sm" data-ckb-list-item data-ckb-item-type="link">
-      <div class="widget">
-        <div class="widget--body">
-          <i class="fas fa-folder-plus"></i>
-          <%= link_to 'Email All Users', email_all_path, 'data-ckb-item-link' => '' %>
         </div>
       </div>
     </div>

--- a/db/migrate/20230817213150_rename_site_setting_category_email_subscriptions.rb
+++ b/db/migrate/20230817213150_rename_site_setting_category_email_subscriptions.rb
@@ -1,0 +1,5 @@
+class RenameSiteSettingCategoryEmailSubscriptions < ActiveRecord::Migration[7.0]
+  def change
+    SiteSetting.where(category: 'EmailSubscriptions').update_all(category: 'Email')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_03_191600) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_17_213150) do
   create_table "abilities", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "community_id"
     t.string "name"

--- a/db/seeds/site_settings.yml
+++ b/db/seeds/site_settings.yml
@@ -178,21 +178,21 @@
 - name: InterestingSubscriptionScoreThreshold
   value: 1
   value_type: integer
-  category: EmailSubscriptions
+  category: Email
   description: >
     The minimum score a question must have to qualify for selection for the Interesting email subscription.
 
 - name: SubscriptionSenderName
   value: Codidact Subscriptions
   value_type: string
-  category: EmailSubscriptions
+  category: Email
   description: >
-    The name of the sender of subscriptions. Email clients show this as whom the email was from.
+    The name of the sender of subscription emails.
 
 - name: SubscriptionSenderEmail
   value: subscriptions@codidact.com
   value_type: string
-  category: EmailSubscriptions
+  category: Email
   description: >
     The address to send subscription emails from.
     Make sure your server is allowed to send email from this address, or your mails will not be received.

--- a/db/seeds/site_settings.yml
+++ b/db/seeds/site_settings.yml
@@ -194,7 +194,30 @@
   value_type: string
   category: EmailSubscriptions
   description: >
-    The address to send subscription emails from. Make sure your server is allowed to send email from this address, or it will land in spam.
+    The address to send subscription emails from.
+    Make sure your server is allowed to send email from this address, or your mails will not be received.
+
+- name: ModeratorDistributionListSenderName
+  value: Codidact Admins
+  value_type: string
+  category: Email
+  description: >
+    The name of the sender of the moderator distribution list.
+
+- name: ModeratorDistributionListSenderEmail
+  value: moderators-noreply@codidact.com
+  value_type: string
+  category: Email
+  description: >
+    The address to send moderator distribution list emails from.
+    Make sure your server is allowed to send email from this address, or your mails will not be received.
+
+- name: ModeratorDistributionListReceiverEmail
+  value: moderators-noreply@codidact.com
+  value_type: string
+  category: Email
+  description: >
+    The (fake) address to send moderator distribution list emails to.
 
 - name: LotteryAgeDeprecationSpeed
   value: 0.002

--- a/db/seeds/site_settings.yml
+++ b/db/seeds/site_settings.yml
@@ -182,6 +182,20 @@
   description: >
     The minimum score a question must have to qualify for selection for the Interesting email subscription.
 
+- name: SubscriptionSenderName
+  value: Codidact Subscriptions
+  value_type: string
+  category: EmailSubscriptions
+  description: >
+    The name of the sender of subscriptions. Email clients show this as whom the email was from.
+
+- name: SubscriptionSenderEmail
+  value: subscriptions@codidact.com
+  value_type: string
+  category: EmailSubscriptions
+  description: >
+    The address to send subscription emails from. Make sure your server is allowed to send email from this address, or it will land in spam.
+
 - name: LotteryAgeDeprecationSpeed
   value: 0.002
   value_type: float


### PR DESCRIPTION
Previously, all email senders were hardcoded in the source to be `@codidact.com`/`@codidact.org` email addresses. This changes those to be configurable.

- Creates configuration for all the emails QPixel can send
- Require both developer and global admin to send email to all users, rather than just developer.
- Avoid accidental send all users email by adding more warnings and confirmation
- Move buttons for email sending together in admin tools.
