### PR TITLE
Fixes for some minor positioning annoyances

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -17,14 +17,6 @@ select.form-element {
 
   @media screen and (min-width: $screen-md) {
     flex-direction: row;
-
-    & > :first-child {
-      margin: 0 0.5em 0 0 !important;
-    }
-
-    & > :last-child {
-      margin: 0 0 0 0.5em !important;
-    }
   }
 
   & > .form-group {

--- a/app/views/micro_auth/apps/index.html.erb
+++ b/app/views/micro_auth/apps/index.html.erb
@@ -29,7 +29,9 @@
       <%= text_field_tag :search, params[:search], class: 'form-element' %>
     </div>
     <div class="actions has-padding-bottom-1">
-      <%= submit_tag 'Search', class: 'button' %>
+     <%= button_tag type: :submit, class: 'button is-medium is-filled is-outlined', name: nil do %>
+        <i class="fa fa-search"></i>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/search/_filters.html.erb
+++ b/app/views/search/_filters.html.erb
@@ -19,7 +19,7 @@
       <button type="button" class="filter-save button is-medium is-filled">Save</button>
     <% end %>
     <% if allow_delete %>
-      <button type="button" class="filter-delete button is-medium is-filled is-danger">Delete</button>
+      <button type="button" class="filter-delete button is-medium is-filled is-danger has-margin-left-2">Delete</button>
     <% end %>
   </div>
   <% if user_signed_in? && defined? @category %>


### PR DESCRIPTION
This is a minor PR addressing positioning annoyances that drive me mad every time I see them.

Filters "delete" button before the change:
![2024-12-07_21-57](https://github.com/user-attachments/assets/fb78a494-7e9d-402c-84e3-6c7222ced1ce)
And after:
![2024-12-07_22-33](https://github.com/user-attachments/assets/801ec07d-674d-4d9c-82f3-20175e7d196c)

Search OAuth apps button before the change:
![qpixel-search-oauth-btn-before](https://github.com/user-attachments/assets/c40e64c2-3b44-4a48-881e-82b7a34c7a64)
And after (the icon is changed from textual to icon-based to align with every other search input):
![qpixel-search-oauth-btn-after](https://github.com/user-attachments/assets/a42f1c62-d4a9-4fdf-ab09-e26010bd1320)
