### PR TITLE
Fix broken Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.6
+FROM ruby:3.0.0
 
 # docker build -f docker/Dockerfile -t qpixel_uwsgi .
 


### PR DESCRIPTION
Simple fix for the Docker build failing due to using Ruby 2.7.6 image while the current Gem list requiring Ruby 3.0.0 and higher.