### PR TITLE
generalized footer

### DIFF
--- a/app/views/application/dashboard.html.erb
+++ b/app/views/application/dashboard.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :title, 'Dashboard' %>
 
 <h1>Dashboard</h1>
-<p>All communities, with categories, on this network.  You can also see a list of all communities from the dropdown arrow in the top right corner of this page.</p>
+<p>All communities, with their categories. You can also see the communities from the dropdown arrow at the top right of each page.</p>
 <div class="grid community-list">
   <% @communities.each do |c| %>
     <% categories = Category.unscoped.where(community: c).order(sequence: :asc, id: :asc) %>

--- a/app/views/application/dashboard.html.erb
+++ b/app/views/application/dashboard.html.erb
@@ -1,6 +1,7 @@
 <%= content_for :title, 'Dashboard' %>
 
 <h1>Dashboard</h1>
+<p>All communities, with categories, on this network.  You can also see a list of all communities from the dropdown arrow in the top right corner of this page.</p>
 <div class="grid community-list">
   <% @communities.each do |c| %>
     <% categories = Category.unscoped.where(community: c).order(sequence: :asc, id: :asc) %>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -2,26 +2,21 @@
   <div class="footer--container container">
     <div class="grid">
       <div class="grid--cell is-6 is-12-md is-12-sm">
-	<h3>This Network</h3>
 	<ul>
-          <li><%= link_to 'All communities', '/dashboard' %></li>
-          <li><%= link_to 'Terms of Service', '/policy/tos' %></li>
-          <li><%= link_to 'Privacy Policy', '/policy/privacy-policy' %></li>
-          <li><%= link_to 'Code of Conduct', '/policy/code-of-conduct' %></li>
+          <li><%= link_to 'Our Communities', '/dashboard' %></li>
+          <li><%= link_to 'About Us', '/policy/network-faq' %></li>
 	</ul>
       </div>
       <div class="grid--cell is-6 is-12-md is-12-sm">
-	<h3>The Codidact Project</h3>
         <ul>
-          <li><%= link_to 'About us', 'https://codidact.org/' %></li>
-          <li><%= link_to 'Contact us', 'https://codidact.com/contact' %></li>
-          <li><%= link_to 'GitHub', 'https://github.com/codidact' %></li>
+          <li><%= link_to 'Terms of Service', '/policy/tos' %></li>
+          <li><%= link_to 'Privacy Policy', '/policy/privacy-policy' %></li>
+          <li><%= link_to 'Code of Conduct', '/policy/code-of-conduct' %></li>
         </ul>
       </div>
     </div>
     <% commit = Rails.cache.persistent('current_commit') %>
-    <p>
-      Version <%= link_to commit[0][0..7], "https://github.com/codidact/qpixel/commit/#{commit[0]}" %> (<%= commit[1] %>)
+    <p>Powered by <%= link_to 'Codidact', 'https://codidact.org/' %>. Version <%= link_to commit[0][0..7], "https://github.com/codidact/qpixel/commit/#{commit[0]}" %> (<%= commit[1] %>)
     </p>
   </div>
 </footer>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -2,22 +2,20 @@
   <div class="footer--container container">
     <div class="grid">
       <div class="grid--cell is-6 is-12-md is-12-sm">
-        <h3>The Codidact Project</h3>
-        <ul>
+	<h3>This Network</h3>
+	<ul>
+          <li><%= link_to 'All communities', '/dashboard' %></li>
           <li><%= link_to 'Terms of Service', '/policy/tos' %></li>
           <li><%= link_to 'Privacy Policy', '/policy/privacy-policy' %></li>
           <li><%= link_to 'Code of Conduct', '/policy/code-of-conduct' %></li>
-          <li><%= link_to 'About us', 'https://codidact.org/' %></li>
-          <li><%= link_to 'Contact us', 'https://codidact.com/contact' %></li>
-          <li><%= link_to 'Other communities', 'https://codidact.com/' %></li>
-        </ul>
+	</ul>
       </div>
       <div class="grid--cell is-6 is-12-md is-12-sm">
-        <h3>Other Codidact Communities</h3>
+	<h3>The Codidact Project</h3>
         <ul>
