### PR TITLE
On profile page dont mess with aspect ratio of profile picture

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -61,6 +61,7 @@
 
   img {
     width: 100%;
+    object-fit: contain;
   }
 }
 


### PR DESCRIPTION
Decided to split off this very small change from #876, as fixing that PR requires a trickier change relating to page load times.

Old (stretched out to fit):
![image](https://github.com/codidact/qpixel/assets/668952/caac1732-9b10-476d-8994-4a89007d5e08)

New (keeps aspect ratio):
![image](https://github.com/codidact/qpixel/assets/668952/fac0517e-372f-4ed4-878c-86a4845d3fa6)
