### PR TITLE
add check for wiki status when deciding whether to show 'suggest edit' or 'edit'

### DIFF
--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -232,6 +232,11 @@
               <% elsif !current_user.nil? %>
                 <% if post.pending_suggested_edit? %>
                   <span class="tools--item">suggested edit pending...</span>
+		<% elsif post_type.is_freely_editable %>
+                  <%= link_to edit_post_path(post), class: 'tools--item', 'aria-label': 'Edit this post' do %>
+                    <i class="fa fa-pencil-alt"></i>
+                    Edit
+		  <% end %>
                 <% else %>
                   <%= link_to edit_post_path(post), class: 'tools--item', 'aria-label': 'Suggest edit to this post' do %>
                     <i class="fa fa-pencil-alt"></i>


### PR DESCRIPTION
https://meta.codidact.com/posts/288743

Wiki posts -- specifically, post types that are "freely editable" per the configuration -- are incorrectly showing "suggest edit" as the name of the edit action to users who do not have the Edit ability.  We were failing to check for the "freely editable" property in this case. This fixes that.

I tested this locally by creating a Wiki post type matching that used in production, creating a post as one user, and then editing it as another (regular, unprivileged) user.

I think I've got the indentation right in this code but if I've failed to follow our coding standards, please educate me.
