### PR TITLE
In flags queue, show when a post was modified after the flag

### DIFF
--- a/app/views/flags/_flag.html.erb
+++ b/app/views/flags/_flag.html.erb
@@ -22,6 +22,11 @@
     <p>
       <strong><%= flag.post_flag_type&.name || 'Flag reason' %></strong>: <%= flag.reason %> &mdash;
       <%= user_link flag.user %> at <%= flag.created_at.iso8601 %>
+      <% if flag.post_type == 'Post' && flag.post.updated_at > flag.created_at %>
+      <%= link_to post_history_path(flag.post) do %>
+	(post modified after flag)
+      <% end %>
+      <% end %>
     </p>
   </div>
   <% if escalation %>

--- a/app/views/flags/queue.html.erb
+++ b/app/views/flags/queue.html.erb
@@ -6,6 +6,7 @@
 <h1>Moderator Flag Queue</h1>
 <p>Below is a list of posts that users have flagged. Users are asked to provide a reason when flagging posts for
   moderator attention; use that to help you determine what needs to be done.</p>
+<p>You can mark a flag helpful even if you take no action. If a post was edited after the flag was raised, for example, the problem might already be fixed.</p>
 
 <div class="button-list is-gutterless">
   <%= link_to 'Active', flag_queue_path,


### PR DESCRIPTION
Sometimes a user raises a flag in good faith, the post gets edited to fix the problem before a moderator sees it, and the moderator doesn't notice the sequence of events and declines the flag.  This change gives mods a little more information: if a post was edited after the flag was raised, the flag entry says so and links to the post's history.  If the flag is the newest activity, the view is unchanged:

![screenshot, two flags, one with the link and one without](https://github.com/user-attachments/assets/bf8d5f41-77dd-44bf-ba03-aabbace36489)
