### PR TITLE
Show correct number of posts on user profile page

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -85,7 +85,7 @@
         <h2 class="user-profile-heading">Posts</h2>
         <% if @posts.size > 0 %>
           <%= link_to user_posts_path(@user), class: "button is-muted", 'aria-label': "View all posts by #{rtl_safe_username(@user)}" do %>
-            See all <%= @posts.count %> &raquo;
+            See all <%= @allposts.count %> &raquo;
           <% end %>
         <% end %>
       </div>
@@ -98,7 +98,7 @@
           <% end %>
         </div>
         <%= link_to user_posts_path(@user), class: "button is-muted", 'aria-label': "View all posts by #{rtl_safe_username(@user)}" do %>
-          See all <%= @posts.count %> &raquo;
+          See all <%= @allposts.count %> &raquo;
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
Corrected fix for PR 1346: count of user posts was maxed at 15 because of local scoping, now is correct.

![button: 20 posts](https://github.com/codidact/qpixel/assets/5557942/b95b7e24-ce36-45ab-8837-c84df679fbee)

![posts page: 20 posts](https://github.com/codidact/qpixel/assets/5557942/c3f50961-287b-4f52-a47d-1d273d5459fd)
