### PR TITLE
Fix for server error on the tags page when the category doesn't have tags

### DIFF
--- a/app/models/tag_set.rb
+++ b/app/models/tag_set.rb
@@ -13,4 +13,12 @@ class TagSet < ApplicationRecord
   def self.main
     where(name: 'Main').first
   end
+
+  def with_paths(no_excerpt = false)
+    if no_excerpt
+      tags_with_paths.where(excerpt: ['', nil])
+    else
+      tags_with_paths
+    end
+  end
 end

--- a/db/scripts/create_tags_path_view.sql
+++ b/db/scripts/create_tags_path_view.sql
@@ -1,4 +1,4 @@
-create view tags_paths as
+CREATE OR REPLACE VIEW tags_paths AS
 WITH RECURSIVE tag_path (id, created_at, updated_at, community_id, tag_set_id, wiki_markdown,
                          wiki, excerpt, parent_id, name, path) AS
                    (

--- a/test/fixtures/tag_sets.yml
+++ b/test/fixtures/tag_sets.yml
@@ -5,3 +5,7 @@ main:
 meta:
   name: Meta
   community: sample
+
+empty:
+  name: 'Empty'
+  community: sample

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -10,6 +10,7 @@ support:
 
 bug:
   name: bug
+  excerpt: use for bug reports
   community: sample
   tag_set: main
 

--- a/test/models/tag_set_test.rb
+++ b/test/models/tag_set_test.rb
@@ -1,7 +1,9 @@
 require 'test_helper'
 
 class TagSetTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  include CommunityRelatedHelper
+
+  test 'is community related' do
+    assert_community_related(TagSet)
+  end
 end

--- a/test/models/tag_set_test.rb
+++ b/test/models/tag_set_test.rb
@@ -6,4 +6,13 @@ class TagSetTest < ActiveSupport::TestCase
   test 'is community related' do
     assert_community_related(TagSet)
   end
+
+  test 'with_paths method should respect no_excerpt' do
+    main = TagSet.main
+
+    all = main.with_paths.size
+    excerptless = main.with_paths(true).size
+
+    assert_not_equal(all, excerptless)
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,7 @@ class ActiveSupport::TestCase
   def load_fixtures(config)
     # Loading a fixture deletes all data in the same tables, so it has to happen before we load our normal seeds.
     fixture_data = super(config)
+    load_tags_paths
     load_seeds
 
     # We do need to return the same thing as the original method to not break fixtures
@@ -40,6 +41,10 @@ class ActiveSupport::TestCase
   def load_seeds
     set_request_context
     Rails.application.load_seed
+  end
+
+  def load_tags_paths
+    ActiveRecord::Base.connection.execute File.read(Rails.root.join('db/scripts/create_tags_path_view.sql'))
   end
 
   def clear_cache


### PR DESCRIPTION
closes #1485

![Screenshot from 2024-12-15 14-03-45](https://github.com/user-attachments/assets/771bf619-457f-460f-abc6-4567192a802c)

Additionally, fixes an issue with specifying both `hierarchical` and `no_excerpt` leading to the latter parameter being ignored (with a proper test case for the new `with_paths` method on the `TagsSet` model to prevent future regressions).