### PR TITLE
fixed bug where comment flags caused an error for the full (mod) activity log

### DIFF
--- a/app/views/users/_activity_items.html.erb
+++ b/app/views/users/_activity_items.html.erb
@@ -78,7 +78,11 @@
           Flag
         </td>
         <td>
+	  <% if i.post_type == 'Post' %>
           <%= link_to "Post #" + i.post.id.to_s, generic_share_link(i.post)%>
+	  <% elsif i.post_type == 'Comment' %>
+	  <%= link_to "Comment thread: " + i.post.comment_thread.title, comment_link(i.post) %>
+	  <% end %>
         </td>
         <td class="h-fs-caption">
           <%= i.reason[0..300] + ((i.reason.length > 300) ? "..." : "") %><br>


### PR DESCRIPTION
Now instead of a 500 you get this if the user has comment flags:

![comment link entry for flag](https://github.com/codidact/qpixel/assets/5557942/8e3004f5-6ed6-4cc3-9861-e5334e0195b2)
