### PR TITLE
if you can't post, give a link to where you can try instead

### DIFF
--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -34,4 +34,6 @@
   <div class="notice is-danger is-filled">
       You don't have a high enough trust level to post in the <%= @category.name %> category.
   </div>
+  <p>Not where you meant to post? See <%= link_to 'Categories', categories_path %></p>
+
 <% end %>


### PR DESCRIPTION
Someone pointed out in chat that if you hit the block when trying to post in a restricted category, we're missing the guidance about other categories.  I realize there is duplication here; I wanted "what to do instead" to come after the big red rejection (better flow), while in the default case the link about other categories is not *usually* what the user wants (it's just an FYI).  Rather than reversing all of the logic, I just copied some text.
