### PR TITLE
show only active abilities on profile

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -161,12 +161,14 @@
 
       <div class="widget">
         <% @abilities.each do |a| %>
+	<% if @user.privilege?(a.internal_id) %>
           <div class="widget--body" title="<%= a.summary %>">
             <i class="fa-fw fas fa-<%= a.icon %>"></i>
             <a href="<%= ability_url(a.internal_id, for: @user.id) %>">
               <%= a.name %>
             </a>
           </div>
+        <% end %>
         <% end %>
         <div class="widget--footer">
           <% if current_user&.id == @user.id %>


### PR DESCRIPTION
Fixes https://github.com/codidact/qpixel/issues/1362.

I opted for the simpler approach of just restricting the list, instead of showing abilities as earned but suspended.  A user with a suspended ability sees more info about that when clicking through to the full list, and I'd rather not try to jam more information into a small space here too.
