### PR TITLE
paginate handled flags

### DIFF
--- a/app/views/flags/handled.html.erb
+++ b/app/views/flags/handled.html.erb
@@ -14,3 +14,5 @@
 <% @flags.each do |flag| %>
   <%= render 'handled', flag: flag %>
 <% end %>
+
+<%= will_paginate @flags, renderer: BootstrapPagination::Rails %>


### PR DESCRIPTION
I noticed that the (moderator) page of handled flags was getting a little sluggish on our most flag-heavy site.  This one-liner adds pagination.  The pages for pending flags and user flag history were already paginated.  I couldn't find where the list of escalations is produced.  We should check that at some point, but having enough pending escalations to slow down page load also feels like a very rare case.

Proof of pagination (hey, when you need to manufacture 50+ flags to test, the reasons get a little, uh, minimal):

![Screenshot](https://github.com/codidact/qpixel/assets/5557942/96f9983e-843e-4403-84af-3bca4748dff7)
