### PR TITLE
Expanding post draft logic to handle fields other than the body

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -344,7 +344,7 @@ $(() => {
   $('.js-draft-loaded').each((i, e) => {
     $(e).parents('.widget').after(`<div class="notice is-info has-font-size-caption">
       <i class="fas fa-exclamation-circle"></i> <strong>Draft loaded.</strong>
-      You've edited this post before but didn't save it. We loaded your edits here for you.
+      You had edited this before but haven't saved it. We loaded the edits for you.
     </div>`);
   });
 

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -99,6 +99,7 @@ $(() => {
    * @typedef {{
    *  body: string
    *  comment?: string
+   *  excerpt?: string
    *  license?: string
    *  tags?: string[]
    *  title?: string
@@ -148,21 +149,24 @@ $(() => {
 
     const $bodyField = $form.find('.js-post-field');
     const $licenseField = $form.find('.js-license-select');
-    const $tagField = $form.find('.js-tag-select');
-    // TODO: switch to .js-* lookup
+    const $excerptField = $form.find('.js-tag-excerpt');
+    
+    const $tagsField = $form.find('#post_tags_cache');
     const $titleField = $form.find('#post_title');
     const $commentField = $form.find('#edit_comment');
 
     const bodyText = $bodyField.val();
     const commentText = $commentField.val();
+    const excerptText = $excerptField.val();
     const license = $licenseField.val();
-    const tags = $tagField.val();
+    const tags = $tagsField.val();
     const titleText = $titleField.val();
 
     /** @type {PostDraft} */
     const draft = {
       body: bodyText,
       comment: commentText,
+      excerpt: excerptText,
       license: license,
       tags: tags,
       title: titleText,
@@ -181,14 +185,24 @@ $(() => {
 
   const postFields = $('.post-field');
 
+  const draftFieldsSelectors = [
+    '.js-post-field',
+    '.js-license-select',
+    '.js-tag-excerpt',
+    '#edit_comment',
+    '#post_tags_cache',
+    '#post_title',
+    '#tag_parent_id',
+  ];
+
   // TODO: consider merging with post fields
-  $('.js-post-field, .js-license-select, .js-tag-select, #edit_comment, #post_title').on('keyup change', (ev) => {
-      clearTimeout(draftTimeout);
-      draftTimeout = setTimeout(() => {
-        const { draft, field } = parseDraft(ev.target);
-        saveDraft(draft, field);
-      }, 3000);
-    });
+  $(draftFieldsSelectors.join(', ')).on('keyup change', (ev) => {
+    clearTimeout(draftTimeout);
+    draftTimeout = setTimeout(() => {
+      const { draft, field } = parseDraft(ev.target);
+      saveDraft(draft, field);
+    }, 3000);
+  });
 
   postFields.on('paste', async (evt) => {
     if (evt.originalEvent.clipboardData.files.length > 0) {

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -164,7 +164,7 @@ $(() => {
       body: bodyText,
       comment: commentText,
       license: license,
-      tags: tags ?? [],
+      tags: tags,
       title: titleText,
     };
 

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -101,6 +101,7 @@ $(() => {
    *  comment?: string
    *  excerpt?: string
    *  license?: string
+   *  tag_name?: string
    *  tags?: string[]
    *  title?: string
    * }} PostDraft
@@ -154,6 +155,7 @@ $(() => {
     const $tagsField = $form.find('#post_tags_cache');
     const $titleField = $form.find('#post_title');
     const $commentField = $form.find('#edit_comment');
+    const $tagNameField = $form.find('#tag_name');
 
     const bodyText = $bodyField.val();
     const commentText = $commentField.val();
@@ -161,6 +163,7 @@ $(() => {
     const license = $licenseField.val();
     const tags = $tagsField.val();
     const titleText = $titleField.val();
+    const tagName = $tagNameField.val();
 
     /** @type {PostDraft} */
     const draft = {
@@ -169,6 +172,7 @@ $(() => {
       excerpt: excerptText,
       license: license,
       tags: tags,
+      tag_name: tagName,
       title: titleText,
     };
 
@@ -193,6 +197,7 @@ $(() => {
     '#post_tags_cache',
     '#post_title',
     '#tag_parent_id',
+    '#tag_name',
   ];
 
   // TODO: consider merging with post fields

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -614,6 +614,12 @@ class PostsController < ApplicationController
       RequestContext.redis.expire license_key, expiration_time
     end
 
+    if params.key?(:tag_name)
+      tag_name_key = "saved_post.#{current_user.id}.#{params[:path]}.tag_name"
+      RequestContext.redis.set tag_name_key, params[:tag_name]
+      RequestContext.redis.expire tag_name_key, expiration_time
+    end
+
     if params.key?(:tags)
       tags_key = "saved_post.#{current_user.id}.#{params[:path]}.tags"
       RequestContext.redis.sadd tags_key, params[:tags]
@@ -698,6 +704,7 @@ class PostsController < ApplicationController
     excerpt_key = "saved_post.#{current_user.id}.#{path}.excerpt"
     license_key = "saved_post.#{current_user.id}.#{path}.license"
     tags_key = "saved_post.#{current_user.id}.#{path}.tags"
+    tag_name_key = "saved_post.#{current_user.id}.#{path}.tag_name"
     title_key = "saved_post.#{current_user.id}.#{path}.title"
     saved_at = "saved_post_at.#{current_user.id}.#{path}"
 
@@ -707,6 +714,7 @@ class PostsController < ApplicationController
       excerpt_key,
       license_key,
       tags_key,
+      tag_name_key,
       title_key,
       saved_at
     ]

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -602,6 +602,12 @@ class PostsController < ApplicationController
       RequestContext.redis.expire comment_key, expiration_time
     end
 
+    if params.key?(:excerpt)
+      exceprt_key = "saved_post.#{current_user.id}.#{params[:path]}.excerpt"
+      RequestContext.redis.set exceprt_key, params[:excerpt]
+      RequestContext.redis.expire exceprt_key, expiration_time
+    end
+
     if params.key?(:license)
       license_key = "saved_post.#{current_user.id}.#{params[:path]}.license"
       RequestContext.redis.set license_key, params[:license]
@@ -689,11 +695,23 @@ class PostsController < ApplicationController
   def do_draft_delete(path)
     body_key = "saved_post.#{current_user.id}.#{path}"
     comment_key = "saved_post.#{current_user.id}.#{path}.comment"
+    excerpt_key = "saved_post.#{current_user.id}.#{path}.excerpt"
     license_key = "saved_post.#{current_user.id}.#{path}.license"
     tags_key = "saved_post.#{current_user.id}.#{path}.tags"
     title_key = "saved_post.#{current_user.id}.#{path}.title"
     saved_at = "saved_post_at.#{current_user.id}.#{path}"
-    RequestContext.redis.del body_key, comment_key, license_key, tags_key, title_key, saved_at
+
+    keys = [
+      body_key,
+      comment_key,
+      excerpt_key,
+      license_key,
+      tags_key,
+      title_key,
+      saved_at
+    ]
+
+    RequestContext.redis.del(*keys)
   end
 end
 # rubocop:enable Metrics/MethodLength

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -699,25 +699,11 @@ class PostsController < ApplicationController
   end
 
   def do_draft_delete(path)
-    body_key = "saved_post.#{current_user.id}.#{path}"
-    comment_key = "saved_post.#{current_user.id}.#{path}.comment"
-    excerpt_key = "saved_post.#{current_user.id}.#{path}.excerpt"
-    license_key = "saved_post.#{current_user.id}.#{path}.license"
-    tags_key = "saved_post.#{current_user.id}.#{path}.tags"
-    tag_name_key = "saved_post.#{current_user.id}.#{path}.tag_name"
-    title_key = "saved_post.#{current_user.id}.#{path}.title"
-    saved_at = "saved_post_at.#{current_user.id}.#{path}"
-
-    keys = [
-      body_key,
-      comment_key,
-      excerpt_key,
-      license_key,
-      tags_key,
-      tag_name_key,
-      title_key,
-      saved_at
-    ]
+    keys = [:body, :comment, :excerpt, :license, :saved_at, :tags, :tag_name, :title].map do |key|
+      pfx = key == :saved_at ? 'saved_post_at' : 'saved_post'
+      base = "#{pfx}.#{current_user.id}.#{path}"
+      [:body, :saved_at].include?(key) ? base : "#{base}.#{key}"
+    end
 
     RequestContext.redis.del(*keys)
   end

--- a/app/views/posts/_edit_comment.html.erb
+++ b/app/views/posts/_edit_comment.html.erb
@@ -1,6 +1,7 @@
 <%#
   Edit comment reusable partial.
   Variables:
+    comment       : [String, Nil] optional, initial value of the field (default '')
     cur_length    : [Integer, Nil] optional, current character length (default 0)
     min_length    : [Integer, Nil] optional, the minimum allowed length (default 0)
     max_length    : [Integer, Nil] optional, the maximum allowed length (default 255)
@@ -8,6 +9,7 @@
 
 <%
   # Defaults
+  comment = (defined?(comment) ? comment : nil) || ''
   cur_length = (defined?(cur_length) ? cur_length : nil) || 0
   min_length = (defined?(min_length) ? min_length : nil) || 0
   max_length = (defined?(max_length) ? max_length : nil) || 255
@@ -15,9 +17,10 @@
 
 <div class="form-group">
   <%= label_tag :edit_comment, t('posts.edit_comment_label'), class: 'form-element' %>
-  <%= text_field_tag :edit_comment, 
-                     nil, 
-                     class: 'form-element', 
+  <%= text_field_tag :edit_comment,
+                     nil,
+                     class: 'form-element',
+                     value: comment,
                      data: { character_count: ".js-character-count-edit-comment" } %>
   <div class="clearfix">
     <%= render 'shared/char_count', type: 'edit-comment', cur: cur_length, min: min_length, max: max_length %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -68,13 +68,30 @@
   <div class="post-preview"></div>
 
   <% unless post_type.has_parent? %>
+    <% value = {} %>
+    <% key = "saved_post.#{current_user&.id}.#{request.path}.title" %>
+    <% saved_at_key = "saved_post_at.#{current_user&.id}.#{request.path}" %>
+    <% saved_at = DateTime.parse(RequestContext.redis.get(saved_at_key) || '') rescue Date.new(2000, 1, 1) %>
+    <%
+      # Find the most recent between post-create, post-update, and draft-saved, and use the value corresponding to that.
+      value = [
+        [post.created_at || Date.new(2000, 1, 1), {}],
+        [post.updated_at || Date.new(2000, 1, 1), {}],
+        [saved_at || Date.new(2001, 1, 1), { value: RequestContext.redis.get(key) }]
+      ].max_by do |x|
+        x[0]
+      end[1]
+    %>
     <div class="form-group">
       <%= f.label :title, t('posts.post_title_label'), class: 'form-element' %>
-      <%= f.text_field :title, class: 'form-element post_title', data: { character_count: ".js-character-count-post-title" } %>
+      <%= f.text_field :title,
+                        **({ class: 'form-element post_title' }).merge(value),
+                        data: { character_count: ".js-character-count-post-title" }
+      %>
       <div class="clearfix">
-        <%= render 'shared/char_count', type: 'post-title', 
-                                        cur: post.title&.length, 
-                                        max: max_title_length(category), 
+        <%= render 'shared/char_count', type: 'post-title',
+                                        cur: value[:value]&.length || post.title&.length,
+                                        max: max_title_length(category),
                                         min: min_title_length(category, post_type) %>
       </div>
     </div>
@@ -95,8 +112,26 @@
           <% end %>
         </span>
       <% end %>
-      <%= f.select :tags_cache, options_for_select(post.tags_cache.map { |t| [t, t] }, selected: post.tags_cache),
-                   { include_blank: true }, multiple: true, class: "form-element js-tag-select",
+      <% tags = post.tags_cache %>
+      <% key = "saved_post.#{current_user&.id}.#{request.path}.tags" %>
+      <% saved_at_key = "saved_post_at.#{current_user&.id}.#{request.path}" %>
+      <% saved_at = DateTime.parse(RequestContext.redis.get(saved_at_key) || '') rescue Date.new(2000, 1, 1) %>
+      <%
+        # Find the most recent between post-create, post-update, and draft-saved, and use the value corresponding to that.
+        tags = [
+          [post.created_at || Date.new(2000, 1, 1), post.tags_cache],
+          [post.updated_at || Date.new(2000, 1, 1), post.tags_cache],
+          [saved_at || Date.new(2001, 1, 1), RequestContext.redis.smembers(key)]
+        ].max_by do |x|
+          x[0]
+        end[1]
+      %>
+      <%= f.select :tags_cache, options_for_select(
+                                  (tags || post.tags_cache).map { |t| [t, t] },
+                                  selected: tags || post.tags_cache),
+                   { include_blank: true },
+                   multiple: true,
+                   class: "form-element js-tag-select",
                    data: { tag_set: category.tag_set_id } %>
     </div>
   <% end %>
@@ -130,9 +165,23 @@
           </a>
         <% end %>
       </span>
+      <% license = post.license_id %>
+      <% key = "saved_post.#{current_user&.id}.#{request.path}.license" %>
+      <% saved_at_key = "saved_post_at.#{current_user&.id}.#{request.path}" %>
+      <% saved_at = DateTime.parse(RequestContext.redis.get(saved_at_key) || '') rescue Date.new(2000, 1, 1) %>
+      <%
+        # Find the most recent between post-create, post-update, and draft-saved, and use the value corresponding to that.
+        license = [
+          [post.created_at || Date.new(2000, 1, 1), post.license_id],
+          [post.updated_at || Date.new(2000, 1, 1), post.license_id],
+          [saved_at || Date.new(2001, 1, 1), RequestContext.redis.get(key)]
+        ].max_by do |x|
+          x[0]
+        end[1]
+      %>
       <%= f.select :license_id, options_for_select(License.enabled.default_order(category, user_default)
                                                           .map { |l| [l.name, l.id, { 'data-title': l.description }] },
-                                                   selected: post.license_id),
+                                                   selected: license || post.license_id),
                    { include_blank: user_default == 'No default (make me choose)' },
                    class: 'form-element js-license-select' %>
     </div>
@@ -179,8 +228,25 @@
   <% end %>
 
   <% if edit_comment %>
+    <% comment = '' %>
+    <% key = "saved_post.#{current_user&.id}.#{request.path}.comment" %>
+    <% saved_at_key = "saved_post_at.#{current_user&.id}.#{request.path}" %>
+    <% saved_at = DateTime.parse(RequestContext.redis.get(saved_at_key) || '') rescue Date.new(2000, 1, 1) %>
+    <%
+      # Find the most recent between post-create, post-update, and draft-saved, and use the value corresponding to that.
+      comment = [
+        [post.created_at || Date.new(2000, 1, 1), ''],
+        [post.updated_at || Date.new(2000, 1, 1), ''],
+        [saved_at || Date.new(2001, 1, 1), RequestContext.redis.get(key)]
+      ].max_by do |x|
+        x[0]
+      end[1]
+    %>
     <hr/>
-    <%= render 'edit_comment', max_length: max_edit_comment_length %>
+    <%= render 'edit_comment', comment: comment,
+                               cur_length: comment&.length || 0,
+                               max_length: max_edit_comment_length
+    %>
   <% end %>
 
   <div class="actions">

--- a/app/views/tags/_form.html.erb
+++ b/app/views/tags/_form.html.erb
@@ -14,12 +14,26 @@
 
 <%= form_for @tag, url: submit_path do |f| %>
   <% if submit_path == create_tag_path %>
+    <% tag_name = @tag.name %>
+    <% key = "saved_post.#{current_user&.id}.#{request.path}.tag_name" %>
+    <% saved_at_key = "saved_post_at.#{current_user&.id}.#{request.path}" %>
+    <% saved_at = DateTime.parse(RequestContext.redis.get(saved_at_key) || '') rescue Date.new(2000, 1, 1) %>
+    <%
+      # Find the most recent between post-create, post-update, and draft-saved, and use the value corresponding to that.
+      tag_name = [
+        [@tag.created_at || Date.new(2000, 1, 1), @tag.name],
+        [@tag.updated_at || Date.new(2000, 1, 1), @tag.name],
+        [saved_at || Date.new(2001, 1, 1), RequestContext.redis.get(key)]
+      ].max_by do |x|
+        x[0]
+      end[1]
+    %>
     <div class="form-group">
       <%= f.label :name, 'Name', class: 'form-element' %>
       <span class="form-caption">
         Name of the tag
       </span>
-      <%= f.text_field :name, class: 'form-element' %>
+      <%= f.text_field :name, value: tag_name, class: 'form-element' %>
     </div>
   <% end %>
 

--- a/app/views/tags/_form.html.erb
+++ b/app/views/tags/_form.html.erb
@@ -57,13 +57,31 @@
   </div>
 
   <div class="form-group">
+    <% excerpt = @tag.excerpt %>
+    <% key = "saved_post.#{current_user&.id}.#{request.path}.excerpt" %>
+    <% saved_at_key = "saved_post_at.#{current_user&.id}.#{request.path}" %>
+    <% saved_at = DateTime.parse(RequestContext.redis.get(saved_at_key) || '') rescue Date.new(2000, 1, 1) %>
+    <%
+      # Find the most recent between post-create, post-update, and draft-saved, and use the value corresponding to that.
+      excerpt = [
+        [@tag.created_at || Date.new(2000, 1, 1), @tag.excerpt],
+        [@tag.updated_at || Date.new(2000, 1, 1), @tag.excerpt],
+        [saved_at || Date.new(2001, 1, 1), RequestContext.redis.get(key)]
+      ].max_by do |x|
+        x[0]
+      end[1]
+    %>
     <%= f.label :excerpt, 'Usage guidance', class: 'form-element' %>
     <span class="form-caption">
       Short usage guidance for this tag. Will be cut off at 120 characters in the tags list, but displayed in full on
       the tag page.
     </span>
-    <%= f.text_area :excerpt, class: 'form-element js-tag-excerpt', rows: 3, data: { character_count: '.js-character-count-tag-excerpt' } %>
-    <%= render 'shared/char_count', type: 'tag-excerpt', cur: @tag.excerpt&.length, min: 0, max: 600 %>
+    <%= f.text_area :excerpt, class: 'form-element js-tag-excerpt',
+                              value: excerpt,
+                              rows: 3,
+                              data: { character_count: '.js-character-count-tag-excerpt' }
+    %>
+    <%= render 'shared/char_count', type: 'tag-excerpt', cur: excerpt&.length || @tag.excerpt&.length, min: 0, max: 600 %>
   </div>
 
   <%= render 'shared/body_field', f: f, min_length: 0, max_length: 30_000, cur_length: @tag.wiki_markdown&.length, 

--- a/test/controllers/posts/drafts_test.rb
+++ b/test/controllers/posts/drafts_test.rb
@@ -8,6 +8,7 @@ class PostsControllerTest < ActionController::TestCase
     post :save_draft, params: {
       body: 'test_body',
       comment: 'test_comment',
+      excerpt: 'test_excerpt',
       license: '4',
       path: 'test_path',
       tags: ['tag1', 'tag2'],
@@ -23,6 +24,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_equal "saved_post.#{users(:standard_user).id}.test_path", base_key
     assert_equal 'test_body', RequestContext.redis.get(base_key)
     assert_equal 'test_comment', RequestContext.redis.get("#{base_key}.comment")
+    assert_equal 'test_excerpt', RequestContext.redis.get("#{base_key}.excerpt")
     assert_equal '4', RequestContext.redis.get("#{base_key}.license")
     assert_empty ['tag1', 'tag2'].difference(RequestContext.redis.smembers("#{base_key}.tags"))
     assert_equal 'test_title', RequestContext.redis.get("#{base_key}.title")

--- a/test/controllers/posts/drafts_test.rb
+++ b/test/controllers/posts/drafts_test.rb
@@ -11,6 +11,7 @@ class PostsControllerTest < ActionController::TestCase
       excerpt: 'test_excerpt',
       license: '4',
       path: 'test_path',
+      tag_name: 'test_tag_name',
       tags: ['tag1', 'tag2'],
       title: 'test_title'
     }
@@ -25,6 +26,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_equal 'test_body', RequestContext.redis.get(base_key)
     assert_equal 'test_comment', RequestContext.redis.get("#{base_key}.comment")
     assert_equal 'test_excerpt', RequestContext.redis.get("#{base_key}.excerpt")
+    assert_equal 'test_tag_name', RequestContext.redis.get("#{base_key}.tag_name")
     assert_equal '4', RequestContext.redis.get("#{base_key}.license")
     assert_empty ['tag1', 'tag2'].difference(RequestContext.redis.smembers("#{base_key}.tags"))
     assert_equal 'test_title', RequestContext.redis.get("#{base_key}.title")

--- a/test/controllers/posts/drafts_test.rb
+++ b/test/controllers/posts/drafts_test.rb
@@ -5,13 +5,27 @@ class PostsControllerTest < ActionController::TestCase
 
   test 'can save draft' do
     sign_in users(:standard_user)
-    post :save_draft, params: { path: 'test', post: 'test' }
+    post :save_draft, params: {
+      body: 'test_body',
+      comment: 'test_comment',
+      license: '4',
+      path: 'test_path',
+      tags: ['tag1', 'tag2'],
+      title: 'test_title'
+    }
     assert_response 200
     assert_nothing_raised do
       JSON.parse(response.body)
     end
-    assert_equal "saved_post.#{users(:standard_user).id}.test", JSON.parse(response.body)['key']
-    assert_equal 'test', RequestContext.redis.get(JSON.parse(response.body)['key'])
+
+    base_key = JSON.parse(response.body)['key']
+
+    assert_equal "saved_post.#{users(:standard_user).id}.test_path", base_key
+    assert_equal 'test_body', RequestContext.redis.get(base_key)
+    assert_equal 'test_comment', RequestContext.redis.get("#{base_key}.comment")
+    assert_equal '4', RequestContext.redis.get("#{base_key}.license")
+    assert_empty ['tag1', 'tag2'].difference(RequestContext.redis.smembers("#{base_key}.tags"))
+    assert_equal 'test_title', RequestContext.redis.get("#{base_key}.title")
   end
 
   test 'can delete draft' do


### PR DESCRIPTION
closes #1395 

In addition to the post's body, we now save (all fields are optional, so we only save them if the context allows for it):

- post title;
- post tags;
- post license;
- edit comment ;
- tag wiki;
- tag excerpt;
- tag name;

Those fields are stored individually, I opted to do so to not invalidate drafts created prior to the change, but open to switching to a hash value instead.