### PR TITLE
profile remove category column

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -6,7 +6,7 @@ class NotificationsController < ApplicationController
     @notifications = Notification.unscoped.where(user: current_user).paginate(page: params[:page], per_page: 100)
                                  .order(Arel.sql('is_read ASC, created_at DESC'))
     respond_to do |format|
-      format.html { render :index }
+      format.html { render :index, layout: 'without_sidebar' }
       format.json { render json: @notifications, methods: :community_name }
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -67,9 +67,10 @@ class UsersController < ApplicationController
         @community_prefs = prefs[:community]
       end
       format.json do
-        render json: current_user.preferences
+        render json: current_user.preferences 
       end
     end
+    render layout: 'without_sidebar'
   end
 
   # Helper method to convert it to the form expected by the client
@@ -108,6 +109,7 @@ class UsersController < ApplicationController
         render json: filters_json
       end
     end
+    render layout: 'without_sidebar'
   end
 
   def set_filter
@@ -581,6 +583,7 @@ class UsersController < ApplicationController
                    end \
                    .paginate(page: params[:page], per_page: 15)
     @votes
+    render layout: 'without_sidebar'
   end
 
   def avatar


### PR DESCRIPTION
Mitigates https://meta.codidact.com/posts/291869 as discussed in [comments](https://meta.codidact.com/comments/thread/9741).

The user profile page has 8 tabs (for your own profile, when logged in).  Some of those sub-pages omit the right column but others don't, and the addition of the right column causes some unfortunate wrapping in both the tabs row and some page content.  Except on the main profile page (which is not changed by this PR), the right column is the "category" column that you see on most pages on the site.  The content there -- bulletins, hot posts, subscription links, etc -- makes sense in the context of a list of posts or even an individual post, but it's less relevant when looking at your vote summary.

This PR removes that column from most of the profile sub-pages that had it, specifically: votes summary,  preferences, filters, notifications.  Activity and edit already omitted it, and the main profile page is special.  That leaves the account sub-page (where you change your password etc), for which I couldn't find the relevant code.  Since all of this is mitigation for wrapping that will still happen on smaller screens, I figure an incremental fix is better than nothing at all.

Before: see meta post.

After: 

![Screenshot, single tabs line without wrapping](https://github.com/user-attachments/assets/897f046b-d6f3-4aa4-af44-bd3ae89a1d5c)

