### PR TITLE
Latest version timestamp format fixup

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -2,10 +2,10 @@
   <div class="footer--container container">
     <div class="grid">
       <div class="grid--cell is-6 is-12-md is-12-sm">
-	<ul>
+        <ul>
           <li><%= link_to 'Our Communities', '/dashboard' %></li>
           <li><%= link_to 'About Us', '/policy/network-faq' %></li>
-	</ul>
+        </ul>
       </div>
       <div class="grid--cell is-6 is-12-md is-12-sm">
         <ul>
@@ -16,7 +16,9 @@
       </div>
     </div>
     <% commit = Rails.cache.persistent('current_commit') %>
-    <p>Powered by <%= link_to 'Codidact', 'https://codidact.org/' %>. Version <%= link_to commit[0][0..7], "https://github.com/codidact/qpixel/commit/#{commit[0]}" %> (<%= commit[1] %>)
+    <p>Powered by <%= link_to 'Codidact', 'https://codidact.org/' %>. Version <%= 
+      link_to commit[0][0..7], "https://github.com/codidact/qpixel/commit/#{commit[0]}" 
+    %> (<%= DateTime.iso8601(commit[1]).to_time.utc.strftime('%F %TZ') %>)
     </p>
   </div>
 </footer>

--- a/config/initializers/zz_cache_setup.rb
+++ b/config/initializers/zz_cache_setup.rb
@@ -1,3 +1,3 @@
 Rails.cache.persistent 'current_commit', clear: true do
-  [`git rev-parse HEAD`.strip, `git log -1 --date=iso --pretty=format:%cd`.strip]
+  [`git rev-parse HEAD`.strip, `git log -1 --date=iso-strict --pretty=format:%cd`.strip]
 end


### PR DESCRIPTION
This fixup switches the latest commit timestamp to UTC+0 properly formatted as an ISO8601 string (addendum for the [footer PR](https://github.com/codidact/qpixel/pull/1402)).