### PR TITLE
on suggested-edits page, link to other category pages

### DIFF
--- a/app/views/suggested_edit/category_index.html.erb
+++ b/app/views/suggested_edit/category_index.html.erb
@@ -1,5 +1,5 @@
 <h1>Suggested Edits</h1>
-<p class="is-lead">This is a list of suggested edits on posts in this category.</p>
+<p class="is-lead">Suggested edits for review.</p>
 
 <% categories = Category.unscoped.where(community: @community).order(sequence: :asc, id: :asc) %>
 <% current_cat = current_category %>
@@ -20,22 +20,36 @@
 
 <% if params[:show_decided] != '1' %>
   <h3>All categories</h3>
-  <ul>
+  <table>
+    <tr>
+      <th>category</th>
+      <th>pending edits</th>
+    </tr>
   <% categories.each do |cat| %>
       <% next if (cat.min_view_trust_level || -1) > (current_user&.trust_level || 0) %>
       <% sug_edits = SuggestedEdit.where(post: Post.undeleted.where(category: cat), active: true).count %>
-      <li>
-	<%= cat.name %>
-	<% if cat == current_cat %>
-	(this page): <%= sug_edits %> pending
-	<% else %>
-	: <%= link_to suggested_edits_queue_url(cat) do %>
-	<%= sug_edits %> pending
+    <tr>
+      <td>
+      <% if cat == current_cat %>
+        <%= cat.name %>
+      <% else %>
+        <%= link_to suggested_edits_queue_url(cat) do %>
+        <%= cat.name %>
 	<% end %>
-	<% end %>
-      </li>
       <% end %>
-  </ul>
+      </td>
+      <td>
+      <% if cat == current_cat %>
+        <%= sug_edits %>
+      <% else %>
+        <%= link_to suggested_edits_queue_url(cat) do %>
+        <%= sug_edits %>
+	<% end %>
+      <% end %>
+      </td>
+    </tr>
+    <% end %>
+  </table>
 <% end %>
 
 

--- a/app/views/suggested_edit/category_index.html.erb
+++ b/app/views/suggested_edit/category_index.html.erb
@@ -1,6 +1,9 @@
 <h1>Suggested Edits</h1>
 <p class="is-lead">This is a list of suggested edits on posts in this category.</p>
 
+<% categories = Category.unscoped.where(community: @community).order(sequence: :asc, id: :asc) %>
+<% current_cat = current_category %>
+
 <div class="button-list is-gutterless">
   <%= link_to 'Pending', query_url(show_decided: 0),
               class: "button is-muted is-outlined #{params[:show_decided] != '1' ? 'is-active' : ''}" %>
@@ -14,6 +17,27 @@
     because you haven't yet earned the <%= link_to 'Edit Posts', ability_path('edit_posts') %> ability.
   </div>
 <% end %>
+
+<% if params[:show_decided] != '1' %>
+  <h3>All categories</h3>
+  <ul>
+  <% categories.each do |cat| %>
+      <% next if (cat.min_view_trust_level || -1) > (current_user&.trust_level || 0) %>
+      <% sug_edits = SuggestedEdit.where(post: Post.undeleted.where(category: cat), active: true).count %>
+      <li>
+	<%= cat.name %>
+	<% if cat == current_cat %>
+	(this page): <%= sug_edits %> pending
+	<% else %>
+	: <%= link_to suggested_edits_queue_url(cat) do %>
+	<%= sug_edits %> pending
+	<% end %>
+	<% end %>
+      </li>
+      <% end %>
+  </ul>
+<% end %>
+
 
 <% if @edits.any? %>
   <div class="widget">


### PR DESCRIPTION
Fixes https://github.com/codidact/qpixel/issues/1279.

Increase visibility of pending edits in other categories by cross-referencing the per-category pages.  The new list shows up when you're looking at the "pending" tab (default) but not the "decided" tab; I don't see much value in xrefs in the latter case, particularly when you had to click through the view with the xrefs to get to "decided".

New table below buttons and above the list of edits:

![screen shot](https://github.com/codidact/qpixel/assets/5557942/fee053e2-7d19-4c50-a9ca-19422a10f622)

The table includes the current category (because the count is useful), but it's not a link because that's this page.

"Decided" view is unchanged:

![screen shot](https://github.com/codidact/qpixel/assets/5557942/80b82655-ce8d-4560-86bc-151c9cf28c54)

Also adjusted the top-level text since it's not just suggestions for this category any more.
