### PR TITLE
make RSS feeds more obvious

### DIFF
--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -18,16 +18,16 @@
       <%= 'post'.pluralize(post_count) %> &nbsp;
     </span>
 
+    <%= link_to category_feed_path(@category, format: 'rss') do %>
+    <i class="fas fa-rss"></i> RSS
+    <% end %>
+    
     <% if current_user&.is_admin %>
     <%= link_to 'Edit Category', edit_category_path(@category) %> &nbsp;
     <% end %>
 
-    <%= link_to 'Subscribe',
-	new_subscription_path(type: 'category', qualifier: @category.id, return_to: request.path),
-	class: 'button is-outlined',
-	title: 'Get email notifications for new top-level posts' %>
   </span>
-      
+
   <div class="button-list is-gutterless has-margin-2">
     <%= link_to 'Activity', request.params.merge(sort: 'activity'),
                 class: "button is-muted is-outlined #{(params[:sort].nil?) && !current_page?(questions_lottery_path) ||

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -21,10 +21,12 @@
     <%= link_to category_feed_path(@category, format: 'rss') do %>
     <i class="fas fa-rss"></i> RSS
     <% end %>
-    
-    <% if current_user&.is_admin %>
-    <%= link_to 'Edit Category', edit_category_path(@category) %> &nbsp;
-    <% end %>
+
+    <span class="has-margin-4">
+      <% if current_user&.is_admin %>
+      <%= link_to 'Edit Category', edit_category_path(@category) %> &nbsp;
+      <% end %>
+    </span>
 
   </span>
 

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -92,10 +92,10 @@
       <div class="widget has-margin-4">
         <div class="widget--header">
           <%= link_to 'edit', subscriptions_path, class: 'widget--header-link' %>
-          Subscribe to Questions
+          Subscribe by Email
         </div>
         <div class="widget--body">
-          <p>You can subscribe to
+          <p>You can subscribe by email to
             <%= link_to 'all new questions', new_subscription_path(type: 'all', return_to: request.path) %>
             (from all categories) or to
             <%= link_to 'interesting questions', new_subscription_path(type: 'interesting', return_to: request.path) %>.</p>


### PR DESCRIPTION
Fixes https://github.com/codidact/qpixel/issues/1256.

RSS is a common subscription method, custom email subscriptions less so.  We got a question on Meta recently asking how to subscribe to content without having to sign up for email, and I realized that while we have an RSS feed, it wasn't very obvious.

The category list has a "Subscribe" button at the top, which does the same thing as the subscribe links in the sidebar.  This change replaces the button with the RSS feed link and clarifies in the sidebar that those links are for email subscriptions.

I did not remove the RSS feed link from the bottom of the category list; except for very new (or dev) sites, that's a few page-downs from the first one.  I think they both have utility; one's clear up front and the other's there for people who read to the bottom of the list and decided they like what they see enough to subscribe.

I wanted to put the RSS link in the sidebar, but the sidebar is category-agnostic.  Instead I settled for a small wording adjustment.

Screenshots:

Regular user:

![](https://github.com/codidact/qpixel/assets/5557942/0edad85f-d8db-4838-b933-06a7e2424bcd)

Admin user:

![](https://github.com/codidact/qpixel/assets/5557942/e55e7071-a49b-4fce-8316-7f49639b301b)

Sidebar widget:

![Subscribe by email](https://github.com/codidact/qpixel/assets/5557942/37ea70a4-8453-4ab7-8302-be83a13bb8ad)


