### PR TITLE
Rework of the character count requirements display

### DIFF
--- a/app/assets/javascripts/character_count.js
+++ b/app/assets/javascripts/character_count.js
@@ -1,5 +1,9 @@
 $(() => {
-  const setIcon = (el, icon) => {
+  /**
+   * Sets the icon to show before the counter, if any
+   * @param {'fa-times'|'fa-exclamation-circle'|'fa-check'} icon name of the icon to show
+   */
+  const setCounterIcon = (el, icon) => {
     const icons = ['fa-ellipsis-h', 'fa-check', 'fa-exclamation-circle', 'fa-times'];
     el.removeClass(icons.join(' ')).addClass(icon);
   };
@@ -61,16 +65,16 @@ $(() => {
     
     if(gtnMax || ltnMin) {
       setCounterState($counter, 'error');
-      setIcon($icon, 'fa-times');
+      setCounterIcon($icon, 'fa-times');
       setSubmitButtonDisabledState($button, 'disabled');
       setInputValidationState($tgt, 'invalid');
     } else if (gteThreshold) {
       setCounterState($counter, 'warning');
-      setIcon($icon, 'fa-exclamation-circle');
+      setCounterIcon($icon, 'fa-exclamation-circle');
       setSubmitButtonDisabledState($button, 'enabled');
     } else {
       setCounterState($counter, 'default');
-      setIcon($icon, 'fa-check');
+      setCounterIcon($icon, 'fa-check');
       setSubmitButtonDisabledState($button, 'enabled');
       setInputValidationState($tgt, 'valid');
     }

--- a/app/assets/javascripts/character_count.js
+++ b/app/assets/javascripts/character_count.js
@@ -20,10 +20,13 @@ $(() => {
     el.toggleClass('failed-validation', state);
   };
 
-  const setSubmitButtonState = (el, state) => {
-    if (el) {
-      el.attr('disabled', state).toggleClass('is-muted', state);
-    }
+  /**
+   * Sets the submit button's disabled state
+   * @param {'disabled'|'enabled'} state the state to set
+   */
+  const setSubmitButtonDisabledState = (el, state) => {
+    const isDisabled = state === 'disabled';
+    el.attr('disabled', isDisabled).toggleClass('is-muted', isDisabled);
   };
 
   $(document).on('keyup change paste', '[data-character-count]', (ev) => {
@@ -47,16 +50,16 @@ $(() => {
     if(gtnMax || ltnMin) {
       setCounterState($counter, 'error');
       setIcon($icon, 'fa-times');
-      setSubmitButtonState($button, true);
+      setSubmitButtonDisabledState($button, 'disabled');
       setInputState($tgt, true);
     } else if (gteThreshold) {
       setCounterState($counter, 'warning');
       setIcon($icon, 'fa-exclamation-circle');
-      setSubmitButtonState($button, false);
+      setSubmitButtonDisabledState($button, 'enabled');
     } else {
       setCounterState($counter);
       setIcon($icon, 'fa-check');
-      setSubmitButtonState($button, false);
+      setSubmitButtonDisabledState($button, 'enabled');
       setInputState($tgt, false);
     }
 

--- a/app/assets/javascripts/character_count.js
+++ b/app/assets/javascripts/character_count.js
@@ -4,14 +4,21 @@ $(() => {
     el.removeClass(icons.join(' ')).addClass(icon);
   };
 
+  /**
+   * Sets the counter's state
+   * @param {'info'|'warning'|'error'|'default'} state 
+   */
   const setCounterState = (el, state) => {
-    if(state == 'info') {
+    if(state === 'info') {
       el.removeClass('has-color-yellow-700 has-color-red-500').addClass('has-color-primary');
-    } else if(state === 'warning') {
+    }
+    else if(state === 'warning') {
       el.removeClass('has-color-red-500 has-color-primary').addClass('has-color-yellow-700');
-    } else if(state === 'error') {
+    }
+    else if(state === 'error') {
       el.removeClass('has-color-yellow-700 has-color-primary').addClass('has-color-red-500');
-    } else {
+    }
+    else {
       el.removeClass('has-color-red-500 has-color-yellow-700 has-color-primary');
     }
   }
@@ -21,7 +28,7 @@ $(() => {
    * @param {'valid'|'invalid'} state the state to set
    */
   const setInputValidationState = (el, state) => {
-    const isInvalid = state === 'invalid'
+    const isInvalid = state === 'invalid';
     el.toggleClass('failed-validation', isInvalid);
   };
 
@@ -62,7 +69,7 @@ $(() => {
       setIcon($icon, 'fa-exclamation-circle');
       setSubmitButtonDisabledState($button, 'enabled');
     } else {
-      setCounterState($counter);
+      setCounterState($counter, 'default');
       setIcon($icon, 'fa-check');
       setSubmitButtonDisabledState($button, 'enabled');
       setInputValidationState($tgt, 'valid');

--- a/app/assets/javascripts/character_count.js
+++ b/app/assets/javascripts/character_count.js
@@ -16,8 +16,13 @@ $(() => {
     }
   }
 
-  const setInputState = (el, state) => {
-    el.toggleClass('failed-validation', state);
+  /**
+   * Sets the input's validation state
+   * @param {'valid'|'invalid'} state the state to set
+   */
+  const setInputValidationState = (el, state) => {
+    const isInvalid = state === 'invalid'
+    el.toggleClass('failed-validation', isInvalid);
   };
 
   /**
@@ -51,7 +56,7 @@ $(() => {
       setCounterState($counter, 'error');
       setIcon($icon, 'fa-times');
       setSubmitButtonDisabledState($button, 'disabled');
-      setInputState($tgt, true);
+      setInputValidationState($tgt, 'invalid');
     } else if (gteThreshold) {
       setCounterState($counter, 'warning');
       setIcon($icon, 'fa-exclamation-circle');
@@ -60,7 +65,7 @@ $(() => {
       setCounterState($counter);
       setIcon($icon, 'fa-check');
       setSubmitButtonDisabledState($button, 'enabled');
-      setInputState($tgt, false);
+      setInputValidationState($tgt, 'valid');
     }
 
     $count.text(text);

--- a/app/assets/javascripts/character_count.js
+++ b/app/assets/javascripts/character_count.js
@@ -20,13 +20,13 @@ $(() => {
    * @param {CounterState} state 
    */
   const setCounterState = (el, state) => {
-    if(state === 'info') {
+    if (state === 'info') {
       el.removeClass('has-color-yellow-700 has-color-red-500').addClass('has-color-primary');
     }
-    else if(state === 'warning') {
+    else if (state === 'warning') {
       el.removeClass('has-color-red-500 has-color-primary').addClass('has-color-yellow-700');
     }
-    else if(state === 'error') {
+    else if (state === 'error') {
       el.removeClass('has-color-yellow-700 has-color-primary').addClass('has-color-red-500');
     }
     else {
@@ -70,7 +70,7 @@ $(() => {
 
     const text = `${count} / ${ltnMin ? min : max}`;
     
-    if(gtnMax || ltnMin) {
+    if (gtnMax || ltnMin) {
       setCounterState($counter, 'error');
       setCounterIcon($icon, 'fa-times');
       setSubmitButtonDisabledState($button, 'disabled');

--- a/app/assets/javascripts/character_count.js
+++ b/app/assets/javascripts/character_count.js
@@ -1,7 +1,14 @@
 $(() => {
   /**
+   * @typedef {'fa-ellipsis-h'|'fa-times'|'fa-exclamation-circle'|'fa-check'} CounterIcon
+   * @typedef {'info'|'warning'|'error'|'default'} CounterState
+   * @typedef {'valid'|'invalid'} InputValidationState
+   * @typedef {'disabled'|'enabled'} SubmitButtonDisabledState
+   */
+
+  /**
    * Sets the icon to show before the counter, if any
-   * @param {'fa-times'|'fa-exclamation-circle'|'fa-check'} icon name of the icon to show
+   * @param {CounterIcon} icon name of the icon to show
    */
   const setCounterIcon = (el, icon) => {
     const icons = ['fa-ellipsis-h', 'fa-check', 'fa-exclamation-circle', 'fa-times'];
@@ -10,7 +17,7 @@ $(() => {
 
   /**
    * Sets the counter's state
-   * @param {'info'|'warning'|'error'|'default'} state 
+   * @param {CounterState} state 
    */
   const setCounterState = (el, state) => {
     if(state === 'info') {
@@ -29,7 +36,7 @@ $(() => {
 
   /**
    * Sets the input's validation state
-   * @param {'valid'|'invalid'} state the state to set
+   * @param {InputValidationState} state the state to set
    */
   const setInputValidationState = (el, state) => {
     const isInvalid = state === 'invalid';
@@ -38,7 +45,7 @@ $(() => {
 
   /**
    * Sets the submit button's disabled state
-   * @param {'disabled'|'enabled'} state the state to set
+   * @param {SubmitButtonDisabledState} state the state to set
    */
   const setSubmitButtonDisabledState = (el, state) => {
     const isDisabled = state === 'disabled';

--- a/app/assets/javascripts/character_count.js
+++ b/app/assets/javascripts/character_count.js
@@ -44,12 +44,6 @@ $(() => {
 
     const text = `${count} / ${ltnMin ? min : max}`;
     
-    if(!ltnMin && !gtnMax && !gteThreshold) {
-      $counter.addClass('hide');
-    } else {
-      $counter.removeClass('hide');
-    }
-
     if(gtnMax || ltnMin) {
       setCounterState($counter, 'error');
       setIcon($icon, 'fa-times');

--- a/app/assets/javascripts/character_count.js
+++ b/app/assets/javascripts/character_count.js
@@ -17,7 +17,7 @@ $(() => {
 
   /**
    * Sets the counter's state
-   * @param {CounterState} state 
+   * @param {CounterState} state the state to set
    */
   const setCounterState = (el, state) => {
     if (state === 'info') {
@@ -32,7 +32,7 @@ $(() => {
     else {
       el.removeClass('has-color-red-500 has-color-yellow-700 has-color-primary');
     }
-  }
+  };
 
   /**
    * Sets the input's validation state

--- a/app/views/comments/_new_thread_modal.html.erb
+++ b/app/views/comments/_new_thread_modal.html.erb
@@ -20,11 +20,7 @@
       <div class="form-caption">Start the thread with a comment.</div>
       <%= text_area_tag :body, '', class: 'form-element js-comment-field', required: true,
                         data: { post: post.id, thread: '-1', character_count: ".js-character-count-#{post.id}" } %>
-      <span class="has-float-right has-font-size-caption js-character-count-<%= post.id %>"
-            data-max="1000" data-min="15">
-        <i class="fas fa-ellipsis-h js-character-count__icon"></i>
-        <span class="js-character-count__count">0 / 1000</span>
-      </span>
+      <%= render 'shared/char_count', type: post.id, min: 15, max: 1000 %>
 
       <%= label_tag :title, 'Comment thread title (optional)', class: 'form-element' %>
       <span class="form-caption">
@@ -32,12 +28,7 @@
         be shown.
       </span>
       <%= text_field_tag :title, '', class: 'form-element', data: { character_count: ".js-character-count-thread-title" } %>
-
-      <span class="has-float-right has-font-size-caption js-character-count-thread-title hide"
-            data-max="255" data-min="0" data-display-at="0.75">
-        <i class="fas fa-ellipsis-h js-character-count__icon"></i>
-        <span class="js-character-count__count">0 / 255</span>
-      </span>
+      <%= render 'shared/char_count', type: 'thread-title' %>
 
       <%= submit_tag 'Create thread', class: 'button is-filled', id: "create_thread_button_#{post.id}", disabled: true %>
     <% end %>

--- a/app/views/comments/thread.html.erb
+++ b/app/views/comments/thread.html.erb
@@ -121,12 +121,8 @@
             <%= text_area_tag :content, '', class: 'form-element js-comment-field',
                               data: { thread: @comment_thread.id, post: @comment_thread.post_id,
                                       character_count: ".js-character-count-#{@post.id}" } %>
-            <span class="has-float-right has-font-size-caption js-character-count-<%= @post.id %>"
-                  data-max="1000" data-min="15">
-              <i class="fas fa-ellipsis-h js-character-count__icon"></i>
-              <span class="js-character-count__count">0 / 1000</span>
-            </span>
-            
+            <%= render 'shared/char_count', type: @post.id, min: 15, max: 1000 %>
+
             <%= submit_tag 'Add reply', class: 'button is-muted is-filled', disabled:true %>
           <% end %>
         <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -65,14 +65,9 @@
       <%= f.text_field :title, class: 'form-element post_title', data: { character_count: ".js-character-count-post-title" } %>
     </div>
     <div>
-      <span class="has-float-right has-font-size-caption js-character-count-post-title hide"
-            data-min="<%= min_title_length(category) %>"
-            data-max="<%= max_title_length(category) %>"
-            data-display-at="0.75">
-        <i class="fas fa-ellipsis-h js-character-count__icon"></i>
-        <span class="js-character-count__count">0 / <%= max_title_length(category) %></span>
-      </span>
+      <%= render 'shared/char_count', type: 'post-title', cur: post.body_markdown&.length, max: max_title_length(category), min: min_title_length(category) %>
     </div>
+
   <% end %>
 
   <% if post_type.has_tags? && category.present? %>

--- a/app/views/posts/_mdhint.html.erb
+++ b/app/views/posts/_mdhint.html.erb
@@ -16,11 +16,5 @@
 <div class="form-caption widget--footer js-post-field-footer">
   We <a href="/help/formatting">support Markdown</a> for posts:
   <strong>**bold**</strong>, <em>*italics*</em>, <code>`code`</code>, two newlines for paragraphs
-  <span class="has-float-right has-font-size-caption js-character-count-post-body hide"
-        data-min="<%= min_length %>"
-        data-max="<%= max_length %>"
-        data-display-at="0.75">
-    <i class="fas fa-ellipsis-h js-character-count__icon"></i>
-    <span class="js-character-count__count">0 / <%= max_length %></span>
-  </span>
+  <%= render 'shared/char_count', type: 'post-body', min: min_length, max: max_length %>
 </div>

--- a/app/views/shared/_char_count.html.erb
+++ b/app/views/shared/_char_count.html.erb
@@ -17,7 +17,7 @@
   threshold ||= defined?(threshold) && !threshold.nil? ? threshold.to_f : 0.75
 %>
 
-<span class="has-float-right has-font-size-caption js-character-count-<%= type %> <%= cur.between?(min, max) ? 'hide' : '' %>"
+<span class="has-float-right has-font-size-caption js-character-count-<%= type %>"
   data-max="<%= max %>"
   data-min="<%= min %>"
   data-threshold="<%= threshold %>">

--- a/app/views/shared/_char_count.html.erb
+++ b/app/views/shared/_char_count.html.erb
@@ -1,0 +1,28 @@
+<%# 
+  Reusable helper view for character count requirements.
+
+  Variables:
+    cur : current number of characters (default 0)
+    max : maximum number of characters allowed (default 255)
+    min : minimum number of characters allowed (default 0)
+    threshold : fraction of max to show the count at (default 0.75)
+    type : character count type (e.g.: post-title)
+%>
+
+<%
+  # defaults & normalization
+  cur ||= defined?(cur) && !cur.nil? ? cur.to_i : 0
+  max ||= defined?(max) && !max.nil? ? max.to_i : 255
+  min ||= defined?(min) && !min.nil? ? min.to_i : 0
+  threshold ||= defined?(threshold) && !threshold.nil? ? threshold.to_f : 0.75
+%>
+
+<span class="has-float-right has-font-size-caption js-character-count-<%= type %> <%= cur.between?(min, max) ? 'hide' : '' %>"
+  data-max="<%= max %>"
+  data-min="<%= min %>"
+  data-threshold="<%= threshold %>">
+    <i class="fas fa-ellipsis-h js-character-count__icon"></i>
+    <span class="js-character-count__count">
+      <%= cur %> / <%= cur < min ? min : max %>
+    </span>
+</span>


### PR DESCRIPTION
This PR reworks the display of character count requirements, including:
- adds a shared char_count view for reusable & configurable character counters;
- adds proper abstractions (`setCounterState`, `setInputState`, `setSubmitButtonState`) for the character_count JS handler;
- ensures character count limits are always displayed on initial load so as the user knows how many they can enter (or left to enter);
- ensures current character count is properly displayed in forms with content already set;

The following is an example of how the character count will work after the change:

[Screencast from 23.08.2023 17:19:13.webm](https://github.com/codidact/qpixel/assets/34833340/d1740a6b-de32-497d-960a-8ae8216f099b)

Closes #1145