### PR TITLE
avert some confusion in the tour

### DIFF
--- a/app/views/tour/question3.html.erb
+++ b/app/views/tour/question3.html.erb
@@ -339,7 +339,7 @@
           <p>Voting also helps good content be more visible. Good answers are promoted to the top, while bad ones sink to the bottom. Please help curate the community by voting responsibly.</p>
           <p>Do so by clicking the <svg class="h-c-tertiary-400" width="2em" height="1.33em" viewbox="0 0 100 50">
             <path d="M50,0 L100,50 L0,50 Z" fill="currentColor" />
-          </svg> icon next to the post.</p>
+          </svg> icon next to the post. After you vote, the tour will continue.</p>
         </div>
         <div class="widget--footer">
           <button class="button"  data-step-from=".step-2" data-step-to=".step-3">Back</button>


### PR DESCRIPTION
Addresses https://meta.codidact.com/posts/292383.

For most of the tour, you get a "next" button at each step that advances to the next stage.  Voting is different, though: when you get to the first answer, the tour tells you to vote on it and gives you a "back" button but no "next" button.  This change adds a line that the tour will continue after you vote.

Yes, we're railroading you into voting here, while you can click through the earlier steps without doing anything.  We also railroad you when it comes to flagging the second answer, so that feels kind of ok.  I tried adding a "next" button that would skip the voting and move on, but I couldn't get it to work with two paths out from this step to the next.

Should we remove the "back" button here, so the only clicky thing is the vote buttons?  "Back" works, but I don't know how useful it is, and the rest of the tour doesn't have back-navigation.