### PR TITLE
Fix global site settings cache

### DIFF
--- a/app/controllers/site_settings_controller.rb
+++ b/app/controllers/site_settings_controller.rb
@@ -49,7 +49,7 @@ class SiteSettingsController < ApplicationController
     @setting.update(setting_params)
     AuditLog.admin_audit(event_type: 'setting_update', related: @setting, user: current_user,
                          comment: "from <<SiteSetting #{before}>>\nto <<SiteSetting #{@setting.attributes_print}>>")
-    Rails.cache.delete "SiteSettings/#{RequestContext.community_id}/#{@setting.name}"
+    Rails.cache.delete "SiteSettings/#{RequestContext.community_id}/#{@setting.name}", include_community: false
     render json: { status: 'OK', setting: @setting&.as_json&.merge(typed: @setting.typed) }
   end
 

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -16,7 +16,7 @@ class SiteSetting < ApplicationRecord
     end
 
     if cached.nil?
-      Rails.cache.delete, include_community: false key
+      Rails.cache.delete key, include_community: false
       value = SiteSetting.applied_setting(name)&.typed
       Rails.cache.write key, value, include_community: false
       value

--- a/lib/namespaced_env_cache.rb
+++ b/lib/namespaced_env_cache.rb
@@ -16,7 +16,8 @@ module QPixel
     # These methods need a hash of cache keys updating before we pass it to the underlying cache.
     [:write_multi].each do |method|
       define_method method do |hash, *args, **opts, &block|
-        hash = hash.map { |k, v| [construct_ns_key(k), v] }.to_h
+        include_community = opts.delete(:include_community)
+        hash = hash.map { |k, v| [construct_ns_key(k, include_community: include_community), v] }.to_h
         @underlying.send(method, hash, *args, **opts, &block)
       end
     end
@@ -29,13 +30,15 @@ module QPixel
     end
 
     def read_multi(*keys, **opts)
-      keys = keys.map { |k| [construct_ns_key(k), k] }.to_h
+      include_community = opts.delete(:include_community)
+      keys = keys.map { |k| [construct_ns_key(k, include_community: include_community), k] }.to_h
       results = @underlying.read_multi *keys.keys, **opts
       results.map { |k, v| [keys[k], v] }.to_h
     end
 
     def fetch_multi(*keys, **opts, &block)
-      keys = keys.map { |k| construct_ns_key(k) }
+      include_community = opts.delete(:include_community)
+      keys = keys.map { |k| construct_ns_key(k, include_community: include_community)) }
       @underlying.fetch_multi *keys, **opts, &block
     end
 

--- a/lib/namespaced_env_cache.rb
+++ b/lib/namespaced_env_cache.rb
@@ -8,7 +8,8 @@ module QPixel
     # These methods need the cache key name updating before we pass it to the underlying cache.
     [:decrement, :delete, :exist?, :fetch, :increment, :read, :write, :delete_matched].each do |method|
       define_method method do |name, *args, **opts, &block|
-        @underlying.send(method, construct_ns_key(name, include_community: opts.delete(:include_community) || true),
+        include_community = opts.delete(:include_community)
+        @underlying.send(method, construct_ns_key(name, include_community: include_community),
                          *args, **opts, &block)
       end
     end

--- a/lib/namespaced_env_cache.rb
+++ b/lib/namespaced_env_cache.rb
@@ -32,14 +32,14 @@ module QPixel
     def read_multi(*keys, **opts)
       include_community = opts.delete(:include_community)
       keys = keys.map { |k| [construct_ns_key(k, include_community: include_community), k] }.to_h
-      results = @underlying.read_multi *keys.keys, **opts
+      results = @underlying.read_multi(*keys.keys, **opts)
       results.map { |k, v| [keys[k], v] }.to_h
     end
 
     def fetch_multi(*keys, **opts, &block)
       include_community = opts.delete(:include_community)
       keys = keys.map { |k| construct_ns_key(k, include_community: include_community) }
-      @underlying.fetch_multi *keys, **opts, &block
+      @underlying.fetch_multi(*keys, **opts, &block)
     end
 
     def persistent(name, **opts, &block)

--- a/lib/namespaced_env_cache.rb
+++ b/lib/namespaced_env_cache.rb
@@ -38,7 +38,7 @@ module QPixel
 
     def fetch_multi(*keys, **opts, &block)
       include_community = opts.delete(:include_community)
-      keys = keys.map { |k| construct_ns_key(k, include_community: include_community)) }
+      keys = keys.map { |k| construct_ns_key(k, include_community: include_community) }
       @underlying.fetch_multi *keys, **opts, &block
     end
 


### PR DESCRIPTION
When updating site settings, although we nominally [bust the cache](https://github.com/codidact/qpixel/blob/develop/app/controllers/site_settings_controller.rb#L52) and it would include nil as the community ID, our cache setup automatically [includes the current community ID](https://github.com/codidact/qpixel/blob/develop/lib/namespaced_env_cache.rb#L76) as a hidden part of the key. This is particularly evident with global site settings, where changes to the value enacted on one community don't propagate to others because there's a separate cache for each community.