### PR TITLE
add policy links

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -8,8 +8,7 @@
 <% end %>
 
 <div class="notice is-info has-margin-bottom-4">
-  <i class="fas fa-info-circle"></i> Your sign-in information is the same on all
-  <a href="https://codidact.com/">Codidact communities</a>.
+  <i class="fas fa-info-circle"></i> Your sign-in information is the same on all communities on this network.
 </div>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name), method: :post) do |f| %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -8,7 +8,8 @@
 <% end %>
 
 <div class="notice is-info has-margin-bottom-4">
-  <i class="fas fa-info-circle"></i> Your sign-in information is the same on all communities on this network.
+  <p><i class="fas fa-info-circle"></i> Your sign-in information is the same on all communities on this network.</p>
+  <p>By signing in, you agree to abide by our <a href="/help/tos">Terms of Service</a>, <a href="/help/code-of-conduct">Code of Conduct</a>, <a href="/help/spam">Guidelines for promotional content</a>, and any other policies listed in the <a href="/help">Help Center</a>.</p>
 </div>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name), method: :post) do |f| %>


### PR DESCRIPTION
Partially in response to https://meta.codidact.com/posts/292975, added links to the ToS, CoC, spam policy, and "any other policies" to the sign-in page.  I was going to add those links to the confirmation email, but the confirmation link takes you straight to the sign-in page and this way the links are visible after the first sign-in too, so I thought this was a better place to put them. 

![Screenshot of new notice](https://github.com/user-attachments/assets/7a4e91bc-f09b-482f-b608-a56e4421769f)

The three explicit links are "safe" in that those pages are seeded for new installations, but if anybody adds more policies (like a university with an IRB policy or a workplace with an NDA), they wouldn't be able to add those without forking the code, hence the catch-all.
