### PR TITLE
RSS link improvements

### DIFF
--- a/app/assets/stylesheets/categories.scss
+++ b/app/assets/stylesheets/categories.scss
@@ -16,6 +16,12 @@
     align-items: center;
     justify-content: space-between;
   }
+
+  & .category-meta--start {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+  }
 }
 
 .category-header--nav {

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -18,13 +18,11 @@
       <%= 'post'.pluralize(post_count) %> &nbsp;
     </span>
 
-    <%= link_to category_feed_path(@category, format: 'rss') do %>
-    <i class="fas fa-rss"></i> RSS
-    <% end %>
+    <%= render 'shared/rss_link', url: category_feed_path(@category, format: 'rss') %>
 
     <span class="has-margin-4">
       <% if current_user&.is_admin %>
-      <%= link_to 'Edit Category', edit_category_path(@category) %> &nbsp;
+        <%= link_to 'Edit Category', edit_category_path(@category) %> &nbsp;
       <% end %>
     </span>
 
@@ -83,7 +81,5 @@
 </div>
 
 <div class="has-padding-top-4">
-  <%= link_to category_feed_path(@category, format: 'rss') do %>
-    <i class="fas fa-rss"></i> Category RSS feed
-  <% end %>
+  <%= render 'shared/rss_link', url: category_feed_path(@category, format: 'rss'), text: 'Category RSS feed' %>
 </div>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -12,20 +12,17 @@
 
 <% post_count = @posts.count %>
 <div class="has-color-tertiary-500 category-meta">
-  <span>
+  <span class=category-meta--start>
     <span title="<%= post_count %> posts">
       <%= short_number_to_human post_count, precision: 1, significant: false %>
-      <%= 'post'.pluralize(post_count) %> &nbsp;
+      <%= 'post'.pluralize(post_count) %>
     </span>
-
     <%= render 'shared/rss_link', url: category_feed_path(@category, format: 'rss') %>
-
     <span class="has-margin-4">
       <% if current_user&.is_admin %>
-        <%= link_to 'Edit Category', edit_category_path(@category) %> &nbsp;
+        <%= link_to 'Edit Category', edit_category_path(@category) %>
       <% end %>
     </span>
-
   </span>
 
   <div class="button-list is-gutterless has-margin-2">

--- a/app/views/shared/_rss_link.html.erb
+++ b/app/views/shared/_rss_link.html.erb
@@ -1,0 +1,20 @@
+<%# 
+   'Adds an RSS link.
+    Variables:
+      url     : [String] URL to the feed
+      text    : [String, Nil] text to visibly show
+      tooltip : [String, Nil] text to show in the tooltip
+   '
+ %>
+
+<%
+  # Defaults
+  text = defined?(text) ? text : 'RSS'
+  tooltip = defined?(tooltip) ? tooltip : 'RSS Feed'
+%>
+
+<span title="<%= tooltip %>">
+  <%= link_to url, class: 'has-display-inline-block' do %>
+    <i class="fas fa-rss"></i> RSS
+  <% end %>
+</span>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -91,14 +91,12 @@
 
 <% post_count = @posts.count %>
 <div class="has-color-tertiary-500 category-meta" title="<%= post_count %>">
-  <div>
+  <div class="category-meta--start">
     <span title="<%= post_count %> posts with this tag">
       <%= short_number_to_human post_count, precision: 1, significant: false %>
-      <%= 'post'.pluralize(post_count) %> &nbsp;&nbsp;
+      <%= 'post'.pluralize(post_count) %>
     </span>
-
     <%= render 'shared/rss_link', url: tag_path(id: @category.id, tag_id: @tag.id, format: 'rss'), tooltip: 'RSS feed for this tag' %>
-
     <% if user_signed_in? && current_user&.subscriptions.where(type: 'tag', qualifier: @tag.name).exists? %>
       <span class="has-margin-4" title="Subscribed: manage email subscriptions">
         <%= link_to 'Subscribed', subscriptions_path(current_user),

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -32,7 +32,7 @@
 
 <p class="has-color-tertiary-900 has-font-weight-normal has-margin-0 has-font-family-brand">
   <% if @tag.parent_id.present? %>
-      Subtag of <%= link_to @tag.parent.name, tag_path(id: @category.id, tag_id: @tag.parent_id),
+    Subtag of <%= link_to @tag.parent.name, tag_path(id: @category.id, tag_id: @tag.parent_id),
                             class: tag_classes(@tag.parent, @category) %>
   <% end %>
   <% child_count = @tag.children.count %>
@@ -62,12 +62,12 @@
   <div class="widget--body">
     <% if @tag.wiki.present? %>
       <% if @tag.wiki.length < 600 %>
-      <%= raw(sanitize(@tag.wiki, scrubber: scrubber)) %>
-      <% else %>
-      <details>
-        <summary>Tag Wiki</summary>
         <%= raw(sanitize(@tag.wiki, scrubber: scrubber)) %>
-      </details>
+      <% else %>
+        <details>
+          <summary>Tag Wiki</summary>
+          <%= raw(sanitize(@tag.wiki, scrubber: scrubber)) %>
+        </details>
       <% end %>
     <% end %>
     <% unless @tag.wiki.present? %>
@@ -97,23 +97,19 @@
       <%= 'post'.pluralize(post_count) %> &nbsp;&nbsp;
     </span>
 
-    <span title="RSS feed for this tag">
-      <%= link_to tag_path(id: @category.id, tag_id: @tag.id, format: 'rss') do %>
-      <i class="fas fa-rss"></i> RSS
-      <% end %>
-    </span>
+    <%= render 'shared/rss_link', url: tag_path(id: @category.id, tag_id: @tag.id, format: 'rss'), tooltip: 'RSS feed for this tag' %>
 
     <% if user_signed_in? && current_user&.subscriptions.where(type: 'tag', qualifier: @tag.name).exists? %>
-    <span class="has-margin-4" title="Subscribed: manage email subscriptions">
-      <%= link_to 'Subscribed', subscriptions_path(current_user),
+      <span class="has-margin-4" title="Subscribed: manage email subscriptions">
+        <%= link_to 'Subscribed', subscriptions_path(current_user),
           class: 'button is-outlined', 'aria-label': "Subscribed to tag #{@tag.name}" %>
-    </span>
+      </span>
     <% else %>
-    <span title="Create email subscription">
-      <%= link_to 'Subscribe',
+      <span title="Create email subscription">
+        <%= link_to 'Subscribe',
           new_subscription_path(type: 'tag', qualifier: @tag.name, return_to: request.path),
           class: 'button is-outlined', 'aria-label': "Subscribe to tag #{@tag.name}" %>
-    </span>
+      </span>
     <% end %>
   </div>
 
@@ -138,7 +134,5 @@
 </div>
 
 <div class="has-padding-top-4">
-  <%= link_to tag_path(id: @category.id, tag_id: @tag.id, format: 'rss') do %>
-    <i class="fas fa-rss"></i> Tag RSS feed
-  <% end %>
+  <%= render 'shared/rss_link', url: tag_path(id: @category.id, tag_id: @tag.id, format: 'rss'), text: 'Tag RSS feed' %>
 </div>


### PR DESCRIPTION
@cellio I'd like to expand a bit on your [PR](#1399) regarding the RSS links. This PR targets _your branch_ and adds:

- adds a proper configurable partial for RSS links;
- fixes the trailing whitespace underlining on hover (that's not related to your fix in response to my review, it's a general issue with our templates);
- solves the annoying misalignment of the header (see screenshot):

![2024-09-21_02-35](https://github.com/user-attachments/assets/f80bfbe0-24d6-42c9-b6ba-101032ad9575)

If you'd like, we can merge the changes into your branch and then merge to `develop`.