### PR TITLE
fixed typo in help seed

### DIFF
--- a/db/seeds/posts/category-permissions.html
+++ b/db/seeds/posts/category-permissions.html
@@ -19,7 +19,7 @@
 <p>For the sake of this trust level, every user with either the <a href="/abilities/edit_posts">Edit Posts</a> or the <a href="/abilities/flag_close">Vote on Hold</a> is considered "veteran".</p>
 
 <h3>5. Moderators only</h3>
-<p>Moderators, Adminis and the global variants thereof are the users that have this trust level.</p>
+<p>Moderators, Admins and the global variants thereof are the users that have this trust level.</p>
 
 <h3>6. Staff only</h3>
 <p>This trust level is only reached by users with the staff mark.</p>


### PR DESCRIPTION
One-character typo in the seed; already fixed in our live help.
