### PR TITLE
show your own deleted posts on "all posts" page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,7 +27,7 @@ class UsersController < ApplicationController
 
   def show
     @abilities = Ability.on_user(@user)
-    @posts = if current_user&.privilege?('flag_curate') || @user == current_user
+    @posts = if current_user&.privilege?('flag_curate')
                @user.posts
              else
                @user.posts.undeleted

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,7 +27,7 @@ class UsersController < ApplicationController
 
   def show
     @abilities = Ability.on_user(@user)
-    @posts = if current_user&.privilege?('flag_curate')
+    @posts = if current_user&.privilege?('flag_curate') || @user == current_user
                @user.posts
              else
                @user.posts.undeleted
@@ -174,7 +174,7 @@ class UsersController < ApplicationController
   end
 
   def posts
-    @posts = if current_user&.privilege?('flag_curate')
+    @posts = if current_user&.privilege?('flag_curate') || @user == current_user
                Post.all
              else
                Post.undeleted


### PR DESCRIPTION
Following up on https://meta.codidact.com/posts/291221, where no one's objected to my answer so far but it's only been a few days, this change includes your deleted posts when viewing the "all posts" page on your profile.  You could already see them if you had the direct links, but this makes them easier to find.  I'm not showing them on the main page, just the "all" page.

Possible issue: these are always shown, rather than being controlled by a sticky selection of some sort.  Reviewers, please decide if always showing them is ok or if we need to let users opt in.  The current change is, as you can see, quite trivial code-wise, but I don't know if it's enough.
