### PR TITLE
Header buttons should have tooltips set on the outer link element

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -22,10 +22,12 @@
     </div>
     <nav class="header--menu">
       <% unless @community.is_fake %>
-        <%= link_to users_path, class: 'header--item' do %>
+        <%= link_to users_path, class: 'header--item', title: 'Open users list' do %>
           <i class="fas fa-fw fa-users"></i> Users
         <% end %>
-        <%= link_to search_path, class: 'header--item', data: { 'header-slide' => '#search-slide' } do %>
+        <%= link_to search_path, class: 'header--item', 
+                                 data: { 'header-slide' => '#search-slide' },
+                                 title: 'Show search' do %>
           <i class="fas fa-fw fa-search"></i> Search
         <% end %>
       <% end %>
@@ -33,7 +35,9 @@
       <% if user_signed_in? %>
         <% unless @community.is_fake %>
           <% if current_user.is_moderator %>
-            <%= link_to (@open_flags > 0) ? flag_queue_path : moderator_path, class: 'header--item' do %>
+            <%= link_to (@open_flags > 0) ? flag_queue_path : moderator_path, 
+                class: 'header--item',
+                title: 'Open moderator dashboard' do %>
               <i class="fas fa-fw fa-wrench"></i> Mod
               <% if @open_flags > 0 %>
                 <span class="header--alert"><%= @open_flags %></span>
@@ -43,27 +47,38 @@
         <% end %>
       <% end %>
       <% unless @community.is_fake %>
-        <%= link_to help_center_path, class: 'header--item' do %>
+        <%= link_to help_center_path, class: 'header--item', title: 'Open Help Center' do %>
           <i class="fas fa-fw fa-question-circle"></i> Help
         <% end %>
-        <%= link_to dashboard_path, class: 'header--item' do %>
-          <i class="fas fa-fw fa-th" title='Dashboard'></i>
+        <%= link_to dashboard_path, class: 'header--item', title: 'Open dashboard' do %>
+          <i class="fas fa-fw fa-th"></i>
         <% end %>
       <% end %>
       <% if user_signed_in? %>
-        <a href="#" class="header--item inbox-toggle is-visible-on-mobile" data-header-slide="#js-inbox">
+        <a href="#" class="header--item inbox-toggle is-visible-on-mobile" 
+                    data-header-slide="#js-inbox"
+                    title='Open notifications'
+                    >
           <% unread = current_user.unread_count %>
           <% if unread > 0 %>
             <span class="header--alert inbox-count"><%= unread %></span>
           <% end %>
-          <i class='fas fa-fw fa-inbox' title='Notifications'></i>
+          <i class='fas fa-fw fa-inbox'></i>
         </a>
-        <%= link_to user_path(current_user), class: 'header--item is-complex is-visible-on-mobile' do %>
+        <%= link_to user_path(current_user), class: 'header--item is-complex is-visible-on-mobile',
+                                             title: 'Manage profile' do %>
           <img alt="user avatar" src="<%= avatar_url(current_user, 40) %>" class="header--item-image avatar-40">&nbsp;&nbsp;
           <span class="<%= SiteSetting['SiteHeaderIsDark'] ? 'has-color-white' : 'has-color-tertiary-600' %>"><%= current_user.reputation %></span>
         <% end %>
       <% end %>
-      <a href="#" class="header--item is-visible-on-mobile" aria-label="Show Communities" data-header-slide="#communities-slide"><i class="far fa-fw fa-caret-square-down"></i></a>
+      <a href="#" 
+         class="header--item is-visible-on-mobile" 
+         aria-label="Show Communities" 
+         data-header-slide="#communities-slide"
+         title="Show Communities"
+         >
+          <i class="far fa-fw fa-caret-square-down"></i>
+      </a>
       <% unless user_signed_in? %>
         <div class="header--item">
           <% if devise_sign_in_enabled? %>


### PR DESCRIPTION
Closes #1044 

This PR moves title text of the header buttons to the outer anchor tag ensuring tooltips are shown not only when hovering the icons. Also adds a list of missing button titles for other header buttons.