### PR TITLE
Fix empty ephemeral tags in post drafts if the draft is saved with no tags

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -602,7 +602,9 @@ class PostsController < ApplicationController
       key_name = [:body, :saved_at].include?(key) ? base_key : "#{base_key}.#{key}"
 
       if key == :tags
-        RequestContext.redis.sadd(key_name, params[key])
+        if params[key].present?
+          RequestContext.redis.sadd(key_name, params[key])
+        end
       else
         RequestContext.redis.set(key_name, params[key])
       end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -14,6 +14,10 @@ every 1.day, at: '02:15' do
   runner 'scripts/run_spam_cleanup.rb'
 end
 
+every 1.day, at: '02:20' do
+  runner 'scripts/cleanup_drafts.rb'
+end
+
 every 6.hours do
   runner 'scripts/recalc_abilities.rb'
 end

--- a/scripts/cleanup_drafts.rb
+++ b/scripts/cleanup_drafts.rb
@@ -1,0 +1,5 @@
+redis = RequestContext.redis
+
+redis.scan_each(:match => "saved_post.*.*.tags") do |key| 
+  redis.srem?(key, '')
+end


### PR DESCRIPTION
closes #1457 

This PR fixes an issue with saving post drafts with no tags. Due to a `null` value coming from a completely empty tag field, we end up persisting a `nil` value in Redis. This results in conversion to an empty string on load, which in turn ends up showing an empty tag box in the field.

Also introduces a daily job for automatic cleanup of drafts (for now, the only action is to non-destructively fix existing drafts).