### PR TITLE
Escape hyphen in already correctly working regex to fix warning

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Allow ngrok connections to dev server
-  config.hosts << /[a-z0-9-.]+\.ngrok-free\.app/
+  config.hosts << /[a-z0-9\-.]+\.ngrok-free\.app/
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
When running `rails s` to serve a local development instance, a warning is given:

```text
warning: character class has '-' without escape: /[a-z0-9-.]+\.ngrok\-free\.app/
```

Nothing is broken. Ruby understands that the third hyphen inside the square brackets is a literal hyphen, not a range indicator. The regex already matches exactly what it should. The only problem is the warning, causing clutter in the terminal.

This pull request escapes the hyphen in order to fix the warning. There is no change to functionality.