### PR TITLE
Fix `wipe_everything.rb` Script to handle FK Checks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.3-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.15.3-x86_64-linux)
       racc (~> 1.4)
     omniauth (2.1.0)
@@ -386,6 +388,7 @@ GEM
     zeitwerk (2.6.11)
 
 PLATFORMS
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/scripts/wipe_everything.rb
+++ b/scripts/wipe_everything.rb
@@ -9,11 +9,15 @@ end
 
 conn = ActiveRecord::Base.connection
 leave_tables = ['ar_internal_metadata', 'schema_migrations']
+
+exec_sql 'SET FOREIGN_KEY_CHECKS = 0'
 (conn.tables - leave_tables).each do |t|
   exec_sql "DELETE FROM `#{t}`"
   exec_sql "ALTER TABLE `#{t}` AUTO_INCREMENT=1"
 end
+exec_sql 'SET FOREIGN_KEY_CHECKS = 1'
 
+Community.create(name: 'Dev Community', host: 'localhost:3000')
 Rails.cache.clear
 
-`bundle exec rails db:seed`
+`rails db:seed`


### PR DESCRIPTION
Fix for #1195 

File Changes:

- `Gemfile.lock`
  - Adds new platform `x86_64-darwin-21`
  - Adds `nokogiri` reference (same version as `linux` Platform)
- `scripts/wipe_everything.rb`
  - Adds `SET FOREIGN_KEY_CHECKS` SQL to disable FK checks during `DELETE FROM {table}` Calls (re-enables when finished)
  - Adds `Community.create(name: 'Dev Community', host: 'localhost:3000')` (from initial setup document: https://collab.codidact.org/posts/280451/280452)
  - Adjusts Seeder command (removes `bundle exec`)

Screenshots:

<img width="871" alt="Screen Shot 2023-10-03 at 4 46 06 PM" src="https://github.com/codidact/qpixel/assets/7892392/deed7801-9730-4518-8970-679d9de09a3a">

