### PR TITLE
pagination breaks when there are no tags

### DIFF
--- a/app/views/tags/category.html.erb
+++ b/app/views/tags/category.html.erb
@@ -53,7 +53,9 @@
   <% end %>
 <% end %>
 
+<% if @tags&.size > 0 %>
 <%= will_paginate @tags, renderer: BootstrapPagination::Rails %>
+<% end %>
 
 <% end %> <%# unless @tags == nil %>
 


### PR DESCRIPTION
Fixes https://github.com/codidact/qpixel/issues/1353 .  The problem is that we were checking nil but not a count of 0, and apparently tags pagination requires there actually be something there.

I do not fully understand the problem, because it appears that other places with pagination don't have these kinds of checks, but with this check in place, I can't break tag search in my local dev environment, so I propose to try it.
