### PR TITLE
1186 tag merge creates duplicates

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -126,64 +126,68 @@ class TagsController < ApplicationController
 
     @subordinate = Tag.find params[:merge_with_id]
 
-    AuditLog.moderator_audit event_type: 'tag_merge', related: @primary, user: current_user,
-                             comment: "#{@subordinate.name} (#{@subordinate.id}) into #{@primary.name} (#{@primary.id})"
+    Post.transaction do
+      AuditLog.moderator_audit event_type: 'tag_merge', related: @primary, user: current_user, comment:
+        "#{@subordinate.name} (#{@subordinate.id}) into #{@primary.name} (#{@primary.id})"
 
-    # Replace subordinate with primary, except when a post already has primary (to avoid giving them a duplicate tag)
-    posts_sql = 'UPDATE posts INNER JOIN posts_tags ON posts.id = posts_tags.post_id ' \
-                'SET posts.tags_cache = REPLACE(posts.tags_cache, ?, ?) ' \
-                'WHERE posts_tags.tag_id = ? ' \
-                'AND post_tags.post_id NOT IN (SELECT post_id FROM posts_tags WHERE tag_id = ?)'
-    exec_sql([posts_sql, "\n- #{@subordinate.name}\n", "\n- #{@primary.name}\n", @subordinate.id, @primary.id])
+      # Replace subordinate with primary, except when a post already has primary (to avoid giving them a duplicate tag)
+      posts_sql = 'UPDATE posts INNER JOIN posts_tags ON posts.id = posts_tags.post_id ' \
+                  'SET posts.tags_cache = REPLACE(posts.tags_cache, ?, ?) ' \
+                  'WHERE posts_tags.tag_id = ? ' \
+                  'AND post_tags.post_id NOT IN (SELECT post_id FROM posts_tags WHERE tag_id = ?)'
+      exec_sql([posts_sql, "\n- #{@subordinate.name}\n", "\n- #{@primary.name}\n", @subordinate.id, @primary.id])
 
-    # Remove the subordinate tag from posts that still have it (the ones that were excluded from our previous query)
-    posts2_sql = 'UPDATE posts INNER JOIN posts_tags ON posts.id = posts_tags.post_id ' \
-                 'SET posts.tags_cache = REPLACE(posts.tags_cache, ?, ?) ' \
-                 'WHERE posts_tags.tag_id = ?'
-    exec_sql([posts2_sql, "\n- #{@subordinate.name}\n", "\n", @subordinate.id])
+      # Remove the subordinate tag from posts that still have it (the ones that were excluded from our previous query)
+      posts2_sql = 'UPDATE posts INNER JOIN posts_tags ON posts.id = posts_tags.post_id ' \
+                   'SET posts.tags_cache = REPLACE(posts.tags_cache, ?, ?) ' \
+                   'WHERE posts_tags.tag_id = ?'
+      exec_sql([posts2_sql, "\n- #{@subordinate.name}\n", "\n", @subordinate.id])
 
-    # Break hierarchies
-    tags_sql = 'UPDATE tags SET parent_id = NULL WHERE parent_id = ?'
-    exec_sql([tags_sql, @subordinate.id])
+      # Break hierarchies
+      tags_sql = 'UPDATE tags SET parent_id = NULL WHERE parent_id = ?'
+      exec_sql([tags_sql, @subordinate.id])
 
-    # Remove references to the tag
-    sql = 'UPDATE IGNORE $TABLENAME SET tag_id = ? WHERE tag_id = ?'
-    exec_sql([sql.gsub('$TABLENAME', 'posts_tags'), @primary.id, @subordinate.id])
-    exec_sql([sql.gsub('$TABLENAME', 'categories_moderator_tags'), @primary.id, @subordinate.id])
-    exec_sql([sql.gsub('$TABLENAME', 'categories_required_tags'), @primary.id, @subordinate.id])
-    exec_sql([sql.gsub('$TABLENAME', 'categories_topic_tags'), @primary.id, @subordinate.id])
-    exec_sql([sql.gsub('$TABLENAME', 'post_history_tags'), @primary.id, @subordinate.id])
-    exec_sql([sql.gsub('$TABLENAME', 'suggested_edits_tags'), @primary.id, @subordinate.id])
-    exec_sql([sql.gsub('$TABLENAME', 'suggested_edits_before_tags'), @primary.id, @subordinate.id])
+      # Remove references to the tag
+      sql = 'UPDATE IGNORE $TABLENAME SET tag_id = ? WHERE tag_id = ?'
+      exec_sql([sql.gsub('$TABLENAME', 'posts_tags'), @primary.id, @subordinate.id])
+      exec_sql([sql.gsub('$TABLENAME', 'categories_moderator_tags'), @primary.id, @subordinate.id])
+      exec_sql([sql.gsub('$TABLENAME', 'categories_required_tags'), @primary.id, @subordinate.id])
+      exec_sql([sql.gsub('$TABLENAME', 'categories_topic_tags'), @primary.id, @subordinate.id])
+      exec_sql([sql.gsub('$TABLENAME', 'post_history_tags'), @primary.id, @subordinate.id])
+      exec_sql([sql.gsub('$TABLENAME', 'suggested_edits_tags'), @primary.id, @subordinate.id])
+      exec_sql([sql.gsub('$TABLENAME', 'suggested_edits_before_tags'), @primary.id, @subordinate.id])
 
