### PR TITLE
Fix not being able to edit privilege thresholds to 0 from the admin panel

### DIFF
--- a/app/assets/javascripts/privileges.js
+++ b/app/assets/javascripts/privileges.js
@@ -30,7 +30,7 @@ $(() => {
 
     const rawValue = parseFloat($input.val() || '')
 
-    const value = rawValue || rawValue === 0 ? rawValue : null;
+    const value = Number.isNaN(rawValue) ? null : rawValue;
 
     const resp = await fetch(`/admin/privileges/${name}`, {
       method: 'POST',

--- a/app/assets/javascripts/privileges.js
+++ b/app/assets/javascripts/privileges.js
@@ -28,6 +28,7 @@ $(() => {
     const name = $input.data('name');
     const type = $input.data('type');
 
+    // incorrect input values will cause rawValue to be NaN
     const rawValue = parseFloat($input.val() || '')
 
     const value = Number.isNaN(rawValue) ? null : rawValue;

--- a/app/assets/javascripts/privileges.js
+++ b/app/assets/javascripts/privileges.js
@@ -29,7 +29,7 @@ $(() => {
     const type = $input.data('type');
 
     // incorrect input values will cause rawValue to be NaN
-    const rawValue = parseFloat($input.val() || '')
+    const rawValue = parseFloat($input.val())
 
     const value = Number.isNaN(rawValue) ? null : rawValue;
 

--- a/app/assets/javascripts/privileges.js
+++ b/app/assets/javascripts/privileges.js
@@ -27,7 +27,10 @@ $(() => {
     const $input = $td.find('.js-privilege-edit');
     const name = $input.data('name');
     const type = $input.data('type');
-    const value = parseFloat($input.val() || '') || null;
+
+    const rawValue = parseFloat($input.val() || '')
+
+    const value = rawValue || rawValue === 0 ? rawValue : null;
 
     const resp = await fetch(`/admin/privileges/${name}`, {
       method: 'POST',


### PR DESCRIPTION
This PR fixes a bug with privilege thresholds not being editable to `0`. The script submitting the form used to parse the input value and short-circuit to `null` on any falsy value, resulting in `0` being interpreted as `null`.