### PR TITLE
Allow slashes in doc slugs

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,8 +158,8 @@ Rails.application.routes.draw do
     get    ':id/:answer',                  to: 'posts#show', as: :answer_post
   end
 
-  get    'policy/:slug',                   to: 'posts#document', as: :policy
-  get    'help/:slug',                     to: 'posts#document', as: :help
+  get    'policy/:slug',                   to: 'posts#document', as: :policy, constraints: { slug: /.*/ }
+  get    'help/:slug',                     to: 'posts#document', as: :help, constraints: { slug: /.*/ }
 
   get    'tags',                           to: 'tags#index', as: :tags
 


### PR DESCRIPTION
Tiny change - allows slashes in help doc slugs.