### PR TITLE
show profile creation date/time to owner and mods

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -147,6 +147,14 @@
         <td><%= @user.metric 'E' %></td>
       </tr>
     </table>
+    
+    <% if current_user&.id == @user.id || current_user&.is_moderator %>
+    <table class="table is-full-width">
+      <tr>
+	<td>User since <%= @user.created_at %></td>
+      </tr>
+    </table>
+    <% end %>
 
     <% unless @abilities.empty? %>
       <h2>Earned Abilities</h2>


### PR DESCRIPTION
Based on a question in chat, this PR adds the date and time a profile was created, only for the owner and moderators.  (Owner because it's yours and why not; mods because it might help with investigating certain kinds of abuse.)

Some sites show account age to everyone.  If we decide to do this, I would suggest showing the full info to the owner and mods but showing at most only the date to everyone else.  I don't know if there's a privacy reason to fuzz this more, so for now I'm not showing it publicly at all.

I considered adding this to the table of stats (top-level posts, answers, edits, etc), but all of those values are short while timestamps are long, so it flowed weirdly.  I saw no clean way to fit it in there, so I made a separate new mini-section.