### PR TITLE
Fix name of the sample .irbrc file in Docker's local-setup script

### DIFF
--- a/docker/local-setup.sh
+++ b/docker/local-setup.sh
@@ -4,4 +4,4 @@ cp ./docker/dummy.env ./docker/env
 cp ./docker/compose-env .env
 cp config/database.docker.yml config/database.yml
 cp config/storage.docker.yml config/storage.yml
-cp ./.irbrc.sample ./.irbrc
+cp ./.sample.irbrc ./.irbrc


### PR DESCRIPTION
This is a minor PR fixing incorrect naming of the sample `.irbrc` file in Docker's installation `local-setup.sh` script.