### PR TITLE
add total pending edits to dashboard if you can see them

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -193,6 +193,10 @@ img {
   border-top: 1px solid #9daeb7;
 }
 
+.widget .widget--body .widget--body-extra {
+  margin-left: 0.75em;
+}
+
 pre {
   background: #f0f0f0;
   border: 0;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -133,7 +133,7 @@ class User < ApplicationRecord
       return false
     end
 
-    cu = community_users.find { |cu| cu.community_id == community_id && cu.id == id }
+    cu = community_users.find { |cuf| cuf.community_id == community_id && cuf.id == id }
 
     if cu.nil?
       return false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # Represents a user. Most of the User's logic is controlled by Devise and its overrides. A user, as far as the
 # application code (i.e. excluding Devise) is concerned, has many questions, answers, and votes.
 class User < ApplicationRecord
@@ -120,6 +121,30 @@ class User < ApplicationRecord
 
   def is_admin
     is_global_admin || community_user&.is_admin || false
+  end
+
+  def has_ability_on(community_id, ability_internal_id)
+    if is_admin || is_global_moderator
+      return true
+    end
+
+    ability = Ability.where(community_id: community_id).find_by internal_id: ability_internal_id
+
+    if ability.nil?
+      return false
+    end
+
+    cu = community_users.find { |cu| cu.community_id == community_id && cu.id == id }
+
+    if cu.nil?
+      return false
+    end
+
+    if cu.is_moderator || cu.privilege('mod')
+      return true
+    end
+
+    UserAbility.where(community_user_id: cu.id, ability_id: ability.id, is_suspended: false).exists?
   end
 
   def rtl_safe_username

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # Represents a user. Most of the User's logic is controlled by Devise and its overrides. A user, as far as the
 # application code (i.e. excluding Devise) is concerned, has many questions, answers, and votes.
 class User < ApplicationRecord

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # Represents a user. Most of the User's logic is controlled by Devise and its overrides. A user, as far as the
 # application code (i.e. excluding Devise) is concerned, has many questions, answers, and votes.
 class User < ApplicationRecord
@@ -125,14 +124,14 @@ class User < ApplicationRecord
 
   def has_ability_on(community_id, ability_internal_id)
     cu = community_users.joins(:community).where(communities: { id: community_id }).first
-    if is_admin || is_global_moderator || cu.is_moderator 
+    if is_admin || is_global_moderator || cu.is_moderator
       true
     else
-      UserAbility.joins(:ability).where(community_user_id: cu.id, is_suspended: false, ability: { internal_id: ability_internal_id }).exists?
+      UserAbility.joins(:ability).where(community_user_id: cu.id, is_suspended: false,
+                                        ability: { internal_id: ability_internal_id }).exists?
     end
   end
 
-  
   def rtl_safe_username
     "#{username}\u202D"
   end

--- a/app/views/application/dashboard.html.erb
+++ b/app/views/application/dashboard.html.erb
@@ -30,7 +30,15 @@
             <% end %>
           </div>
         <% end %>
-        <% if current_user&.is_global_moderator || current_user&.is_global_admin %>
+
+	<% if current_user&.has_ability_on(c.id, 'edit_posts') %>
+        <div class="widget--body h-fw-bold h-bg-tertiary-050">
+	  <% suggested_edits = SuggestedEdit.unscoped.where(community: c, active: true).count %>
+	  Pending edits: <%= suggested_edits %>
+	</div>
+	<% end %>
+
+	<% if current_user&.is_global_moderator || current_user&.is_global_admin %>
           <% open_flags = Flag.unscoped.where(community: c, status: nil).count %>
           <% resolved_flags = Flag.unscoped.where(community: c).where.not(status: nil).count %>
           <div class="widget--body h-fw-bold h-bg-tertiary-050">

--- a/app/views/application/dashboard.html.erb
+++ b/app/views/application/dashboard.html.erb
@@ -28,12 +28,12 @@
                 <span class="badge is-status" title="unread activity in category"></span>
               <% end %>
 	      <% if current_user&.has_ability_on(c.id, 'edit_posts') %>
-	      <% sug_edits = SuggestedEdit.where(post: Post.undeleted.where(category: cat), active: true).count %>
-	      <% if sug_edits != 0 %>
-	      &nbsp;&nbsp;(<%= sug_edits %> pending edits)
+	        <% sug_edits = SuggestedEdit.where(post: Post.undeleted.where(category: cat), active: true).count %>
+		<% if sug_edits != 0 %>
+		  &nbsp;&nbsp;(<a href="<%= suggested_edits_queue_path(cat) %>">
+		  <%= sug_edits %> pending <%= "edit".pluralize(sug_edits) %></a>)
+		<% end %>
 	      <% end %>
-	      <% end %>
-
 	    <% end %>
           </div>
         <% end %>

--- a/app/views/application/dashboard.html.erb
+++ b/app/views/application/dashboard.html.erb
@@ -27,16 +27,16 @@
               <% if user_signed_in? && cat.new_posts_for?(current_user) %>
                 <span class="badge is-status" title="unread activity in category"></span>
               <% end %>
-            <% end %>
+	      <% if current_user&.has_ability_on(c.id, 'edit_posts') %>
+	      <% sug_edits = SuggestedEdit.where(post: Post.undeleted.where(category: cat), active: true).count %>
+	      <% if sug_edits != 0 %>
+	      &nbsp;&nbsp;(<%= sug_edits %> pending edits)
+	      <% end %>
+	      <% end %>
+
+	    <% end %>
           </div>
         <% end %>
-
-	<% if current_user&.has_ability_on(c.id, 'edit_posts') %>
-        <div class="widget--body h-fw-bold h-bg-tertiary-050">
-	  <% suggested_edits = SuggestedEdit.unscoped.where(community: c, active: true).count %>
-	  Pending edits: <%= suggested_edits %>
-	</div>
-	<% end %>
 
 	<% if current_user&.is_global_moderator || current_user&.is_global_admin %>
           <% open_flags = Flag.unscoped.where(community: c, status: nil).count %>

--- a/app/views/application/dashboard.html.erb
+++ b/app/views/application/dashboard.html.erb
@@ -30,8 +30,9 @@
 	      <% if current_user&.has_ability_on(c.id, 'edit_posts') %>
 	        <% sug_edits = SuggestedEdit.where(post: Post.undeleted.where(category: cat), active: true).count %>
 		<% if sug_edits != 0 %>
-		  &nbsp;&nbsp;(<a href="<%= suggested_edits_queue_path(cat) %>">
-		  <%= sug_edits %> pending <%= "edit".pluralize(sug_edits) %></a>)
+		  &nbsp;
+		  <a href="<%= suggested_edits_queue_path(cat) %>">
+		  (<%= sug_edits %> pending <%= "edit".pluralize(sug_edits) %>)</a>
 		<% end %>
 	      <% end %>
 	    <% end %>

--- a/app/views/application/dashboard.html.erb
+++ b/app/views/application/dashboard.html.erb
@@ -19,6 +19,8 @@
             <% end %>
           </div>
         </div>
+
+
         <% categories.each do |cat| %>
           <% next if (cat.min_view_trust_level || -1) > (current_user&.trust_level || 0) %>
           <div class="widget--body">
@@ -27,18 +29,19 @@
               <% if user_signed_in? && cat.new_posts_for?(current_user) %>
                 <span class="badge is-status" title="unread activity in category"></span>
               <% end %>
-	      <% if current_user&.has_ability_on(c.id, 'edit_posts') %>
-	        <% sug_edits = SuggestedEdit.where(post: Post.undeleted.where(category: cat), active: true).count %>
-		<% if sug_edits != 0 %>
-		  &nbsp;
-		  <a href="<%= suggested_edits_queue_path(cat) %>">
-		  (<%= sug_edits %> pending <%= "edit".pluralize(sug_edits) %>)</a>
-		<% end %>
-	      <% end %>
-	    <% end %>
+            <% end %>
+
+            <% if current_user&.has_ability_on(c.id, 'edit_posts') %>
+              <% sug_edits = SuggestedEdit.where(post: Post.undeleted.where(category: cat), active: true).count %>
+              <% if sug_edits > 0 %>
+                <%= link_to suggested_edits_queue_path(cat), class: 'widget--body-extra' do %>
+                (<%= sug_edits %> pending <%= "edit".pluralize(sug_edits) %>)
+                <% end %>
+              <% end %>
+            <% end %>
+
           </div>
         <% end %>
-
 	<% if current_user&.is_global_moderator || current_user&.is_global_admin %>
           <% open_flags = Flag.unscoped.where(community: c, status: nil).count %>
           <% resolved_flags = Flag.unscoped.where(community: c).where.not(status: nil).count %>


### PR DESCRIPTION
meta:290471

Adds the number of pending edits to the dashboard and links, for users who can review edits.  Thanks @Oaphi for getting me started and @MoshiKoi for the clue about per-category tallies.

![screen shot](https://github.com/codidact/qpixel/assets/5557942/e495ad49-f0e5-4805-a5c4-9a3419eb530e)

