### PR TITLE
added guidance on score values

### DIFF
--- a/app/views/search/_filters.html.erb
+++ b/app/views/search/_filters.html.erb
@@ -25,10 +25,10 @@
   <% if user_signed_in? && defined? @category %>
     <%= label_tag :save_as_default, 'Is default for this category?' %>
     <%= check_box_tag :save_as_default, @category.id, false, { class: 'filter-is-default form-checkbox-element' } %>
-    <% end %>
+  <% end %>
   <div class="form-group-horizontal">
     <div class="form-group">
-      <%= label_tag :min_score, 'Min Score (8-1)', class: "form-element" %>
+      <%= label_tag :min_score, 'Min Score (0-1)', class: "form-element" %>
       <%= number_field_tag :min_score, @active_filter[:min_score],
           min: 0, max: 1, step: 0.01, class: 'form-element form--filter',
           data: { name: 'min_score' } %>

--- a/app/views/search/_filters.html.erb
+++ b/app/views/search/_filters.html.erb
@@ -25,16 +25,16 @@
   <% if user_signed_in? && defined? @category %>
     <%= label_tag :save_as_default, 'Is default for this category?' %>
     <%= check_box_tag :save_as_default, @category.id, false, { class: 'filter-is-default form-checkbox-element' } %>
-  <% end %>
+    <% end %>
   <div class="form-group-horizontal">
     <div class="form-group">
-      <%= label_tag :min_score, 'Min Score', class: "form-element" %>
+      <%= label_tag :min_score, 'Min Score (8-1)', class: "form-element" %>
       <%= number_field_tag :min_score, @active_filter[:min_score],
           min: 0, max: 1, step: 0.01, class: 'form-element form--filter',
           data: { name: 'min_score' } %>
     </div>
     <div class="form-group">
-      <%= label_tag :max_score, 'Max Score', class: "form-element" %>
+      <%= label_tag :max_score, 'Max Score (0-1)', class: "form-element" %>
       <%= number_field_tag :max_score, @active_filter[:max_score],
           min: 0, max: 1, step: 0.01, class: 'form-element form--filter',
           data: { name: 'max_score' } %>
@@ -57,6 +57,9 @@
         min: 0, step: 1, class: 'form-element form--filter',
         data: { name: 'status' } %>
     </div>
+  </div>
+  <div>
+    <a href="/help/scoring">How scores are computed</a>
   </div>
   <div class="form-group-horizontal">
     <div class="form-group">


### PR DESCRIPTION
Added a little guidance about scores after seeing [some user confusion](https://meta.codidact.com/posts/290048).

I tried to make "min score" and "max score" links, but those were clickable before and triggered the form field, and that behavior overrides the link.

I also tried to move the help link closer to the form fields, to more clearly "go with" the previous row, but couldn't figure out how.  I tried adding an extra layer of form grouping to include that row plus this link, but it laid out as one row with (now) five elements.  We have a design framework, so I don't think resorting to direct HTML hackery is the right way to go about it.  I think having the link is better than not having it, and having it in a slightly different place would be better than this.

Update: here's a screenshot:

![Min Score (0-1), Max Score (0-1), link below fields](https://github.com/codidact/qpixel/assets/5557942/ab4ddffb-0af1-4680-812c-8a33b47fe408)
