### PR TITLE
changes the hard-coded min length for custom flags

### DIFF
--- a/app/assets/javascripts/flags.js
+++ b/app/assets/javascripts/flags.js
@@ -30,7 +30,7 @@ $(() => {
 
     if (requiresDetails && data['reason'].length < 1) {
       QPixel.createNotification('danger',
-                                'Details are required for this flag type - please enter at least a few characters.');
+                                'Details are required for this flag type - please enter a message.');
       return;
     }
 

--- a/app/assets/javascripts/flags.js
+++ b/app/assets/javascripts/flags.js
@@ -28,9 +28,9 @@ $(() => {
       'reason': $(`#flag-post-${postId}`).val()
     };
 
-    if (requiresDetails && data['reason'].length < 15) {
+    if (requiresDetails && data['reason'].length < 1) {
       QPixel.createNotification('danger',
-                                'Details are required for this flag type - please enter at least 15 characters.');
+                                'Details are required for this flag type - please enter at least a few characters.');
       return;
     }
 


### PR DESCRIPTION
Fixes https://github.com/codidact/qpixel/issues/1103

Lowers the hard-coded limit for custom flags from 15 characters to 1 (i.e. you still need to say something, but if you can convey it in 10 characters or 5 or whatever, why require more?).  Someday maybe it should be configurable but this will do for now and mods can decline garbage flags if people misuse it.
