### PR TITLE
paginate the user activity view and full log

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -221,7 +221,7 @@ class UsersController < ApplicationController
               PostHistory.joins(:post).where(user: @user, posts: { deleted: false }).all
             end
 
-    @items = items.sort_by(&:created_at).reverse
+    @items = items.sort_by(&:created_at).reverse.paginate(page: params[:page], per_page: 50)
     render layout: 'without_sidebar'
   end
 
@@ -264,7 +264,7 @@ class UsersController < ApplicationController
                 Post.where(user: @user).all + Comment.where(user: @user).all + Flag.where(user: @user).all + \
                   SuggestedEdit.where(user: @user).all + PostHistory.where(user: @user).all + \
                   ModWarning.where(community_user: @user.community_user).all
-              end).sort_by(&:created_at).reverse
+              end).sort_by(&:created_at).reverse.paginate(page: params[:page], per_page: 50)
 
     render layout: 'without_sidebar'
   end

--- a/app/views/users/_activity_items.html.erb
+++ b/app/views/users/_activity_items.html.erb
@@ -100,3 +100,5 @@
     </tr>
   <% end %>
 </table>
+
+<%= will_paginate @items, renderer: BootstrapPagination::Rails %>


### PR DESCRIPTION
Fixes https://github.com/codidact/qpixel/issues/1269.

If a user has a lot of activity, loading the "activity" profile tab or the mod "full log" option took a long time and consumed a lot of memory.  This change paginates those views.
