### PR TITLE
Add score tooltips for post list vote counts

### DIFF
--- a/app/views/posts/_article_list.html.erb
+++ b/app/views/posts/_article_list.html.erb
@@ -3,7 +3,7 @@
 <% @show_category_tag = !!defined?(show_category_tag) ? show_category_tag : false %>
 <% @last_activity = !!defined?(last_activity) ? last_activity : true %>
 <div class="item-list--item <%= post.deleted ? 'deleted-content' : '' %>" data-ckb-list-item data-ckb-item-type="link">
-  <div class="item-list--number-value">
+  <div class="item-list--number-value" title="Score: <%= post.score %>">
     <div class="meter is-question-score">
       <div class="meter--bar is-<%= (post.score * 100).to_i %>%"><%= (post.score * 100).to_i %>%</div>
     </div>

--- a/app/views/posts/_list.html.erb
+++ b/app/views/posts/_list.html.erb
@@ -8,7 +8,7 @@
 
 <div class="item-list--item <%= post.deleted ? 'deleted-content' : '' %>" data-ckb-list-item data-ckb-item-type="link">
   <% if post.post_type.has_votes %>
-    <div class="item-list--number-value">
+    <div class="item-list--number-value" title="Score: <%= post.score %>">
       <div class="meter is-question-score">
         <div class="meter--bar is-<%= (post.score * 100).to_i %>%"><%= (post.score * 100).to_i %>%</div>
       </div>


### PR DESCRIPTION
Closes #1097

This PR adds a very minor fix for missing score tooltips on vote counts in post lists:

[Screencast from 23.10.2023 08:03:34.webm](https://github.com/codidact/qpixel/assets/34833340/dd600f56-d0ba-4830-a0f8-c7dc78f86ae3)
