### PR TITLE
Fix for pull request 1364

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -6,7 +6,7 @@ class NotificationsController < ApplicationController
     @notifications = Notification.unscoped.where(user: current_user).paginate(page: params[:page], per_page: 100)
                                  .order(Arel.sql('is_read ASC, created_at DESC'))
     respond_to do |format|
-      format.html { render :index }
+      format.html { render :index, layout: 'without_sidebar' }
       format.json { render json: @notifications, methods: :community_name }
     end
   end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,8 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   protected
 
+  layout "without_sidebar", only: :edit
+
   before_action :check_sso, only: :update
 
   def after_update_path_for(resource)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -65,6 +65,7 @@ class UsersController < ApplicationController
         prefs = current_user.preferences
         @preferences = prefs[:global]
         @community_prefs = prefs[:community]
+        render layout: 'without_sidebar'
       end
       format.json do
         render json: current_user.preferences
@@ -580,6 +581,7 @@ class UsersController < ApplicationController
                      [k, vl.group_by(&:post), vl.sum { |v| v.vote_type * v.vote_count }]
                    end \
                    .paginate(page: params[:page], per_page: 15)
+    render layout: 'without_sidebar'
     @votes
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
 
   before_action :authenticate_user!, only: [:edit_profile, :update_profile, :stack_redirect, :transfer_se_content,
                                             :qr_login_code, :me, :preferences, :set_preference, :my_vote_summary,
-                                            :disconnect_sso, :confirm_disconnect_sso]
+                                            :disconnect_sso, :confirm_disconnect_sso, :filters]
   before_action :verify_moderator, only: [:mod, :destroy, :soft_delete, :role_toggle, :full_log,
                                           :annotate, :annotations, :mod_privileges, :mod_privilege_action]
   before_action :set_user, only: [:show, :mod, :destroy, :soft_delete, :posts, :role_toggle, :full_log, :activity,
@@ -103,7 +103,6 @@ class UsersController < ApplicationController
   def filters
     respond_to do |format|
       format.html do
-        authenticate_user!
         render layout: 'without_sidebar'
       end
       format.json do


### PR DESCRIPTION
When reviewing pull request 1364 I overlooked that the filters tab controller method would error when not signed in due to containing both `authenticate_user!` and a `render` call. The changes from that pull request were therefore reverted. Changing from an explicit `authenticate_user!` to a `before_action` fixes this.