### PR TITLE
Translation files must have a top-level locale key (fixes #1210)

### DIFF
--- a/config/locales/strings/en.rate_limit.yml
+++ b/config/locales/strings/en.rate_limit.yml
@@ -1,10 +1,11 @@
-rate_limit:
-  new_user_posts: >
-    You may only post :count :level posts per day. Once you have some well-received posts, your limit will increase.
-  posts: >
-    You may only post :count :level posts per day.
-  new_user_suggested_edits: >
-    You may only suggest :count edits per day. Once you have some well-received contributions, your limit will increase.
-  suggested_edits: >
-    You may only suggest :count edits per day. Once you have enough well-received suggestions, you will earn the ability
-    to edit without review.
+en:
+  rate_limit:
+    new_user_posts: >
+      You may only post :count :level posts per day. Once you have some well-received posts, your limit will increase.
+    posts: >
+      You may only post :count :level posts per day.
+    new_user_suggested_edits: >
+      You may only suggest :count edits per day. Once you have some well-received contributions, your limit will increase.
+    suggested_edits: >
+      You may only suggest :count edits per day. Once you have enough well-received suggestions, you will earn the ability
+      to edit without review.

--- a/config/locales/strings/es.rate_limit.yml
+++ b/config/locales/strings/es.rate_limit.yml
@@ -1,10 +1,11 @@
-rate_limit:
-  new_user_posts: >
-    Usted sólo debería publicar :count :level publicaciones por día. Cuando usted haya publicado varias publicaciones bien recibidas, su límite será incrementado.
-  posts: >
-    Usted sólo debería publicar :count :level publicaciones por día.
-  new_user_suggested_edits: >
-    Usted sólo debería sugerir :count ediciones por día. Cuando usted haya propuesto varias contribuciones bien recibidas, su límite será incrementado.
-  suggested_edits: >
-    Usted sólo debería sugerir :count ediciones por día. Cuando usted haya propuesto las suficientes sugerencias bien recibidas, usted conseguirá la habilidad
-    de editar sin ser revisado.
+es:
+  rate_limit:
+    new_user_posts: >
+      Usted sólo debería publicar :count :level publicaciones por día. Cuando usted haya publicado varias publicaciones bien recibidas, su límite será incrementado.
+    posts: >
+      Usted sólo debería publicar :count :level publicaciones por día.
+    new_user_suggested_edits: >
+      Usted sólo debería sugerir :count ediciones por día. Cuando usted haya propuesto varias contribuciones bien recibidas, su límite será incrementado.
+    suggested_edits: >
+      Usted sólo debería sugerir :count ediciones por día. Cuando usted haya propuesto las suficientes sugerencias bien recibidas, usted conseguirá la habilidad
+      de editar sin ser revisado.


### PR DESCRIPTION
This minor PR fixes the issue with translation strings missing (all config YAML files for those must start with a top-level key denoting the locale, which were missing, causing the "translation missing" error to pop up).