### PR TITLE
Rewording to specify that editing follows the goals of the post, not the poster

### DIFF
--- a/db/seeds/abilities/edit_posts.html
+++ b/db/seeds/abilities/edit_posts.html
@@ -6,4 +6,4 @@
 <img src="/assets/ability-help/edit-link.png" alt="Edit post button">
 
 <h2>How do I earn this ability?</h2>
-<p>To earn this ability, you need to have at least a 95% approval rate for your suggested edits, with a hard minimum of 30 approved suggested edits (these numbers may vary from site to site).</p>
+<p>To earn this ability, you need to have at least a 95% approval rate for your suggested edits, with a hard minimum of 30 approved suggested edits (these numbers may vary from community to community).</p>

--- a/db/seeds/abilities/edit_posts.html
+++ b/db/seeds/abilities/edit_posts.html
@@ -1,7 +1,7 @@
 <h2>What does this ability allow me to do?</h2>
 <p>This ability allows you to unilaterally edit posts, as well as review suggested edits from other users.</p>
 
-<p>Edits should be used to improve posts, including edits improving spelling, grammar, and formatting, as well as fixes for missing <a href="/help/alt-text">alt text</a>, broken images and links, and other improvements. Edits should, however, respect the goal of the post.</p>
+<p>Edits should be used to improve posts, including edits improving spelling, grammar, and formatting, as well as fixes for missing <a href="/help/alt-text">alt text</a>, broken images and links, and other improvements. Edits should, however, preserve the meaning of the post.</p>
 
 <img src="/assets/ability-help/edit-link.png" alt="Edit post button">
 

--- a/db/seeds/abilities/edit_posts.html
+++ b/db/seeds/abilities/edit_posts.html
@@ -1,7 +1,7 @@
 <h2>What does this ability allow me to do?</h2>
 <p>This ability allows you to unilaterally edit posts, as well as review suggested edits from other users.</p>
 
-<p>Edits should be used to improve posts, including edits improving spelling, grammar, and formatting, as well as fixes for missing <a href="/help/alt-text">alt text</a>, broken images and links, and other improvements. Edits should, however, respect the goal of the original poster.</p>
+<p>Edits should be used to improve posts, including edits improving spelling, grammar, and formatting, as well as fixes for missing <a href="/help/alt-text">alt text</a>, broken images and links, and other improvements. Edits should, however, respect the goal of the post.</p>
 
 <img src="/assets/ability-help/edit-link.png" alt="Edit post button">
 


### PR DESCRIPTION
Clarify that it's the goal of the post itself which matters, and not that of its author. The author's goals may change, or they may have created a post which turned out not to be aligned with the goals they had. Once a post has been committed to Codidact, the author's goals cease, and the network's goals with the post take effect.