### PR TITLE
allow users with the edit-tags ability to create new tags from the tags list

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -2,7 +2,8 @@ class TagsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update, :rename, :merge, :select_merge]
   before_action :set_category, except: [:index]
   before_action :set_tag, only: [:show, :edit, :update, :children, :rename, :merge, :select_merge, :nuke, :nuke_warning]
-  before_action :verify_moderator, only: [:new, :create, :rename, :merge, :select_merge]
+  before_action :verify_tag_editor, only: [:new, :create]
+  before_action :verify_moderator, only: [:rename, :merge, :select_merge]
   before_action :verify_admin, only: [:nuke, :nuke_warning]
 
   def index
@@ -213,4 +214,20 @@ class TagsController < ApplicationController
   def exec_sql(sql_array)
     ApplicationRecord.connection.execute(ActiveRecord::Base.sanitize_sql_array(sql_array))
   end
+
+  def verify_tag_editor
+    if !user_signed_in? || !(current_user&.privilege?(:edit_tags) || current_user.is_moderator || current_user.is_admin)
+      respond_to do |format|
+        format.html do
+          render 'errors/not_found', layout: 'without_sidebar', status: :not_found
+        end
+        format.json do
+          render json: { status: 'failed', success: false, errors: ['not_found'] }, status: :not_found
+        end
+      end
+
+      return false
+    end
+    true
+  end    
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -216,8 +216,7 @@ class TagsController < ApplicationController
   end
 
   def verify_tag_editor
-    if !user_signed_in? ||
-       !(current_user&.privilege?(:edit_tags) || current_user&.is_moderator || current_user&.is_admin)
+    unless user_signed_in? && (current_user.privilege?(:edit_tags) || current_user.is_moderator || current_user.is_admin)
       respond_to do |format|
         format.html do
           render 'errors/not_found', layout: 'without_sidebar', status: :not_found

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -229,5 +229,5 @@ class TagsController < ApplicationController
       return false
     end
     true
-  end    
+  end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -216,7 +216,7 @@ class TagsController < ApplicationController
   end
 
   def verify_tag_editor
-    if !user_signed_in? || !(current_user&.privilege?(:edit_tags) || current_user.is_moderator || current_user.is_admin)
+    if !user_signed_in? || !(current_user&.privilege?(:edit_tags) || current_user&.is_moderator || current_user&.is_admin)
       respond_to do |format|
         format.html do
           render 'errors/not_found', layout: 'without_sidebar', status: :not_found

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -216,7 +216,8 @@ class TagsController < ApplicationController
   end
 
   def verify_tag_editor
-    if !user_signed_in? || !(current_user&.privilege?(:edit_tags) || current_user&.is_moderator || current_user&.is_admin)
+    if !user_signed_in? ||
+       !(current_user&.privilege?(:edit_tags) || current_user&.is_moderator || current_user&.is_admin)
       respond_to do |format|
         format.html do
           render 'errors/not_found', layout: 'without_sidebar', status: :not_found

--- a/app/views/tags/category.html.erb
+++ b/app/views/tags/category.html.erb
@@ -2,8 +2,8 @@
 
 <h1>Tags used in <%= @category.name %></h1>
 
-<% if current_user&.is_moderator %>
-  <%= link_to 'New', new_tag_path(id: @category.id), class: 'button is-muted is-outlined', 'aria-label': 'Create new tag' %>
+<% if current_user&.is_moderator || check_your_privilege('edit_tags') %>
+<%= link_to 'New', new_tag_path(id: @category.id), class: 'button is-muted is-outlined', 'aria-label': 'Create new tag' %>
 <% end %>
 
 <%= form_tag category_tags_path(@category), method: :get, class: 'form-inline' do %>


### PR DESCRIPTION
Currently only moderators and admins get the "new" button on the category tags page to be able to create new tags directly.  This also gives it to users with the "edit tags" ability.

Fixes https://github.com/codidact/qpixel/issues/1251 .
