### PR TITLE
make network pitch a global setting

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -109,11 +109,11 @@
       <img src="/assets/codidact.png" alt="Codidact logo" class="codidact-logo" />
     </div>
     <div class="widget--body">
+      <% pitch = SiteSetting['NetworkPitch'] %>
       <% chat = SiteSetting['ChatLink'] %>
-      <p>
-        This community is part of the <a href="https://codidact.com">Codidact network</a>.
-        We have other communities too &mdash; take a look!
-      </p>
+      <% if pitch.present? %>
+        <%= raw(sanitize(render_markdown(pitch), scrubber: scrubber)) %>
+      <% end %>
       <% if chat.present? %>
         <p>
           You can also <%= link_to 'join us in chat', chat %>!

--- a/db/seeds/site_settings.yml
+++ b/db/seeds/site_settings.yml
@@ -635,6 +635,14 @@
     The content of a post is shown in short in lists (e.g. category post overview or in search).
     This setting controls how many characters of a post are shown.
 
+- name: NetworkPitch
+  value: $FILE site_settings/widgets_network_pitch.html
+  value_type: text
+  community_id: ~
+  category: Widgets
+  description: >
+    Sidebar text to promote the rest of the network.
+  
 - name: SsoSignIn
   value: false
   value_type: boolean

--- a/db/seeds/site_settings/widgets_network_pitch.html
+++ b/db/seeds/site_settings/widgets_network_pitch.html
@@ -1,0 +1,1 @@
+<p>This community is part of the non-profit <a href="https://codidact.com">Codidact network</a>. We have other communities too &#8212; take a look!</p>

--- a/db/seeds/site_settings/widgets_network_pitch.html
+++ b/db/seeds/site_settings/widgets_network_pitch.html
@@ -1,1 +1,1 @@
-<p>This community is part of the non-profit <a href="https://codidact.com">Codidact network</a>. We have other communities too &#8212; take a look!</p>
+<p>This community is part of a <a href="/dashboard">network of communities</a> &#8212; take a look!</p>


### PR DESCRIPTION
Enables fixing https://github.com/codidact/qpixel/issues/1511.

This PR removes the baked-in promotion of codidact.com and modifies the sidebar widget to read from a global site setting.  This text can now be edited on-site for all networks.  The default text refers generally to the (current) network, linking to the dashboard page.

The original text is in the revision history on this PR (for reference when updating prod after this is deployed).
