### PR TITLE
add profile links from other communities

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
                                           :annotate, :annotations, :mod_privileges, :mod_privilege_action]
   before_action :set_user, only: [:show, :mod, :destroy, :soft_delete, :posts, :role_toggle, :full_log, :activity,
                                   :annotate, :annotations, :mod_privileges, :mod_privilege_action,
-                                  :vote_summary, :avatar]
+                                  :vote_summary, :network, :avatar]
   before_action :check_deleted, only: [:show, :posts, :activity]
 
   def index
@@ -205,7 +205,6 @@ class UsersController < ApplicationController
     @communities = Community.all
     render layout: 'without_sidebar'
   end
-  
 
   def activity
     @posts = Post.undeleted.where(user: @user).count

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -201,6 +201,12 @@ class UsersController < ApplicationController
     end
   end
 
+  def network
+    @communities = Community.all
+    render layout: 'without_sidebar'
+  end
+  
+
   def activity
     @posts = Post.undeleted.where(user: @user).count
     @comments = Comment.joins(:comment_thread, :post).undeleted.where(user: @user, comment_threads: { deleted: false },

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -62,7 +62,7 @@ module UsersHelper
   def user_link(user, url_opts = nil, **link_opts)
     url_opts ||= {}
     anchortext = link_opts[:anchortext]
-    if anchortext != nil
+    if !anchortext.nil?
       link_to anchortext, user_url(user, **url_opts), { dir: 'ltr' }.merge(link_opts)
     elsif deleted_user?(user)
       link_to 'deleted user', '#', { dir: 'ltr' }.merge(link_opts).except(:anchortext)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -61,10 +61,13 @@ module UsersHelper
 
   def user_link(user, url_opts = nil, **link_opts)
     url_opts ||= {}
-    if deleted_user?(user)
-      link_to 'deleted user', '#', { dir: 'ltr' }.merge(link_opts)
+    anchortext = link_opts[:anchortext]
+    if anchortext != nil
+      link_to anchortext, user_url(user, **url_opts), { dir: 'ltr' }.merge(link_opts)
+    elsif deleted_user?(user)
+      link_to 'deleted user', '#', { dir: 'ltr' }.merge(link_opts).except(:anchortext)
     else
-      link_to user.rtl_safe_username, user_url(user, **url_opts), { dir: 'ltr' }.merge(link_opts)
+      link_to user.rtl_safe_username, user_url(user, **url_opts), { dir: 'ltr' }.merge(link_opts).except(:anchortext)
     end
   end
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -62,12 +62,13 @@ module UsersHelper
   def user_link(user, url_opts = nil, **link_opts)
     url_opts ||= {}
     anchortext = link_opts[:anchortext]
+    link_opts_reduced = { dir: 'ltr' }.merge(link_opts).except(:anchortext)
     if !anchortext.nil?
       link_to anchortext, user_url(user, **url_opts), { dir: 'ltr' }.merge(link_opts)
     elsif deleted_user?(user)
-      link_to 'deleted user', '#', { dir: 'ltr' }.merge(link_opts).except(:anchortext)
+      link_to 'deleted user', '#', link_opts_reduced
     else
-      link_to user.rtl_safe_username, user_url(user, **url_opts), { dir: 'ltr' }.merge(link_opts).except(:anchortext)
+      link_to user.rtl_safe_username, user_url(user, **url_opts), link_opts_reduced
     end
   end
 

--- a/app/models/community_user.rb
+++ b/app/models/community_user.rb
@@ -28,7 +28,7 @@ class CommunityUser < ApplicationRecord
   def post_count
     Post.unscoped.where(community_id: community_id).where(user: user).undeleted.count
   end
-  
+
   # Calculation functions for privilege scores
   # These are quite expensive, so we'll cache them for a while
   def post_score

--- a/app/models/community_user.rb
+++ b/app/models/community_user.rb
@@ -24,6 +24,11 @@ class CommunityUser < ApplicationRecord
     false
   end
 
+  # All undeleted posts on this community by this user.
+  def post_count
+    Post.unscoped.where(community_id: community_id).where(user: user).undeleted.count
+  end
+  
   # Calculation functions for privilege scores
   # These are quite expensive, so we'll cache them for a while
   def post_score

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # Represents a user. Most of the User's logic is controlled by Devise and its overrides. A user, as far as the
 # application code (i.e. excluding Devise) is concerned, has many questions, answers, and votes.
 class User < ApplicationRecord

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # Represents a user. Most of the User's logic is controlled by Devise and its overrides. A user, as far as the
 # application code (i.e. excluding Devise) is concerned, has many questions, answers, and votes.
 class User < ApplicationRecord
@@ -141,26 +142,22 @@ class User < ApplicationRecord
   # Used by network profile: does this user have a profile on that other comm?
   def has_profile_on(community_id)
     cu = community_users.where(community_id: community_id).first
-    !cu&.user_id.nil?
+    !cu&.user_id.nil? || false
   end
 
   def reputation_on(community_id)
     cu = community_users.where(community_id: community_id).first
-    cu&.reputation
+    cu&.reputation || 1
   end
 
   def post_count_on(community_id)
     cu = community_users.where(community_id: community_id).first
-    cu&.post_count
+    cu&.post_count || 0
   end
 
   def is_moderator_on(community_id)
     cu = community_users.where(community_id: community_id).first
-    if cu&.is_moderator || cu&.privilege?('mod')
-      true
-    else
-      false
-    end
+    cu&.is_moderator || cu&.privilege?('mod')
   end
 
   def has_ability_on(community_id, ability_internal_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # Represents a user. Most of the User's logic is controlled by Devise and its overrides. A user, as far as the
 # application code (i.e. excluding Devise) is concerned, has many questions, answers, and votes.
 class User < ApplicationRecord
@@ -167,7 +166,7 @@ class User < ApplicationRecord
       false
     end
   end
-  
+
   def has_ability_on(community_id, ability_internal_id)
     cu = community_users.where(community_id: community_id).first
     if cu&.is_moderator || cu&.is_admin || is_global_moderator || is_global_admin || cu&.privilege?('mod')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # Represents a user. Most of the User's logic is controlled by Devise and its overrides. A user, as far as the
 # application code (i.e. excluding Devise) is concerned, has many questions, answers, and votes.
 class User < ApplicationRecord
@@ -136,6 +137,15 @@ class User < ApplicationRecord
 
   def is_admin
     is_global_admin || community_user&.is_admin || false
+  end
+
+  def has_profile_on(community_id)
+    cu = community_users.where(community_id: community_id).first
+    if cu&.user_id.nil?
+      false
+    else
+      true
+    end
   end
 
   def has_ability_on(community_id, ability_internal_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -141,11 +141,7 @@ class User < ApplicationRecord
   # Used by network profile: does this user have a profile on that other comm?
   def has_profile_on(community_id)
     cu = community_users.where(community_id: community_id).first
-    if cu&.user_id.nil?
-      false
-    else
-      true
-    end
+    !cu&.user_id.nil?
   end
 
   def reputation_on(community_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -139,6 +139,7 @@ class User < ApplicationRecord
     is_global_admin || community_user&.is_admin || false
   end
 
+  # Used by network profile: does this user have a profile on that other comm?
   def has_profile_on(community_id)
     cu = community_users.where(community_id: community_id).first
     if cu&.user_id.nil?
@@ -148,6 +149,25 @@ class User < ApplicationRecord
     end
   end
 
+  def reputation_on(community_id)
+    cu = community_users.where(community_id: community_id).first
+    cu&.reputation
+  end
+
+  def post_count_on(community_id)
+    cu = community_users.where(community_id: community_id).first
+    cu&.post_count
+  end
+
+  def is_moderator_on(community_id)
+    cu = community_users.where(community_id: community_id).first
+    if cu&.is_moderator || cu&.privilege?('mod')
+      true
+    else
+      false
+    end
+  end
+  
   def has_ability_on(community_id, ability_internal_id)
     cu = community_users.where(community_id: community_id).first
     if cu&.is_moderator || cu&.is_admin || is_global_moderator || is_global_admin || cu&.privilege?('mod')

--- a/app/views/users/_network.html.erb
+++ b/app/views/users/_network.html.erb
@@ -1,15 +1,24 @@
+<p>User: <%= @user %></p>
+<p>User link: <%= user_link @user %></p>
+
 <table class="table is-with-hover is-full-width">
   <tr>
+    <th>User (temporary)</th>
     <th>Community</th>
     <th>Posts</th>
     <th>Reputation</th>
   </tr>
 
   <% @communities.each do |c| %>
-  <tr>
-
-  </tr>
-
+    <% if @user.has_profile_on(c) %>
+    <tr>
+      <td><%= user_link @user, { host: c.host } %>
+      <td><%= c.name %></td>
+      <td><%= @user.posts.count %></td>
+      <td><%= @user.reputation %> </td>
+    </tr>
+    <% end %>
   <% end %>
+  
 
 </table>

--- a/app/views/users/_network.html.erb
+++ b/app/views/users/_network.html.erb
@@ -1,6 +1,3 @@
-<p>User: <%= @user %></p>
-<p>User link: <%= user_link @user %></p>
-
 <table class="table is-with-hover is-full-width">
   <tr>
     <th>User (temporary)</th>
@@ -19,6 +16,5 @@
     </tr>
     <% end %>
   <% end %>
-  
 
 </table>

--- a/app/views/users/_network.html.erb
+++ b/app/views/users/_network.html.erb
@@ -1,7 +1,6 @@
 <table class="table is-with-hover is-full-width">
   <tr>
-    <th>User (temporary)</th>
-    <th>Community</th>
+    <th>Profile on Community</th>
     <th>Posts</th>
     <th>Reputation</th>
   </tr>
@@ -9,10 +8,13 @@
   <% @communities.each do |c| %>
     <% if @user.has_profile_on(c) %>
     <tr>
-      <td><%= user_link @user, { host: c.host } %>
-      <td><%= c.name %></td>
-      <td><%= @user.posts.count %></td>
-      <td><%= @user.reputation %> </td>
+      <td><%= user_link @user, { host: c.host}, anchortext: c.name %>
+	<% if @user.is_moderator_on(c) %>
+	(moderator)
+	<% end %>
+      </td>
+      <td><%= @user.post_count_on(c) %> </td>
+      <td><%= @user.reputation_on(c) %> </td>
     </tr>
     <% end %>
   <% end %>

--- a/app/views/users/_network.html.erb
+++ b/app/views/users/_network.html.erb
@@ -1,0 +1,15 @@
+<table class="table is-with-hover is-full-width">
+  <tr>
+    <th>Community</th>
+    <th>Posts</th>
+    <th>Reputation</th>
+  </tr>
+
+  <% @communities.each do |c| %>
+  <tr>
+
+  </tr>
+
+  <% end %>
+
+</table>

--- a/app/views/users/_tabs.html.erb
+++ b/app/views/users/_tabs.html.erb
@@ -24,5 +24,8 @@
     <%= link_to notifications_path, class: "tabs--item #{current_page?(notifications_path) ? 'is-active' : ''}" do %>
       Notifications
     <% end %>
+    <%= link_to network_path, class: "tabs--item #{current_page?(network_path) ? 'is-active' : ''}" do %>
+      All Communities
+    <% end %>
   <% end %>
 </div>

--- a/app/views/users/_tabs.html.erb
+++ b/app/views/users/_tabs.html.erb
@@ -24,8 +24,8 @@
     <%= link_to notifications_path, class: "tabs--item #{current_page?(notifications_path) ? 'is-active' : ''}" do %>
       Notifications
     <% end %>
-    <%= link_to network_path, class: "tabs--item #{current_page?(network_path) ? 'is-active' : ''}" do %>
-      All Communities
-    <% end %>
+  <% end %>
+  <%= link_to network_path(user), class: "tabs--item #{current_page?(network_path(user)) ? 'is-active' : ''}" do %>
+  All Communities
   <% end %>
 </div>

--- a/app/views/users/network.html.erb
+++ b/app/views/users/network.html.erb
@@ -1,0 +1,10 @@
+<%= render 'tabs', user: current_user %>
+
+<h1>Profiles for <%= user_link @user %></h1>
+
+<p>
+  Links to profiles on other communities on this network.
+</p>
+
+<%= render 'network' %>
+

--- a/app/views/users/network.html.erb
+++ b/app/views/users/network.html.erb
@@ -1,4 +1,4 @@
-<%= render 'tabs', user: current_user %>
+<%= render 'tabs', user: @user %>
 
 <h1>Profiles for <%= user_link @user %></h1>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -202,6 +202,7 @@ Rails.application.routes.draw do
     get    '/:id/mod',                  to: 'users#mod', as: :mod_user
     get    '/:id/posts',                to: 'users#posts', as: :user_posts
     get    '/:id/vote-summary',         to: 'users#vote_summary', as: :vote_summary
+    get    '/:id/network',               to: 'users#network', as: :network
     get    '/:id/mod/privileges',       to: 'users#mod_privileges', as: :user_privileges
     post   '/:id/mod/privileges',       to: 'users#mod_privilege_action', as: :user_privilege_action
     post   '/:id/mod/toggle-role',      to: 'users#role_toggle', as: :toggle_user_role

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -193,6 +193,7 @@ Rails.application.routes.draw do
     get    '/edit/profile',             to: 'users#edit_profile', as: :edit_user_profile
     patch  '/edit/profile',             to: 'users#update_profile', as: :update_user_profile
     get    '/me/vote-summary',          to: 'users#my_vote_summary', as: :my_vote_summary
+    get    '/me/network',               to: 'users#my_network', as: :my_network
     get    '/avatar/:letter/:color/:size', to: 'users#specific_avatar', as: :specific_auto_avatar
     get    '/disconnect-sso',           to: 'users#disconnect_sso', as: :user_disconnect_sso
     post   '/disconnect-sso',           to: 'users#confirm_disconnect_sso', as: :user_confirm_disconnect_sso
@@ -202,7 +203,7 @@ Rails.application.routes.draw do
     get    '/:id/mod',                  to: 'users#mod', as: :mod_user
     get    '/:id/posts',                to: 'users#posts', as: :user_posts
     get    '/:id/vote-summary',         to: 'users#vote_summary', as: :vote_summary
-    get    '/:id/network',               to: 'users#network', as: :network
+    get    '/:id/network',              to: 'users#network', as: :network
     get    '/:id/mod/privileges',       to: 'users#mod_privileges', as: :user_privileges
     post   '/:id/mod/privileges',       to: 'users#mod_privilege_action', as: :user_privilege_action
     post   '/:id/mod/toggle-role',      to: 'users#role_toggle', as: :toggle_user_role


### PR DESCRIPTION
Minimally addresses https://github.com/codidact/qpixel/issues/284 by adding an "all communities" tab to the user profile to hold links to that user's profile on all other network communities where a profile exists. 

Here's a moderator viewing its own tab:

![tab with table: community profile link, mod status where applicable, number of posts, rep](https://github.com/user-attachments/assets/0bc8f583-b270-4c14-96a5-18a932510b58)

And here's how someone else's profile looks:

![same table columns, fewer tabs](https://github.com/user-attachments/assets/07b10e95-7c3c-48d7-bfa8-a785c050192e)

The guts of the profile tab are separated from the "container" (`network.html.erb` renders `_network.html.erb`) to make it easier to pick this up and move it to a truly global place later if we can work out how to do that.  (See discussion on the linked issue.)  Right now, your network profile is part of your user page on each specific community, just like your inbox is, even though these things are really "higher up".

To support this, I added several "accessor" functions to the user model to go fetch information on specific communities.  I followed the pattern of the pre-existing `has_ability_on` function.

Currently this table shows the number of (undeleted) posts on each community.  I was going to separate that out by post type, but post types can be defined in configuration, so that means walking the list of all post types to get their names and counts on each community (some of which might not be enabled on some communities), and I decided to defer that until we decide we need it.  If the consensus from user feedback is that we should have that, we can do it as followup work.

This initial implementation does nothing special with sorting, and I believe the order will automatically be the same as the site switcher and the dashboard.  This implementation also does not give the user a way to change the sort order.  A full implementation would be user-customizable, which requires storing settings somewhere.  Also, we need to work out the UI for custom ordering.

This implementation does not yet have any user-private information.  I once proposed a design that would show you things like where you have new inbox items or flag responses.  I'd still like to do that, but even without it, I think a basic list is better than what we have today.  As a moderator I have sometimes needed to look at a user's activity on other communities, and neither URL editing nor navigating the users list is satisfactory.

I learned a lot about Ruby/Rails while doing this and probably failed to learn other things.  I suspect there are stylistic anomalies in my code ("no don't do it _that_ way!"), which I hope reviewers will point out so I can fix them.