### PR TITLE
on 2fa code-response page, focus on textbox

### DIFF
--- a/app/views/users/sessions/verify_2fa.html.erb
+++ b/app/views/users/sessions/verify_2fa.html.erb
@@ -1,4 +1,11 @@
 <h1>Two-factor authentication</h1>
+
+<script>
+  window.onload = function() {
+      document.getElementById("code").focus();
+  };
+</script>
+
 <p>
   Your account has two-factor authentication enabled. Enter a code from your authenticator app here.
 </p>

--- a/app/views/users/sessions/verify_2fa.html.erb
+++ b/app/views/users/sessions/verify_2fa.html.erb
@@ -1,9 +1,13 @@
 <h1>Two-factor authentication</h1>
 
 <script>
-  window.onload = function() {
-      document.getElementById("code").focus();
-  };
+  addEventListener('load', () => {
+      const codeElem = document.getElementById("code");
+
+      if (codeElem) {
+	  codeElem.focus();
+      }
+  });
 </script>
 
 <p>

--- a/app/views/users/sessions/verify_2fa.html.erb
+++ b/app/views/users/sessions/verify_2fa.html.erb
@@ -1,7 +1,7 @@
 <h1>Two-factor authentication</h1>
 
 <script>
-  addEventListener('load', () => {
+  window.addEventListener('load', () => {
       const codeElem = document.getElementById("code");
 
       if (codeElem) {

--- a/app/views/users/sessions/verify_2fa.html.erb
+++ b/app/views/users/sessions/verify_2fa.html.erb
@@ -1,15 +1,5 @@
 <h1>Two-factor authentication</h1>
 
-<script>
-  window.addEventListener('load', () => {
-      const codeElem = document.getElementById("code");
-
-      if (codeElem) {
-	  codeElem.focus();
-      }
-  });
-</script>
-
 <p>
   Your account has two-factor authentication enabled. Enter a code from your authenticator app here.
 </p>
@@ -19,7 +9,7 @@
 
   <div class="form-group">
     <%= label_tag 'code', 'Code', class: 'form-element' %>
-    <%= text_field_tag 'code', '', class: 'form-element', autocomplete: 'one-time-code' %>
+    <%= text_field_tag 'code', '', class: 'form-element', autocomplete: 'one-time-code', autofocus: 'true' %>
   </div>
 
   <div class="actions">


### PR DESCRIPTION
Focus on code input box instead of requiring a click.  There is nothing else to do on this page so that's a safe assumption.

Fixes https://github.com/codidact/qpixel/issues/1400.