### PR TITLE
Add post history for help center and policy posts

### DIFF
--- a/app/controllers/post_history_controller.rb
+++ b/app/controllers/post_history_controller.rb
@@ -8,7 +8,23 @@ class PostHistoryController < ApplicationController
 
     @history = PostHistory.where(post_id: params[:id])
                           .includes(:post_history_type, :user, post_history_tags: [:tag])
-                          .order(created_at: :desc, id: :desc).paginate(per_page: 20, page: params[:page])
+                          .order(created_at: :desc, id: :desc)
+                          .paginate(per_page: 20, page: params[:page])
     render layout: 'without_sidebar'
+  end
+
+  def slug_post
+    @post = Post.by_slug(params[:slug], current_user)
+
+    if @post.nil?
+      return not_found
+    end
+
+    @history = PostHistory.where(post_id: @post.id)
+                          .includes(:post_history_type, :user)
+                          .order(created_at: :desc, id: :desc)
+                          .paginate(per_page: 20, page: params[:page])
+
+    render 'post_history/post', layout: 'without_sidebar', locals: { show_content: false }
   end
 end

--- a/app/controllers/post_history_controller.rb
+++ b/app/controllers/post_history_controller.rb
@@ -10,7 +10,12 @@ class PostHistoryController < ApplicationController
                           .includes(:post_history_type, :user, post_history_tags: [:tag])
                           .order(created_at: :desc, id: :desc)
                           .paginate(per_page: 20, page: params[:page])
-    render layout: 'without_sidebar'
+
+    if @post&.help_category.nil?
+      render layout: 'without_sidebar'
+    else
+      render 'post_history/post', layout: 'without_sidebar', locals: { show_content: false }
+    end
   end
 
   def slug_post

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -464,13 +464,9 @@ class PostsController < ApplicationController
   end
 
   def document
-    @post = Post.unscoped.where(doc_slug: params[:slug], community_id: [RequestContext.community_id, nil]).first
-    not_found && return if @post.nil?
+    @post = Post.by_slug(params[:slug], current_user)
 
-    if @post&.help_category == '$Disabled'
-      not_found
-    end
-    if @post&.help_category == '$Moderator' && !current_user&.is_moderator
+    if @post.nil?
       not_found
     end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -63,6 +63,23 @@ class Post < ApplicationRecord
     match_search term, posts: :body_markdown
   end
 
+  def self.by_slug(slug, user)
+    post = Post.unscoped.where(
+      doc_slug: slug,
+      community_id: [RequestContext.community_id, nil]
+    ).first
+
+    if post&.help_category == '$Disabled'
+      return nil
+    end
+
+    if post&.help_category == '$Moderator' && !user&.is_moderator
+      return nil
+    end
+
+    post
+  end
+
   # Double-define: initial definitions are less efficient, so if we have a record of the post type we'll
   # override them later with more efficient methods.
   ['Question', 'Answer', 'PolicyDoc', 'HelpDoc', 'Article'].each do |pt|

--- a/app/views/post_history/post.html.erb
+++ b/app/views/post_history/post.html.erb
@@ -1,8 +1,12 @@
+<% @show_content = !!defined?(show_content) ? show_content : true %>
+
 <h1>Post History</h1>
 
+<% if @show_content %>
 <div class="item-list">
   <%= render 'posts/type_agnostic', post: @post, show_category_tag: true, show_type_tag: true, last_activity: false %>
 </div>
+<% end %>
 
 <% @history.each.with_index do |event, index| %>
   <details class="history-event" id="<%= @history.size - index %>">

--- a/app/views/posts/document.html.erb
+++ b/app/views/posts/document.html.erb
@@ -2,9 +2,15 @@
   &laquo; Back to help center
 <% end %>
 <% unless @post.nil? %>
-  <% if (moderator? && @post.post_type_id == HelpDoc.post_type_id) || (admin? && @post.post_type_id == PolicyDoc.post_type_id) %>
+  <% 
+    is_hc = @post.post_type_id == HelpDoc.post_type_id
+    is_policy = @post.post_type_id == PolicyDoc.post_type_id
+    history_path = is_hc ? help_post_history_path(@post.doc_slug) : policy_post_history_path(@post.doc_slug)
+  %>
+  <% if (moderator? && is_hc) || (admin? && is_policy) %>
     <%= link_to 'edit', edit_post_path(@post), class: "button is-outlined is-muted" %>
   <% end %>
+  <%= link_to 'history', history_path,  class: "button is-outlined is-muted" %>
 <% end %>
 
 <% if @post.help_category == '$Moderator' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,7 +158,9 @@ Rails.application.routes.draw do
     get    ':id/:answer',                  to: 'posts#show', as: :answer_post
   end
 
+  get    'policy/:slug/history',           to: 'post_history#slug_post', as: :policy_post_history
   get    'policy/:slug',                   to: 'posts#document', as: :policy, constraints: { slug: /.*/ }
+  get    'help/:slug/history',             to: 'post_history#slug_post', as: :help_post_history
   get    'help/:slug',                     to: 'posts#document', as: :help, constraints: { slug: /.*/ }
 
   get    'tags',                           to: 'tags#index', as: :tags

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,9 +158,9 @@ Rails.application.routes.draw do
     get    ':id/:answer',                  to: 'posts#show', as: :answer_post
   end
 
-  get    'policy/:slug/history',           to: 'post_history#slug_post', as: :policy_post_history
+  get    'policy/:slug/history',           to: 'post_history#slug_post', as: :policy_post_history, constraints: { slug: /.*/ }
   get    'policy/:slug',                   to: 'posts#document', as: :policy, constraints: { slug: /.*/ }
-  get    'help/:slug/history',             to: 'post_history#slug_post', as: :help_post_history
+  get    'help/:slug/history',             to: 'post_history#slug_post', as: :help_post_history, constraints: { slug: /.*/ }
   get    'help/:slug',                     to: 'posts#document', as: :help, constraints: { slug: /.*/ }
 
   get    'tags',                           to: 'tags#index', as: :tags

--- a/test/controllers/posts/help_test.rb
+++ b/test/controllers/posts/help_test.rb
@@ -25,20 +25,20 @@ class PostsControllerTest < ActionController::TestCase
   test 'moderator help requires authentication' do
     get :document, params: { slug: posts(:mod_help_article).doc_slug }
     assert_response 404
-    assert_not_nil assigns(:post)
+    assert_nil assigns(:post)
   end
 
   test 'regular user cannot get mod help' do
     sign_in users(:standard_user)
     get :document, params: { slug: posts(:mod_help_article).doc_slug }
     assert_response 404
-    assert_not_nil assigns(:post)
+    assert_nil assigns(:post)
   end
 
   test 'cannot get disabled help article' do
     sign_in users(:moderator)
     get :document, params: { slug: posts(:disabled_help_article).doc_slug }
     assert_response 404
-    assert_not_nil assigns(:post)
+    assert_nil assigns(:post)
   end
 end


### PR DESCRIPTION
closes #807

This PR enables post history views for the Help Center and policy posts:

![2024-12-15_18-12](https://github.com/user-attachments/assets/23b270a0-4ca6-44f2-8f05-60430526fced)

![2024-12-15_18-11](https://github.com/user-attachments/assets/04a83ad2-415b-48dd-92c8-2be268b337f7)
