### PR TITLE
small wording clarification 

### DIFF
--- a/app/views/suggested_edit/show.html.erb
+++ b/app/views/suggested_edit/show.html.erb
@@ -26,7 +26,7 @@
 <form class="widget">
   <div class="widget--body h-bg-tertiary-050">
     <div class="h-f-r">
-      <a class="button is-muted is-outlined" href="<%= generic_share_link(post)  %>">Return to post</a>
+      <a class="button is-muted is-outlined" href="<%= generic_share_link(post)  %>">View post</a>
     </div>
     <% if @edit.pending? %>
       <p class="h-m-0"><strong class="h-c-tertiary-700">Pending.</strong><br>This suggested edit is pending review.</p>


### PR DESCRIPTION
Fixes the easy part of https://meta.codidact.com/posts/291591 -- several paths to this page, so "return to" isn't accurate.