-    # Nuke it from orbit
-    @subordinate.destroy
+      # Nuke it from orbit
+      @subordinate.destroy
+    end
 
     flash[:success] = "Merged #{@subordinate.name} into #{@primary.name}."
     redirect_to tag_path(id: @category.id, tag_id: @primary.id)
   end
 
   def nuke
-    AuditLog.admin_audit event_type: 'tag_nuke', related: @tag, user: current_user,
-                         comment: "#{@tag.name} (#{@tag.id})"
+    Post.transaction do
+      AuditLog.admin_audit event_type: 'tag_nuke', related: @tag, user: current_user,
+                           comment: "#{@tag.name} (#{@tag.id})"
 
-    tables = ['posts_tags', 'categories_moderator_tags', 'categories_required_tags', 'categories_topic_tags',
-              'post_history_tags', 'suggested_edits_tags', 'suggested_edits_before_tags']
+      tables = ['posts_tags', 'categories_moderator_tags', 'categories_required_tags', 'categories_topic_tags',
+                'post_history_tags', 'suggested_edits_tags', 'suggested_edits_before_tags']
 
-    # Remove tag from caches
-    caches_sql = 'UPDATE posts INNER JOIN posts_tags ON posts.id = posts_tags.post_id ' \
-                 'SET posts.tags_cache = REPLACE(posts.tags_cache, ?, ?) ' \
-                 'WHERE posts_tags.tag_id = ?'
-    exec_sql([caches_sql, "\n- #{@tag.name}\n", "\n", @tag.id])
+      # Remove tag from caches
+      caches_sql = 'UPDATE posts INNER JOIN posts_tags ON posts.id = posts_tags.post_id ' \
+                   'SET posts.tags_cache = REPLACE(posts.tags_cache, ?, ?) ' \
+                   'WHERE posts_tags.tag_id = ?'
+      exec_sql([caches_sql, "\n- #{@tag.name}\n", "\n", @tag.id])
 
-    # Delete all references to the tag
-    tables.each do |tbl|
-      sql = "DELETE FROM #{tbl} WHERE tag_id = ?"
-      exec_sql([sql, @tag.id])
+      # Delete all references to the tag
+      tables.each do |tbl|
+        sql = "DELETE FROM #{tbl} WHERE tag_id = ?"
+        exec_sql([sql, @tag.id])
+      end
+
+      # Nuke it
+      @tag.destroy
     end
-
-    # Nuke it
-    @tag.destroy
 
     flash[:success] = "Deleted #{@tag.name}"
     redirect_to category_tags_path(@category)

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -133,7 +133,7 @@ class TagsController < ApplicationController
     posts_sql = 'UPDATE posts INNER JOIN posts_tags ON posts.id = posts_tags.post_id ' \
                 'SET posts.tags_cache = REPLACE(posts.tags_cache, ?, ?) ' \
                 'WHERE posts_tags.tag_id = ?'
-    exec([posts_sql, "\n- #{@subordinate.name}", "\n- #{@primary.name}", @subordinate.id])
+    exec([posts_sql, "\n- #{@subordinate.name}\n", "\n- #{@primary.name}\n", @subordinate.id])
 
     # Break hierarchies
     tags_sql = 'UPDATE tags SET parent_id = NULL WHERE parent_id = ?'
@@ -167,7 +167,7 @@ class TagsController < ApplicationController
     caches_sql = 'UPDATE posts INNER JOIN posts_tags ON posts.id = posts_tags.post_id ' \
                  'SET posts.tags_cache = REPLACE(posts.tags_cache, ?, ?) ' \
                  'WHERE posts_tags.tag_id = ?'
-    exec([caches_sql, "\n- #{@tag.name}", '', @tag.id])
+    exec([caches_sql, "\n- #{@tag.name}\n", "\n", @tag.id])
 
     # Delete all references to the tag
     tables.each do |tbl|

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -133,21 +133,21 @@ class TagsController < ApplicationController
     posts_sql = 'UPDATE posts INNER JOIN posts_tags ON posts.id = posts_tags.post_id ' \
                 'SET posts.tags_cache = REPLACE(posts.tags_cache, ?, ?) ' \
                 'WHERE posts_tags.tag_id = ?'
