### PR TITLE
when deciding whether to show TOC, count only undeleted posts

### DIFF
--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -482,7 +482,7 @@
           </div>
         <% end %>
 
-        <% if is_top_level && post.children.length >= SiteSetting["TableOfContentsThreshold"] && SiteSetting["TableOfContentsThreshold"] != -1 %>
+        <% if is_top_level && post.children.undeleted.length >= SiteSetting["TableOfContentsThreshold"] && SiteSetting["TableOfContentsThreshold"] != -1 %>
           <div class="toc has-margin-left-4" id="toc-toggle">
             <button class="toc--header" data-toggle="#toc-toggle" data-toggle-property="class" data-toggle-value="is-active">Table of Contents</button>
             <% sorted_answers = post.children.sort_by { |answer| answer.score }.reverse! %>


### PR DESCRIPTION
When deciding whether to show the table of contents on a post, we compared the number of posts to the threshold.  But we counted deleted posts, which was confusing (especially if all are deleted).  Now we just count the undeleted ones.

An argument could be made that we should count the deleted ones if you can see them and not if you can't.  However, we don't do that on the category list page, where you might see "3 answers" and then go there and find 3 undeleted and more deleted.  I opted for consistency over stricter context here.  When a TOC does appear it does include deleted answers if you can see them, so this is only about making the decision about whether to show it.

Fixes https://github.com/codidact/qpixel/issues/1166.