### PR TITLE
remove "needs author's attention" flag

### DIFF
--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -311,7 +311,7 @@
           <div class="widget">
             <div class="widget--header">Why does this post require moderator attention?</div>
             <% unless post.locked? %>
-              <% PostFlagType.where(post_type_id: post.post_type.id).or(PostFlagType.where(post_type_id: nil)).each do |reason| %>
+	    <% PostFlagType.where(post_type_id: [post.post_type.id, nil]).where(active: 1).each do |reason| %>
                 <div class="widget--body">
                   <div class="grid">
                     <div class="grid--cell">

--- a/db/migrate/202309141441_disable_needs_author_attention_flag.rb
+++ b/db/migrate/202309141441_disable_needs_author_attention_flag.rb
@@ -1,0 +1,9 @@
+class DisableNeedsAuthorAttentionFlag < ActiveRecord::Migration[7.0]
+  def up
+    PostFlagType.unscoped.where(name: "needs author's attention").update_all(active: false)
+  end
+
+  def down
+    PostFlagType.unscoped.where(name: "needs author's attention").update_all(active: true)
+  end
+end

--- a/db/seeds/post_flag_types.yml
+++ b/db/seeds/post_flag_types.yml
@@ -16,7 +16,7 @@
   description: >
     This question is off-topic or cannot be reasonably answered in its current form and needs revision by its author.
   confidential: false
-  active: true
+  active: false
   post_type_id: <%= Question.post_type_id %>
 
 - name: is a duplicate


### PR DESCRIPTION
Disabled needs-author-attention flag on posts, and made the flags modal pay attention to disabled flags.  I disabled instead of removing because there's no reason to destroy data -- but in the process of fixing this, I discovered that we weren't paying attention to whether flags were disabled, so fixed that too.

Because i disabled rather than nuking it from orbit, I didn't remove the special handling code that, if this flag is used, creates the comment.  Maybe other deployments want that and will want to turn this flag back on, in which case they would need that code.

Fixes https://github.com/codidact/qpixel/issues/1104 .
