### PR TITLE
Fix tags select clear button

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -206,7 +206,7 @@ $(() => {
     draftTimeout = setTimeout(() => {
       const { draft, field } = parseDraft(ev.target);
       saveDraft(draft, field);
-    }, 3000);
+    }, 1000);
   });
 
   postFields.on('paste', async (evt) => {

--- a/app/assets/javascripts/tags.js
+++ b/app/assets/javascripts/tags.js
@@ -68,6 +68,7 @@ $(() => {
           };
         },
       },
+      placeholder: '',
       templateResult: template,
       allowClear: true
     });

--- a/app/assets/javascripts/tags.js
+++ b/app/assets/javascripts/tags.js
@@ -23,7 +23,7 @@ $(() => {
     return $(tagSpan + descSpan);
   }
 
-  $('.js-tag-select').each((i, el) => {
+  $('.js-tag-select').each((_i, el) => {
     const $tgt = $(el);
     let $this;
     const useIds = $tgt.attr('data-use-ids') === 'true';
@@ -46,7 +46,7 @@ $(() => {
         },
         headers: { 'Accept': 'application/json' },
         delay: 100,
-        processResults: data => {
+        processResults: (data) => {
           // (for the tour)
           if (Number($this.data('tag-set')) === -1) {
             return {
@@ -91,7 +91,7 @@ $(() => {
     return synonymsString;
   }
 
-  $('#add-tag-synonym').on('click', ev => {
+  $('#add-tag-synonym').on('click', (ev) => {
     const $wrapper = $('#tag-synonyms-wrapper');
     const lastId = $wrapper.children('.tag-synonym').last().attr('data-id');
     const newId = parseInt(lastId, 10) + 1;
@@ -121,7 +121,7 @@ $(() => {
     synonym.hide();
   }
 
-  $('.js-add-required-tag').on('click', ev => {
+  $('.js-add-required-tag').on('click', (ev) => {
     const $tgt = $(ev.target);
     const useIds = $tgt.attr('data-use-ids') === 'true';
     const tagId = $tgt.attr('data-tag-id');
@@ -137,7 +137,7 @@ $(() => {
     }
   });
 
-  $('.js-rename-tag').on('click', async ev => {
+  $('.js-rename-tag').on('click', async (ev) => {
     const $tgt = $(ev.target).is('a') ? $(ev.target) : $(ev.target).parents('a');
     const categoryId = $tgt.attr('data-category');
     const tagId = $tgt.attr('data-tag');

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -602,8 +602,12 @@ class PostsController < ApplicationController
       key_name = [:body, :saved_at].include?(key) ? base_key : "#{base_key}.#{key}"
 
       if key == :tags
-        if params[key].present?
-          RequestContext.redis.sadd(key_name, params[key])
+        valid_tags = params[key]&.select(&:present?)
+
+        if valid_tags.present?
+          RequestContext.redis.sadd(key_name, valid_tags)
+        else
+          RequestContext.redis.del(key_name)
         end
       else
         RequestContext.redis.set(key_name, params[key])

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -604,10 +604,10 @@ class PostsController < ApplicationController
       if key == :tags
         valid_tags = params[key]&.select(&:present?)
 
+        RequestContext.redis.del(key_name)
+
         if valid_tags.present?
           RequestContext.redis.sadd(key_name, valid_tags)
-        else
-          RequestContext.redis.del(key_name)
         end
       else
         RequestContext.redis.set(key_name, params[key])

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -221,7 +221,7 @@
       <% disabled = @category.tag_set.nil? %>
       <%= f.select :required_tag_ids, options_for_select(@category.required_tags.map { |t| [t.name, t.id] },
                                                          selected: @category.required_tag_ids),
-                   { include_blank: true }, multiple: true, class: 'form-element js-tag-select js-required-tags',
+                   {}, multiple: true, class: 'form-element js-tag-select js-required-tags',
                    data: { tag_set: @category.tag_set&.id, create: 'false', use_ids: 'true' }, disabled: disabled %>
     </div>
 
@@ -239,7 +239,7 @@
 
       <%= f.select :topic_tag_ids, options_for_select(@category.topic_tags.map { |t| [t.name, t.id] },
                                                       selected: @category.topic_tag_ids),
-                   { include_blank: true }, multiple: true, class: 'form-element js-tag-select js-topic-tags',
+                   {}, multiple: true, class: 'form-element js-tag-select js-topic-tags',
                    data: { tag_set: @category.tag_set&.id, create: 'false', use_ids: 'true' }, disabled: disabled %>
     </div>
 
@@ -256,7 +256,7 @@
 
       <%= f.select :moderator_tag_ids, options_for_select(@category.moderator_tags.map { |t| [t.name, t.id] },
                                                           selected: @category.moderator_tag_ids),
-                   { include_blank: true }, multiple: true, class: 'form-element js-tag-select js-moderator-tags',
+                   {}, multiple: true, class: 'form-element js-tag-select js-moderator-tags',
                    data: { tag_set: @category.tag_set&.id, create: 'false', use_ids: 'true' }, disabled: disabled %>
     </div>
   </details>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -129,7 +129,7 @@
       <%= f.select :tags_cache, options_for_select(
                                   (tags || post.tags_cache).map { |t| [t, t] },
                                   selected: tags || post.tags_cache),
-                   { include_blank: true },
+                   {},
                    multiple: true,
                    class: "form-element js-tag-select",
                    data: { tag_set: category.tag_set_id } %>

--- a/app/views/tour/question2.html.erb
+++ b/app/views/tour/question2.html.erb
@@ -43,7 +43,13 @@
 
     <div class="form-group">
       <label class="form-element" for="post_tags_cache">Tags (at least one):</label>
-      <input name="post[tags_cache][]" type="hidden" value="" /><select multiple="multiple" class="form-element js-tag-select" data-tag-set="<%= @tagset_id %>" name="post[tags_cache][]" id="post_tags_cache"><option value=""></option></select>
+      <input name="post[tags_cache][]" type="hidden" value="" />
+      <select multiple="multiple" 
+              class="form-element js-tag-select" 
+              data-tag-set="<%= @tagset_id %>" 
+              name="post[tags_cache][]" 
+              id="post_tags_cache">
+      </select>
     </div>
 
   </div>


### PR DESCRIPTION
closes #1462 

This PR consists of a couple of fixes for tag handling:

- `save_draft` method on the `posts_controller` now validates that the incoming tags array does not consist of empty elements only;
- `save_draft` method removes existing tags array before inserting new elements (ensures correct partial updates);
- reduced delay before a draft is saved to 1 second (3 seconds is way too long to be useful);
- tag clear button requires `placeholder` to be set to work (`select2` doesn't check if placeholder is provided before accessing its `id` property);
- `include_blank` option should not be used with `multiple` select fields. Otherwise, `select2` will add an ephemeral tag (with an empty name) every time it's cleared;