### PR TITLE
Make current commit parsing more resilient

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -190,4 +190,17 @@ module ApplicationHelper
       false
     end
   end
+
+  def current_commit
+    commit_info = Rails.cache.persistent('current_commit')
+    shasum, timestamp = commit_info
+
+    begin
+      date = DateTime.iso8601(timestamp)
+    rescue
+      date = DateTime.parse(timestamp)
+    end
+
+    [shasum, date]
+  end
 end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -15,10 +15,10 @@
         </ul>
       </div>
     </div>
-    <% commit = Rails.cache.persistent('current_commit') %>
+    <% sha, date = current_commit %>
     <p>Powered by <%= link_to 'Codidact', 'https://codidact.org/' %>. Version <%= 
-      link_to commit[0][0..7], "https://github.com/codidact/qpixel/commit/#{commit[0]}" 
-    %> (<%= DateTime.iso8601(commit[1]).to_time.utc.strftime('%F %TZ') %>)
+      link_to sha[0..7], "https://github.com/codidact/qpixel/commit/#{sha}" 
+    %> (<%= date.to_time.utc.strftime('%F %TZ') %>)
     </p>
   </div>
 </footer>

--- a/config/initializers/zz_cache_setup.rb
+++ b/config/initializers/zz_cache_setup.rb
@@ -1,3 +1,5 @@
 Rails.cache.persistent 'current_commit', clear: true do
-  [`git rev-parse HEAD`.strip, `git log -1 --date=iso-strict --pretty=format:%cd`.strip]
+  commit_sha = `git rev-parse HEAD`.strip
+  commit_date = `git log -1 --date=iso-strict --pretty=format:%cd`.strip
+  [commit_sha, commit_date]
 end


### PR DESCRIPTION
This PR makes timestamp parsing more resilient to errors (we got a case where an old, non-strict ISO timestamp was still cached on a local machine after the timestamp change was merged, which brought down the server). Additionally, the PR adds a new application helper (`current_commit`) for getting the commit info.