### PR TITLE
Add a MathJax button

### DIFF
--- a/app/assets/javascripts/markdown.js
+++ b/app/assets/javascripts/markdown.js
@@ -30,7 +30,8 @@ $(() => {
       numbered: ['\n 1. ', null],
       heading: ['\n# ', null],
       hr: ['\n\n-----\n\n', null],
-      table: ['\n\n| Title1 | Title2 |\n|- | - |\n| row1_1 | row1_2 |\n\n', null]
+      table: ['\n\n| Title1 | Title2 |\n|- | - |\n| row1_1 | row1_2 |\n\n', null],
+      mathjax: ['$', '$']
     };
 
     if (Object.keys(actions).indexOf(action) !== -1) {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,8 @@
   <%= render 'layouts/head' %>
 </head>
 <body class="<%= Rails.env.development? ? 'development' : '' %>"
-      data-user-id="<%= user_signed_in? ? current_user.id : 'none' %>" >
+      data-user-id="<%= user_signed_in? ? current_user.id : 'none' %>"
+      data-mathjax="<%= SiteSetting['MathJaxEnabled'] %>">
   <%= render 'layouts/header' %>
 
   <main class="container">

--- a/app/views/shared/_markdown_tools.html.erb
+++ b/app/views/shared/_markdown_tools.html.erb
@@ -32,6 +32,11 @@
     <%= md_button action: 'code', label: 'Monospace font', class: 'is-icon-only' do %>
       <i class="fas fa-fw fa-code"></i>
     <% end %>
+    <% if SiteSetting['MathJaxEnabled'] %>
+      <%= md_button action: 'mathjax', label: 'MathJax', class: 'is-icon-only' do %>
+        $
+      <% end %>
+    <% end %>
   </div>
 
   <div class="button-list is-gutterless">


### PR DESCRIPTION
Adds a MathJax button to the Markdown editor on communities where MathJax is enabled.

Fixes #1266. 