### PR TITLE
Fix character counter in tag excerpt fields

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -55,7 +55,7 @@
   <% end %>
 
   <%= render 'shared/body_field', f: f, field_name: :body_markdown, field_label: t('posts.body_label'), post: post,
-             min_length: min_body_length(category), max_length: max_body_length(category) %>
+            cur_length: post.body_markdown&.length, min_length: min_body_length(category), max_length: max_body_length(category) %>
 
   <div class="rejected-elements notice is-warning hide">
     <h3>Unsupported HTML detected</h3>

--- a/app/views/posts/_mdhint.html.erb
+++ b/app/views/posts/_mdhint.html.erb
@@ -3,12 +3,14 @@
   post body.
 
   Variables:
+    cur_length    : [Integer, Nil] optional, current character length (default 0)
     min_length    : [Integer, Nil] optional, the minimum allowed length (default 30)
     max_length    : [Integer, Nil] optional, the maximum allowed length (default 30_000)
 %>
 
 <%
   # Defaults
+  cur_length = (defined?(cur_length) ? cur_length : nil) || 0
   min_length = (defined?(min_length) ? min_length : nil) || 30
   max_length = (defined?(max_length) ? max_length : nil) || 30_000
 %>
@@ -16,5 +18,5 @@
 <div class="form-caption widget--footer js-post-field-footer">
   We <a href="/help/formatting">support Markdown</a> for posts:
   <strong>**bold**</strong>, <em>*italics*</em>, <code>`code`</code>, two newlines for paragraphs
-  <%= render 'shared/char_count', type: 'post-body', min: min_length, max: max_length %>
+  <%= render 'shared/char_count', type: 'post-body', cur: cur_length, min: min_length, max: max_length %>
 </div>

--- a/app/views/shared/_body_field.html.erb
+++ b/app/views/shared/_body_field.html.erb
@@ -10,6 +10,7 @@
 
 <%
   # Defaults
+  cur_length = defined?(cur_length) ? cur_length : nil
   min_length = defined?(min_length) ? min_length : nil
   max_length = defined?(max_length) ? max_length : nil
 %>
@@ -38,7 +39,7 @@
     <%= render 'shared/markdown_tools' %>
     <%= f.text_area field_name, **({ class: classes, rows: 15, placeholder: 'Start typing your post...' }).merge(value), 
                                 data: { character_count: ".js-character-count-post-body" } %>
-    <%= render 'posts/mdhint', min_length: min_length, max_length: max_length %>
+    <%= render 'posts/mdhint', cur_length: cur_length, min_length: min_length, max_length: max_length %>
   </div>
   <%= hidden_field_tag "__html", nil, class: 'js-post-html' %>
 </div>

--- a/app/views/tags/_form.html.erb
+++ b/app/views/tags/_form.html.erb
@@ -66,7 +66,7 @@
     <%= render 'shared/char_count', type: 'tag-excerpt', cur: @tag.excerpt&.length, min: 0, max: 600 %>
   </div>
 
-  <%= render 'shared/body_field', f: f, field_name: :wiki_markdown, field_label: 'Wiki', post: @tag do %>
+  <%= render 'shared/body_field', f: f, cur_length: @tag.wiki_markdown&.length, field_name: :wiki_markdown, field_label: 'Wiki', post: @tag do %>
     Full usage guidance and any other information you want people to know about this tag.
   <% end %>
   <div class="post-preview"></div>

--- a/app/views/tags/_form.html.erb
+++ b/app/views/tags/_form.html.erb
@@ -62,9 +62,8 @@
       Short usage guidance for this tag. Will be cut off at 120 characters in the tags list, but displayed in full on
       the tag page.
     </span>
-    <%= f.text_area :excerpt, class: 'form-element js-tag-excerpt', rows: 3 %>
-    <span class="has-float-right has-font-size-caption js-character-count"
-          data-target=".js-tag-excerpt" data-max="600">0 / 600</span>
+    <%= f.text_area :excerpt, class: 'form-element js-tag-excerpt', rows: 3, data: { character_count: '.js-character-count-tag-excerpt' } %>
+    <%= render 'shared/char_count', type: 'tag-excerpt', cur: @tag.excerpt&.length, min: 0, max: 600 %>
   </div>
 
   <%= render 'shared/body_field', f: f, field_name: :wiki_markdown, field_label: 'Wiki', post: @tag do %>

--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -34,7 +34,8 @@
   <div class="form-group has-padding-2">
     <%= f.label :username, class: "form-element" %>
     <div class="form-caption">What other people call you.</div>
-    <%= f.text_field :username, class: 'form-element', autocomplete: 'off' %>
+    <%= f.text_field :username, class: 'form-element', autocomplete: 'off', data: { character_count: '.js-character-count-user-name' } %>
+    <%= render 'shared/char_count', type: 'user-name', cur: current_user.username&.length, min: 3, max: 50 %>
   </div>
 
   <%= render 'shared/body_field', f: f, field_name: :profile_markdown, field_label: 'Profile', post: current_user,

--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -38,7 +38,7 @@
   </div>
 
   <%= render 'shared/body_field', f: f, field_name: :profile_markdown, field_label: 'Profile', post: current_user,
-             min_length: 0 %>
+            cur_length: current_user.profile_markdown&.length, min_length: 0 %>
 
   <div class="post-preview"></div>
 


### PR DESCRIPTION
Closes #1261 

- fixes character counter in tag excerpt fields;
- adds character counter to user profile name (min 3, max 50);
- fixes setting current character count when editing posts;

![Screenshot from 2023-12-01 16-38-43](https://github.com/codidact/qpixel/assets/34833340/463322b7-246e-430f-9423-f156d8da836f)
