### PR TITLE
help center guidance

### DIFF
--- a/app/views/posts/help_center.html.erb
+++ b/app/views/posts/help_center.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Help Center' %>
 
 <h1>Help Center</h1>
-
+<p>Community moderators can edit, reorganize, and create topics in the Help section. Topics in the Policy section are managed by the network administrators.</p>
 <div class="grid">
   <div class="grid--cell is-6 is-12-sm">
     <h2>Help</h2>


### PR DESCRIPTION
In response to https://meta.codidact.com/posts/289743, added a small hint to the Help Center page that mods can edit help (not policy).  If users can see that, they'll know they can ask mods for changes, start meta discussions, etc.

Text-only change on one HTML page.
