### PR TITLE
Ignore emacs temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ qpixel-import.tar.gz
 # Ignore Vim stuff.
 *.swp
 
+# Ignore emacs stuff.
+*~
+
 dump.rdb
 
 # Ignore IRB files


### PR DESCRIPTION
Can haz ignore for emacs backup files plz? :-)  We already have vim, and not having this gives me a lot of pollution in a `git status`.  I've been locally modifying it, but why not just commit it?
