### PR TITLE
updated link in mod-message template

### DIFF
--- a/db/seeds/warning_templates/off-topic.md
+++ b/db/seeds/warning_templates/off-topic.md
@@ -3,7 +3,9 @@ We've noticed that you've written a number of posts about topics that are beyond
 You can find out about what's on-topic and what's off-topic on $SiteName in the [help center](/help/faq).
 
 This is just a gentle reminder that we expect posts on this site to stay focused on the topic on-hand.
-We have a [Network of communities](https://codidact.com/) that you are free to use; you may find one of our other communities more suitable to some of your posts. If you would like to talk about the possibility of creating a site for a subject not currently covered, please write a post on [meta](https://meta.codidact.com/categories/10) with your request.
+We have a [Network of communities](/dashboard) that you are free to use; you may find one of our other communities more suitable to some of your posts.
+If you would like to explore creating a site for a subject not currently covered, see [the Proposals process on codidact.con](https://proposals.codidact.com/help/proposals).
+
 Additionally, we have a $ChatLink available for more free-form discussion.
 
 While we appreciate your continued contributions within the scope of this site, we do ask that you make sure that the topic of your posts remain in scope.

--- a/db/seeds/warning_templates/off-topic.md
+++ b/db/seeds/warning_templates/off-topic.md
@@ -4,7 +4,7 @@ You can find out about what's on-topic and what's off-topic on $SiteName in the 
 
 This is just a gentle reminder that we expect posts on this site to stay focused on the topic on-hand.
 We have a [Network of communities](/dashboard) that you are free to use; you may find one of our other communities more suitable to some of your posts.
-If you would like to explore creating a site for a subject not currently covered, see [the Proposals process on codidact.con](https://proposals.codidact.com/help/proposals).
+If you would like to explore creating a site for a subject not currently covered, see [the Proposals process on codidact.com](https://proposals.codidact.com/help/proposals).
 
 Additionally, we have a $ChatLink available for more free-form discussion.
 


### PR DESCRIPTION
Updated the link in the off-topic template for how to propose a community.  This isn't ideal because it's specific to codidact.com -- so was the previous version, so it's not a regression, but this is something other instances will need to edit.  It would be better to have a generic template here and then for our prod to modify from there, but we need a better framework for doing that.  Meanwhile, at least the link isn't wrong now.

Fixes https://github.com/codidact/qpixel/issues/1356.
