### PR TITLE
on profile page, repeat button for all posts at the top of the list

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -85,6 +85,9 @@
       <% if @posts.size == 0 %>
         <p><span dir="ltr"><%= rtl_safe_username(@user) %></span> hasn't posted anything yet.</p>
       <% else %>
+        <%= link_to user_posts_path(@user), class: "button is-muted", 'aria-label': "View all posts by #{rtl_safe_username(@user)}" do %>
+          See all &raquo;
+        <% end %>
         <div class="item-list user-profile-post-list">
           <% @posts.each do |a| %>
             <%= render 'posts/type_agnostic', post: a, show_type_tag: true, show_category_tag: true %>


### PR DESCRIPTION
On the user profile page, copies the "show all" button from the bottom of the post list to the top as well.  We could make the heading a link instead of having the button, but since it's the same operation maybe we want the same UI presentation.  I'm open to changing that, though we only want the link if there _are_ posts, so it complicates the view a little.  I tried putting a link next to or immediately below the heading instead, but it looked ugly -- maybe just a matter of spacing.

Fixes https://github.com/codidact/qpixel/issues/1106.
