### PR TITLE
"draft saved" positioning fix

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -93,6 +93,13 @@ $(() => {
     tags: true
   });
 
+  /**
+   * Attempts to save a draft with a given body
+   * @param {string} postText draft text
+   * @param {JQuery<Element>} $field body input element
+   * @param {boolean} [manual] whether manual draft saving is enabled
+   * @returns {Promise<void>}
+   */
   const saveDraft = async (postText, $field, manual = false) => {
     const autosavePref = await QPixel.preference('autosave', true);
     if (autosavePref !== 'on' && !manual) {
@@ -111,10 +118,15 @@ $(() => {
         path: location.pathname
       })
     });
+
     if (resp.status === 200) {
-      const $el = $(`<span>&middot; <span class="has-color-green-600">draft saved</span></span>`);
-      $field.parents('.widget').find('.js-post-field-footer').append($el);
-      $el.fadeOut(1500, function () { $(this).remove() });
+      const $statusEl = $field.parents('.widget').find('.js-post-draft-status');
+
+      $statusEl.removeClass('transparent');
+
+      setTimeout(() => {
+        $statusEl.addClass('transparent');
+      }, 1500);
     }
   };
 

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -89,7 +89,25 @@ h1 .badge.is-tag.is-master-tag {
   width: calc(100% + 2px);
 
   + .widget--footer {
-    margin-bottom: 0;
+    border-top: none;
+    align-items: center;
+    margin: 0;
+
+    &.mdhint {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1em 0;
+      justify-content: space-between;
+
+      & > * {
+        padding: 0;
+      }
+    }
+
+    & > .draft-status {
+      text-align: center;
+      transition: opacity 0.5s ease-in-out;
+    }
   }
 }
 

--- a/app/assets/stylesheets/utilities.scss
+++ b/app/assets/stylesheets/utilities.scss
@@ -285,3 +285,7 @@ span.spoiler {
 .clearfix {
   overflow: hidden;
 }
+
+.transparent {
+  opacity: 0;
+}

--- a/app/views/posts/_mdhint.html.erb
+++ b/app/views/posts/_mdhint.html.erb
@@ -15,8 +15,11 @@
   max_length = (defined?(max_length) ? max_length : nil) || 30_000
 %>
 
-<div class="form-caption widget--footer js-post-field-footer">
-  We <a href="/help/formatting">support Markdown</a> for posts:
-  <strong>**bold**</strong>, <em>*italics*</em>, <code>`code`</code>, two newlines for paragraphs
-  <%= render 'shared/char_count', type: 'post-body', cur: cur_length, min: min_length, max: max_length %>
+<div class="mdhint form-caption widget--footer js-post-field-footer">
+  <span>Markdown <a href="/help/formatting">support</a> for posts:
+  <strong>**bold**</strong>, <em>*italics*</em>, <code>`code`</code>, 2 newlines for paragraphs</span>
+  <span class="draft-status transparent has-color-green-600 js-post-draft-status">draft saved</span>
+  <div class="clearfix">
+    <%= render 'shared/char_count', type: 'post-body', cur: cur_length, min: min_length, max: max_length %>
+  </div>
 </div>

--- a/app/views/shared/_body_field.html.erb
+++ b/app/views/shared/_body_field.html.erb
@@ -39,7 +39,9 @@
     <%= render 'shared/markdown_tools' %>
     <%= f.text_area field_name, **({ class: classes, rows: 15, placeholder: 'Start typing your post...' }).merge(value), 
                                 data: { character_count: ".js-character-count-post-body" } %>
-    <%= render 'posts/mdhint', cur_length: cur_length, min_length: min_length, max_length: max_length %>
+    <%= render 'posts/mdhint', cur_length: value[:value]&.length || cur_length, 
+                               min_length: min_length, 
+                               max_length: max_length %>
   </div>
   <%= hidden_field_tag "__html", nil, class: 'js-post-html' %>
 </div>


### PR DESCRIPTION
Closes #1272

Normal view:

![Screenshot from 2024-01-11 12-21-23](https://github.com/codidact/qpixel/assets/34833340/5735730b-4eab-42ab-971c-0b901c048617)

Before responsive adjustments kick in:

![Screenshot from 2024-01-11 12-34-51](https://github.com/codidact/qpixel/assets/34833340/1caa1528-940b-4c86-817c-b205f3ce748e)

After responsive adjustments kick in:

![Screenshot from 2024-01-11 12-36-00](https://github.com/codidact/qpixel/assets/34833340/14e1f6c5-d8cb-4b93-b6e7-a1757b4d8941)

Also fixes character count initialization for posts with saved drafts