### PR TITLE
Fix for Docker setup db service healthcheck

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,7 +1,7 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   protected
 
-  layout "without_sidebar", only: :edit
+  layout 'without_sidebar', only: :edit
 
   before_action :check_sso, only: :update
 

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -13,16 +13,18 @@ class SubscriptionMailer < ApplicationMailer
 
     # Load request community to ensure we can access the settings/posts of the correct community
     RequestContext.community = @subscription.community
+    name = @subscription.name
     site_name = @subscription.community.name
-    subject = if @subscription.name.present?
-                "Latest questions from your '#{@subscription.name}' subscription on #{site_name}"
+    subject = if name.present?
+                "Latest questions from your '#{name}' subscription on #{site_name}"
               else
                 "Latest questions from your subscription on #{site_name}"
               end
 
     @subscription.update(last_sent_at: DateTime.now)
     from = "#{SiteSetting['SubscriptionSenderName']} <#{SiteSetting['SubscriptionSenderEmail']}>"
-    mail from: from, to: @subscription.user.email, subject: subject
-    Rails.logger.info "Sent subscription mail (sub ID ##{@subscription.id}, to: #{@subscription.user.email}, name: '#{@subscription.name}'"
+    to = @subscription.user.email
+    mail from: from, to: to, subject: subject
+    Rails.logger.info "Sent subscription mail (sub ID ##{@subscription.id}, to: '#{to}', name: '#{name}'"
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - ./docker/mysql:/var/lib/mysql
     env_file:
       - ${ENV_FILE_LOCATION}
-    command: mysqld --default-authentication-plugin=mysql_native_password --skip-mysqlx
+    command: mysqld --mysql-native-password=on --skip-mysqlx
     cap_add:
       - SYS_NICE
     healthcheck:

--- a/docker/Dockerfile.db
+++ b/docker/Dockerfile.db
@@ -1,4 +1,4 @@
-FROM mysql
+FROM mysql:8.4.2
 
 # docker build -t qpixel_db -f docker/Dockerfile.db .
 


### PR DESCRIPTION
mysqld 8.4+ dropped the `--default-authentication-plugin` option. Since we do not fix the `mysql` image in Dockerfile, the healthcheck starts to fail for anyone who rebuilds the container. Also fixed the image version to 8.4.2 (latest stable version of major 8 ATTOW, don't have enough time right now to test if major 9 works, unfortunately) to avoid unpleasant surprises on clean builds.

Also fixed current rubocop issues.