### PR TITLE
text-only change: add a hint to the escalations page for admins

### DIFF
--- a/app/views/flags/_flag.html.erb
+++ b/app/views/flags/_flag.html.erb
@@ -30,6 +30,9 @@
         <strong>Escalation reason</strong>: <%= flag.escalation_comment %> &mdash;
         <%= user_link flag.escalated_by %> <%= flag.escalated_at.iso8601 %>
       </p>
+      <p>
+	<strong>Attention</strong>: The reply to the flag will be shown to the flagger, not the mod escalating this flag. Do not share sensitive, mod-only information.
+      </p>
     </div>
   <% end %>
   <% if controls %>


### PR DESCRIPTION
Adds an explicit notice that the response goes to the flagger, not the escalating mod, to handle a rare but potentially unfortunate case.  Note that the bug was filed by a global admin and I, as another global admin, have almost made this mistake too.  Adding a little extra guidance to a rarely-used page seems like a good idea.

Fixes https://github.com/codidact/qpixel/issues/742.