### PR TITLE
fixed 500 error when a category is missing its tag set

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -36,10 +36,10 @@ class TagsController < ApplicationController
             end
     @count = @tags&.count || 0
     table = params[:hierarchical].present? ? 'tags_paths' : 'tags'
-    if @count > 0
+    if @count.positive?
       @tags = @tags.left_joins(:posts).group(Arel.sql("#{table}.id"))
-                .select(Arel.sql("#{table}.*, COUNT(DISTINCT IF(posts.deleted = 0, posts.id, NULL)) AS post_count"))
-                .paginate(per_page: 96, page: params[:page])
+                   .select(Arel.sql("#{table}.*, COUNT(DISTINCT IF(posts.deleted = 0, posts.id, NULL)) AS post_count"))
+                   .paginate(per_page: 96, page: params[:page])
     end
   end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -32,13 +32,15 @@ class TagsController < ApplicationController
               @tag_set.tags.where(excerpt: '').or(@tag_set.tags.where(excerpt: nil))
                       .order(Arel.sql('COUNT(posts.id) DESC'))
             else
-              @tag_set.tags.order(Arel.sql('COUNT(posts.id) DESC'))
+              @tag_set&.tags&.order(Arel.sql('COUNT(posts.id) DESC'))
             end
-    @count = @tags.count
+    @count = @tags&.count || 0
     table = params[:hierarchical].present? ? 'tags_paths' : 'tags'
-    @tags = @tags.left_joins(:posts).group(Arel.sql("#{table}.id"))
-                 .select(Arel.sql("#{table}.*, COUNT(DISTINCT IF(posts.deleted = 0, posts.id, NULL)) AS post_count"))
-                 .paginate(per_page: 96, page: params[:page])
+    if @count > 0
+      @tags = @tags.left_joins(:posts).group(Arel.sql("#{table}.id"))
+                .select(Arel.sql("#{table}.*, COUNT(DISTINCT IF(posts.deleted = 0, posts.id, NULL)) AS post_count"))
+                .paginate(per_page: 96, page: params[:page])
+    end
   end
 
   def show

--- a/app/views/tags/_list.html.erb
+++ b/app/views/tags/_list.html.erb
@@ -4,7 +4,7 @@
   <% topic_ids = @category&.topic_tag_ids %>
 
   <% ApplicationRecord.with_lax_group_rules do %>
-    <% @tags.each do |tag| %>
+    <% @tags&.each do |tag| %>
       <% required = required_ids&.include?(tag.id) ? 'is-filled' : '' %>
       <% topic = topic_ids&.include?(tag.id) ? 'is-outlined' : '' %>
       <% moderator = moderator_ids&.include?(tag.id) ? 'is-red is-outlined' : '' %>

--- a/app/views/tags/category.html.erb
+++ b/app/views/tags/category.html.erb
@@ -2,6 +2,12 @@
 
 <h1>Tags used in <%= @category.name %></h1>
 
+<% if @tags == nil %>
+<p>This category is missing its tag set. Set this in the Category settings (admin).</p>
+<% end %>
+
+<% unless @tags == nil %>
+
 <% if current_user&.is_moderator || check_your_privilege('edit_tags') %>
 <%= link_to 'New', new_tag_path(id: @category.id), class: 'button is-muted is-outlined', 'aria-label': 'Create new tag' %>
 <% end %>
@@ -37,7 +43,7 @@
 
 <%= render 'list' %>
 
-<% if @tags.size == 0 %>
+<% if @tags&.size == 0 %>
   <% if params[:q].present? %>
     <p class="has-color-tertiary"><em>No results for <strong><%= params[:q] %></strong></em></p>
   <% else %>
@@ -46,3 +52,6 @@
 <% end %>
 
 <%= will_paginate @tags, renderer: BootstrapPagination::Rails %>
+
+<% end %> <!-- unless @tags == nil -->
+


### PR DESCRIPTION
Fixes https://meta.codidact.com/posts/291055.

Fixed 500 error by making checks nil-safe and displaying some guidance on the tags page.  It would be good to also ensure during seeding that this error condition can't arise, but we'd still need this check for new categories where admins forget to specify the tag set.

Now if your category tags are messed up you see this instead of a server error:

![This category is missing its tag set. Set this in the Category settings (admin).](https://github.com/codidact/qpixel/assets/5557942/e348da64-44b6-41a8-958a-3e69dd9defdb)