-    exec([posts_sql, "\n- #{@subordinate.name}\n", "\n- #{@primary.name}\n", @subordinate.id])
+    exec_sql([posts_sql, "\n- #{@subordinate.name}\n", "\n- #{@primary.name}\n", @subordinate.id])
 
     # Break hierarchies
     tags_sql = 'UPDATE tags SET parent_id = NULL WHERE parent_id = ?'
-    exec([tags_sql, @subordinate.id])
+    exec_sql([tags_sql, @subordinate.id])
 
     # Remove references to the tag
     sql = 'UPDATE IGNORE $TABLENAME SET tag_id = ? WHERE tag_id = ?'
-    exec([sql.gsub('$TABLENAME', 'posts_tags'), @primary.id, @subordinate.id])
-    exec([sql.gsub('$TABLENAME', 'categories_moderator_tags'), @primary.id, @subordinate.id])
-    exec([sql.gsub('$TABLENAME', 'categories_required_tags'), @primary.id, @subordinate.id])
-    exec([sql.gsub('$TABLENAME', 'categories_topic_tags'), @primary.id, @subordinate.id])
-    exec([sql.gsub('$TABLENAME', 'post_history_tags'), @primary.id, @subordinate.id])
-    exec([sql.gsub('$TABLENAME', 'suggested_edits_tags'), @primary.id, @subordinate.id])
-    exec([sql.gsub('$TABLENAME', 'suggested_edits_before_tags'), @primary.id, @subordinate.id])
+    exec_sql([sql.gsub('$TABLENAME', 'posts_tags'), @primary.id, @subordinate.id])
+    exec_sql([sql.gsub('$TABLENAME', 'categories_moderator_tags'), @primary.id, @subordinate.id])
+    exec_sql([sql.gsub('$TABLENAME', 'categories_required_tags'), @primary.id, @subordinate.id])
+    exec_sql([sql.gsub('$TABLENAME', 'categories_topic_tags'), @primary.id, @subordinate.id])
+    exec_sql([sql.gsub('$TABLENAME', 'post_history_tags'), @primary.id, @subordinate.id])
+    exec_sql([sql.gsub('$TABLENAME', 'suggested_edits_tags'), @primary.id, @subordinate.id])
+    exec_sql([sql.gsub('$TABLENAME', 'suggested_edits_before_tags'), @primary.id, @subordinate.id])
 
     # Nuke it from orbit
     @subordinate.destroy
@@ -167,12 +167,12 @@ class TagsController < ApplicationController
     caches_sql = 'UPDATE posts INNER JOIN posts_tags ON posts.id = posts_tags.post_id ' \
                  'SET posts.tags_cache = REPLACE(posts.tags_cache, ?, ?) ' \
                  'WHERE posts_tags.tag_id = ?'
-    exec([caches_sql, "\n- #{@tag.name}\n", "\n", @tag.id])
+    exec_sql([caches_sql, "\n- #{@tag.name}\n", "\n", @tag.id])
 
     # Delete all references to the tag
     tables.each do |tbl|
       sql = "DELETE FROM #{tbl} WHERE tag_id = ?"
-      exec([sql, @tag.id])
+      exec_sql([sql, @tag.id])
     end
 
     # Nuke it
@@ -199,7 +199,7 @@ class TagsController < ApplicationController
                                 tag_synonyms_attributes: [:id, :name, :_destroy])
   end
 
-  def exec(sql_array)
+  def exec_sql(sql_array)
     ApplicationRecord.connection.execute(ActiveRecord::Base.sanitize_sql_array(sql_array))
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -134,7 +134,7 @@ class TagsController < ApplicationController
       posts_sql = 'UPDATE posts INNER JOIN posts_tags ON posts.id = posts_tags.post_id ' \
                   'SET posts.tags_cache = REPLACE(posts.tags_cache, ?, ?) ' \
                   'WHERE posts_tags.tag_id = ? ' \
-                  'AND post_tags.post_id NOT IN (SELECT post_id FROM posts_tags WHERE tag_id = ?)'
+                  'AND posts_tags.post_id NOT IN (SELECT post_id FROM posts_tags WHERE tag_id = ?)'
       exec_sql([posts_sql, "\n- #{@subordinate.name}\n", "\n- #{@primary.name}\n", @subordinate.id, @primary.id])
 
       # Remove the subordinate tag from posts that still have it (the ones that were excluded from our previous query)


### PR DESCRIPTION
# Depends on #1185

First replacement query is altered to not alter posts that have both the primary tag and subordinate tag.
Second replacement query removes the subordinate tag from posts that still have it (those not affected by the first query).

Fixes #1186