### PR TITLE
in user profiles, restrict visibility of links for new users

### DIFF
--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -41,6 +41,7 @@
   <%= render 'shared/body_field', f: f, field_name: :profile_markdown, field_label: 'Profile', post: current_user,
             cur_length: current_user.profile_markdown&.length, min_length: 0 %>
 
+  <p>Note: Links are not shown publicly until you have earned the Participate Everywhere ability.</p>
   <div class="post-preview"></div>
 
   <div class="grid">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -26,10 +26,13 @@
       <div class="profile-text">
       <p>
         <% if @user.website.present? %>
+  	  <% unless !user_signed_in? && !@user.community_user.privilege?('unrestricted') %>
           <span class="h-m-r-4">
-            <i class="fas fa-link"></i> <%= link_to @user.website_domain, @user.website, rel: 'nofollow',
-                                                    'aria-label': "Visit website of #{rtl_safe_username(@user)} at #{@user.website_domain}" %>
+            <i class="fas fa-link"></i>
+	    <%= link_to @user.website_domain, @user.website, rel: 'nofollow',
+                'aria-label': "Visit website of #{rtl_safe_username(@user)} at #{@user.website_domain}" %>
           </span>
+          <% end %>
         <% end %>
         <% if @user.twitter.present? %>
           <span class="h-m-r-4">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -47,7 +47,9 @@
       <% effective_profile = raw(sanitize(@user.profile&.strip || '', scrubber: scrubber)) %>
       <% if effective_profile.blank? %>
         <p class="is-lead">A quiet enigma. We don't know anything about <span dir="ltr"><%= rtl_safe_username(@user) %></span> yet.</p>
-      <% else %>
+	<% elsif !user_signed_in? && !@user.community_user.privilege?('unrestricted') %>
+	  <%= sanitize(effective_profile, attributes: %w()) %>
+	<% else %>
         <%= effective_profile %>
       <% end %>
       </div>


### PR DESCRIPTION
Fixes https://github.com/codidact/qpixel/issues/1500.

`sanitize` only accepts an allow list, so I couldn't express "allow anything we normally do, except `a`".  I instead blocked all attributes, so the `href` doesn't work and thus the `a` doesn't render.  There might be a more elegant way to do this; writing a custom sanitizer seemed like overkill and I didn't figure out anything else from Rails doc.

This strips links if the viewer is not logged in and the profile user does not have "participate everywhere".   Note for testing: in a new dev environment users come in with that ability by default, so remember to suspend it for your test user.

Screenshots:

1. Logged-out view of account in good standing:

![Screenshot](https://github.com/user-attachments/assets/b6967f29-03e3-4486-b799-277ecaa3e6d9)

2. Logged-out view of restricted account:

![Screenshot](https://github.com/user-attachments/assets/89a1ad2d-779f-496f-b032-93198cba39a0)

3. Logged-in view of restricted account (account in good standing is unchanged):

![Screenshot](https://github.com/user-attachments/assets/1972d1b0-9d09-4cec-a0a9-b0ce96244534)

