### PR TITLE
restrict deletion of freely-editable (wiki) posts

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -392,7 +392,7 @@ class PostsController < ApplicationController
       redirect_to post_path(@post)
       return
     end
-      
+
     if @post.children.any? { |a| !a.deleted? && a.score >= 0.5 } && !current_user&.is_moderator
       flash[:danger] = helpers.i18ns('posts.cant_delete_responded')
       redirect_to post_path(@post)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -387,6 +387,12 @@ class PostsController < ApplicationController
       return
     end
 
+    if @post.post_type.is_freely_editable && !current_user&.is_moderator
+      flash[:danger] = helpers.i18ns('posts.cant_delete_community')
+      redirect_to post_path(@post)
+      return
+    end
+      
     if @post.children.any? { |a| !a.deleted? && a.score >= 0.5 } && !current_user&.is_moderator
       flash[:danger] = helpers.i18ns('posts.cant_delete_responded')
       redirect_to post_path(@post)

--- a/config/locales/strings/en.posts.yml
+++ b/config/locales/strings/en.posts.yml
@@ -25,6 +25,8 @@ en:
       Can't delete a deleted post.
     cant_delete_responded: >
       This post cannot be deleted because it has responses.
+    cant_delete_community: >
+      This post cannot be deleted because it is owned by the community (freely editable).
     cant_restore_post: >
       Can't restore this post right now. Try again later.
     cant_restore_undeleted: >


### PR DESCRIPTION
Normally, the owner of a post can delete it regardless of abilities.  However, the original creator of a post with the `freely_editable` property, which is intended for community-owned posts, should not be able to delete a post out from under the community.

This PR adds a check that allows only moderators to delete such posts.  It would be better to allow curators to do so, as curators can delete (or undelete) other posts.  Here's the problem: the `check_your_privilege` function checks if you have an ability _or are the owner of a post_, so I can't just call this function.  I don't want to change the contract of this widely-used function.  I could add another function, `check_your_privilege_strictly`, that skips the ownership check, but I don't know if that's good style.  I can't think of a way to have the controller check if you only have the privilege because you're the owner (and thus deny deletion).  It feels like we need to discuss a little architecture before trying to do that.

Meanwhile, we can at least make it so that only mods can delete such posts, plugging a gap we have now.  I'd love to hear input on how to best enable it for curators.

Fixes https://github.com/codidact/qpixel/issues/1394.