### PR TITLE
Add support for 'me' as a user ID

### DIFF
--- a/app/controllers/flags_controller.rb
+++ b/app/controllers/flags_controller.rb
@@ -41,7 +41,7 @@ class FlagsController < ApplicationController
   end
 
   def history
-    @user = User.find(params[:id])
+    @user = helpers.user_with_me params[:id]
     unless @user == current_user || (current_user.is_admin || current_user.is_moderator)
       not_found
       return

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -632,7 +632,12 @@ class UsersController < ApplicationController
   end
 
   def set_user
-    @user = user_scope.find_by(id: params[:id])
+    user_id = if params[:id] == 'me' && user_signed_in?
+                current_user.id
+              else
+                params[:id]
+              end
+    @user = user_scope.find_by(id: user_id)
     not_found if @user.nil?
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -201,6 +201,10 @@ class UsersController < ApplicationController
     end
   end
 
+  def my_network
+    redirect_to network_path(current_user)
+  end
+
   def network
     @communities = Community.all
     render layout: 'without_sidebar'

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -79,4 +79,17 @@ module UsersHelper
   def devise_sign_in_enabled?
     SiteSetting['MixedSignIn'] || !sso_sign_in_enabled?
   end
+
+  ##
+  # Returns a user corresponding to the ID provided, with the caveat that if +user_id+ is 'me' and there is a user
+  # signed in, the signed in user will be returned. Use for /users/me links.
+  # @param [String] user_id The user ID to find, from +params+
+  # @return [User] The User object
+  def user_with_me(user_id)
+    if user_id == 'me' && user_signed_in?
+      current_user
+    else
+      User.find(user_id)
+    end
+  end
 end


### PR DESCRIPTION
Closes #1439

Allows `set_user` to process `'me'` as a special case so that me-links work across the users controller.