### PR TITLE
Followup fix for namespaced Redis cache handling of include_community

### DIFF
--- a/lib/namespaced_env_cache.rb
+++ b/lib/namespaced_env_cache.rb
@@ -5,10 +5,15 @@ module QPixel
       @getters = {}
     end
 
+    def include_community(opts)
+      include = opts.delete(:include_community)
+      include.nil? ? true : include
+    end
+
     # These methods need the cache key name updating before we pass it to the underlying cache.
     [:decrement, :delete, :exist?, :fetch, :increment, :read, :write, :delete_matched].each do |method|
       define_method method do |name, *args, **opts, &block|
-        include_community = opts.delete(:include_community)
+        include_community = include_community(opts)
         @underlying.send(method, construct_ns_key(name, include_community: include_community),
                          *args, **opts, &block)
       end
@@ -17,7 +22,7 @@ module QPixel
     # These methods need a hash of cache keys updating before we pass it to the underlying cache.
     [:write_multi].each do |method|
       define_method method do |hash, *args, **opts, &block|
-        include_community = opts.delete(:include_community)
+        include_community = include_community(opts)
         hash = hash.map { |k, v| [construct_ns_key(k, include_community: include_community), v] }.to_h
         @underlying.send(method, hash, *args, **opts, &block)
       end
@@ -31,14 +36,14 @@ module QPixel
     end
 
     def read_multi(*keys, **opts)
-      include_community = opts.delete(:include_community)
+      include_community = include_community(opts)
       keys = keys.map { |k| [construct_ns_key(k, include_community: include_community), k] }.to_h
       results = @underlying.read_multi(*keys.keys, **opts)
       results.map { |k, v| [keys[k], v] }.to_h
     end
 
     def fetch_multi(*keys, **opts, &block)
-      include_community = opts.delete(:include_community)
+      include_community = include_community(opts)
       keys = keys.map { |k| construct_ns_key(k, include_community: include_community) }
       @underlying.fetch_multi(*keys, **opts, &block)
     end


### PR DESCRIPTION
This PR fixes an additional issue with `construct_ns_key` default for `include_community` that got exposed after removing the overzealous (due to `delete` returning either `nil` or `false` _and_ Ruby's OR operator triggering on **both**) default of `|| true`.

Not married to the method name at all, just felt natural to match the symbol.