### PR TITLE
revert: profile remove category column

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -6,7 +6,7 @@ class NotificationsController < ApplicationController
     @notifications = Notification.unscoped.where(user: current_user).paginate(page: params[:page], per_page: 100)
                                  .order(Arel.sql('is_read ASC, created_at DESC'))
     respond_to do |format|
-      format.html { render :index, layout: 'without_sidebar' }
+      format.html { render :index }
       format.json { render json: @notifications, methods: :community_name }
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -65,7 +65,6 @@ class UsersController < ApplicationController
         prefs = current_user.preferences
         @preferences = prefs[:global]
         @community_prefs = prefs[:community]
-        render layout: 'without_sidebar'
       end
       format.json do
         render json: current_user.preferences
@@ -104,7 +103,6 @@ class UsersController < ApplicationController
     respond_to do |format|
       format.html do
         authenticate_user!
-        render layout: 'without_sidebar'
       end
       format.json do
         render json: filters_json
@@ -582,7 +580,6 @@ class UsersController < ApplicationController
                      [k, vl.group_by(&:post), vl.sum { |v| v.vote_type * v.vote_count }]
                    end \
                    .paginate(page: params[:page], per_page: 15)
-    render layout: 'without_sidebar'
     @votes
   end
 


### PR DESCRIPTION
https://github.com/codidact/qpixel/pull/1364 introduced a server error if you are not logged in and access a login-restricted tab directly (e.g. /users/me/filters).  The correct (and previous) behavior is to prompt for login.  This PR removes those changes.