-          <% Rails.cache.persistent('codidact_sites').each do |site| %>
-            <li><%= link_to site['name'], site['canonical_url'] %></li>
-          <% end %>
+          <li><%= link_to 'About us', 'https://codidact.org/' %></li>
+          <li><%= link_to 'Contact us', 'https://codidact.com/contact' %></li>
+          <li><%= link_to 'GitHub', 'https://github.com/codidact' %></li>
         </ul>
       </div>
     </div>

--- a/db/seeds/posts/global_faq.html
+++ b/db/seeds/posts/global_faq.html
@@ -12,5 +12,5 @@
 <!-- <h2 id="support">Where can I get support?</h2> -->
 
 <h2 id="what-is-codidact-">What is Codidact?</h2>
-<p>This community is built using the <a href="https://github.com/codidact/qpixel">open-source QPixel software</a> provided by <a href="https://codidact.org">The Codidact Foundation</a>. The software is free, open-source, and customizable.</p>
+<p>This community is built with the <a href="https://github.com/codidact/qpixel">open-source QPixel engine</a> provided by <a href="https://codidact.org">The Codidact Foundation</a>. The software is free, open-source, and highly customizable.</p>
   

--- a/db/seeds/posts/global_faq.html
+++ b/db/seeds/posts/global_faq.html
@@ -12,5 +12,5 @@
 <!-- <h2 id="support">Where can I get support?</h2> -->
 
 <h2 id="what-is-codidact-">What is Codidact?</h2>
-<p>This community is built with the <a href="https://github.com/codidact/qpixel">open-source QPixel engine</a> provided by <a href="https://codidact.org">The Codidact Foundation</a>. The software is free, open-source, and highly customizable.</p>
+<p>This community is built with the <a href="https://github.com/codidact/qpixel">QPixel engine</a> provided by <a href="https://codidact.org">The Codidact Foundation</a>. The software is free, open-source, and highly customizable.</p>
   

--- a/db/seeds/posts/global_faq.html
+++ b/db/seeds/posts/global_faq.html
@@ -1,4 +1,5 @@
-<!-- This section appears under a "Global FAQ" heading in the help.  Insert something about your network here. We've provided some other sections as starting points.  The section about the Codidact software and project is meant to go at the end, after the stuff about *your* network and communities. -->
+<!-- This section appears under a "Global FAQ" heading in the help.  Insert something about your network here. We've provided some other sections as starting points.  Please ADD A SUPPORT CONTACT METHOD in the support section! -->
+<!-- The section about the Codidact software and project is meant to go at the end, after the stuff about *your* network and communities. -->
 
 <h2 id="how-do-i-ask-a-question-">How do I ask a question?</h2>
 <p>You will need to register an account. Make sure you are logged into the appropriate topic-related site for your question and click the &quot;Ask Question&quot; button at the top of the page. A template should appear with helpful guidelines on how to ask a quality question. Check out the local FAQ page for important information about each community.</p>
@@ -7,6 +8,8 @@
 <h2 id="what-license-do-my-posts-fall-under-">What license do my posts fall under?</h2>
 <p>Most posts fall under <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>. Some communities or contributors may use a license that more closely aligns with the content posted or their ideological position. Check a community&#39;s local FAQ page and Terms of Service for site-specific details. </p>
 
+<!-- uncomment and populate: -->
+<!-- <h2 id="support">Where can I get support?</h2> -->
 
 <h2 id="what-is-codidact-">What is Codidact?</h2>
 <p>This community is built using the <a href="https://github.com/codidact/qpixel">open-source QPixel software</a> provided by <a href="https://codidact.org">The Codidact Foundation</a>. The software is free, open-source, and customizable.</p>


### PR DESCRIPTION
Sorted the footer links into "this network" and "Codidact project".  Replaced the generated list of communities (which was getting long and was a little buggy) with a dashboard link.  Added some wayfinding to the dashboard page, including pointer to the communities switcher.

This change removes the baked-in `codidact.com` link that is incorrect for other networks.  I added the GitHub link under "Codidact project" to make the OSS platform a little more visible on other networks (maybe they want to contribute too).

Closes https://github.com/codidact/qpixel/issues/1349 and (indirectly) https://github.com/codidact/qpixel/issues/1216.