### PR TITLE
allow approving your own suggested edit if you could now make the edit directly

### DIFF
--- a/app/views/suggested_edit/show.html.erb
+++ b/app/views/suggested_edit/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Suggested Edit #" + @edit.id.to_s %>
 <% post = @edit.post %>
 <% is_question_or_article = @edit.on_question? || @edit.on_article? %>
-<% may_decide = check_your_post_privilege(post, 'edit_posts') && @edit.user.id != current_user.id %>
+<% may_decide = check_your_post_privilege(post, 'edit_posts') %>
 
 <h1>Review Suggested Edit</h1>
 


### PR DESCRIPTION
https://meta.codidact.com/posts/291619 describes an edge case: a user suggests edits, then gains the "edit" ability that includes approving edits, but got blocked because you can't approve your own edit suggestions.  On the one hand it seems minor, and there's even an argument to be made that this averts some gaming of the abilities system ([comment thread](https://meta.codidact.com/comments/thread/9610#comment-24186)), but on the other hand, that pending edit blocks any other edits, including one by the user with the new edit ability.  On balance, it seems better to allow you to approve edits you could *now* make directly, even if you couldn't *then*.

I tested this scenario and also confirmed that a user without the edit ability still can't self-approve.