### PR TITLE
Clean up spammers automatically

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -338,13 +338,7 @@ class UsersController < ApplicationController
         return
       end
 
-      AuditLog.moderator_audit(event_type: 'user_delete', related: @user, user: current_user,
-                               comment: @user.attributes_print(join: "\n"))
-      @user.assign_attributes(deleted: true, deleted_by_id: current_user.id, deleted_at: DateTime.now,
-                              username: "user#{@user.id}", email: "#{@user.id}@deleted.localhost",
-                              password: SecureRandom.hex(32))
-      @user.skip_reconfirmation!
-      @user.save
+      @user.do_soft_delete(current_user)
     else
       render json: { status: 'failed', message: 'Unrecognised deletion type.' }, status: 400
       return

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,7 @@
+class ApplicationJob < ActiveJob::Base
+  # Automatically retry jobs that encountered a deadlock
+  # retry_on ActiveRecord::Deadlocked
+
+  # Most jobs are safe to ignore if the underlying records are no longer available
+  # discard_on ActiveJob::DeserializationError
+end

--- a/app/jobs/clean_up_spammy_users_job.rb
+++ b/app/jobs/clean_up_spammy_users_job.rb
@@ -15,6 +15,7 @@ class CleanUpSpammyUsersJob < ApplicationJob
       end
       if all_posts_spam
         spammer.block('automatic block from spam cleanup job', length: 2.years)
+        spammer.do_soft_delete(User.find(-1))
       end
     end
   end

--- a/app/jobs/clean_up_spammy_users_job.rb
+++ b/app/jobs/clean_up_spammy_users_job.rb
@@ -1,0 +1,21 @@
+class CleanUpSpammyUsersJob < ApplicationJob
+  queue_as :default
+
+  def perform(created_after: 1.month.ago)
+    # Select potential spammers: users created within timeframe, who are not deleted, who have posted but all posts have
+    # since been deleted (no live posts).
+    possible_spammers = User.joins('inner join posts on users.id = posts.user_id')
+                            .where('users.created_at >= ?', created_after)
+                            .where(users: { deleted: false }).group('users.id').having('count(posts.id) > 0')
+                            .having('count(distinct if(posts.deleted = true, null, posts.id)) = 0')
+    possible_spammers.each do |spammer|
+      all_posts_spam = spammer.posts.all? do |post|
+        # A post is considered spam if there are any helpful spam flags on it.
+        post.flags.any? { |flag| flag.post_flag_type.name == "it's spam" && flag.status == 'helpful' }
+      end
+      if all_posts_spam
+        spammer.block('automatic block from spam cleanup job', length: 2.years)
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -332,7 +332,7 @@ class User < ApplicationRecord
   def do_soft_delete(attribute_to)
     AuditLog.moderator_audit(event_type: 'user_delete', related: self, user: attribute_to,
                              comment: attributes_print(join: "\n"))
-    assign_attributes(deleted: true, deleted_by_id: current_user.id, deleted_at: DateTime.now,
+    assign_attributes(deleted: true, deleted_by_id: attribute_to.id, deleted_at: DateTime.now,
                       username: "user#{id}", email: "#{id}@deleted.localhost",
                       password: SecureRandom.hex(32))
     skip_reconfirmation!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -331,10 +331,10 @@ class User < ApplicationRecord
 
   def do_soft_delete(attribute_to)
     AuditLog.moderator_audit(event_type: 'user_delete', related: self, user: attribute_to,
-                             comment: self.attributes_print(join: "\n"))
+                             comment: attributes_print(join: "\n"))
     assign_attributes(deleted: true, deleted_by_id: current_user.id, deleted_at: DateTime.now,
-                            username: "user#{self.id}", email: "#{self.id}@deleted.localhost",
-                            password: SecureRandom.hex(32))
+                      username: "user#{id}", email: "#{id}@deleted.localhost",
+                      password: SecureRandom.hex(32))
     skip_reconfirmation!
     save
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -268,7 +268,7 @@ class User < ApplicationRecord
                         'how this site works.', '/tour')
   end
 
-  def block(reason)
+  def block(reason, length: 180.days)
     user_email = email
     user_ip = [last_sign_in_ip]
 
@@ -276,10 +276,10 @@ class User < ApplicationRecord
       user_ip << current_sign_in_ip
     end
 
-    BlockedItem.create(item_type: 'email', value: user_email, expires: DateTime.now + 180.days,
+    BlockedItem.create(item_type: 'email', value: user_email, expires: length.from_now,
                        automatic: true, reason: "#{reason}: #" + id.to_s)
     user_ip.compact.uniq.each do |ip|
-      BlockedItem.create(item_type: 'ip', value: ip, expires: 180.days.from_now,
+      BlockedItem.create(item_type: 'ip', value: ip, expires: length.from_now,
                          automatic: true, reason: "#{reason}: #" + id.to_s)
     end
   end
@@ -328,5 +328,16 @@ class User < ApplicationRecord
   def active_flags(post)
     post.flags.where(user: self, status: nil)
   end
+
+  def do_soft_delete(attribute_to)
+    AuditLog.moderator_audit(event_type: 'user_delete', related: self, user: attribute_to,
+                             comment: self.attributes_print(join: "\n"))
+    assign_attributes(deleted: true, deleted_by_id: current_user.id, deleted_at: DateTime.now,
+                            username: "user#{self.id}", email: "#{self.id}@deleted.localhost",
+                            password: SecureRandom.hex(32))
+    skip_reconfirmation!
+    save
+  end
+
   # rubocop:enable Naming/PredicateName
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -6,10 +6,14 @@ every 1.day, at: '02:05' do
   runner 'scripts/mail_uncaptured_donations.rb'
 end
 
-every 6.hours do
-  runner 'scripts/recalc_abilities.rb'
-end
-
 every 1.day, at: '02:10' do
   runner 'scripts/prune_email_logs.rb'
+end
+
+every 1.day, at: '02:15' do
+  runner 'scripts/run_spam_cleanup.rb'
+end
+
+every 6.hours do
+  runner 'scripts/recalc_abilities.rb'
 end

--- a/scripts/run_spam_cleanup.rb
+++ b/scripts/run_spam_cleanup.rb
@@ -1,0 +1,1 @@
+CleanUpSpammyUsersJob.perform_later

--- a/test/jobs/clean_up_spammy_users_job_test.rb
+++ b/test/jobs/clean_up_spammy_users_job_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class CleanUpSpammyUsersJobTest < ActiveJob::TestCase
   # test "the truth" do

--- a/test/jobs/clean_up_spammy_users_job_test.rb
+++ b/test/jobs/clean_up_spammy_users_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CleanUpSpammyUsersJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Clean up spam users automatically. Runs every night to clean up users who have posted, but whose posts have all since been deleted with at least one helpful spam flag on them. Feeds to STAT and soft-deletes the users, in the same way a moderator can.