### PR TITLE
guardrails for posts with pending spam flags

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -202,6 +202,14 @@ class Post < ApplicationRecord
     false
   end
 
+  # The test here is for flags that are pending (no status). A spam flag
+  # could be marked helpful but the post wouldn't be deleted, and
+  # we don't necessarily want the post to be treated like it's a spam risk
+  # if that happens.
+  def spam_flag_pending?
+    flags.any? { |flag| flag.post_flag_type&.name == "it's spam" && !flag.status }
+  end
+  
   # @param user [User, Nil]
   # @return [Boolean] whether the given user can view this post
   def can_access?(user)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -209,7 +209,7 @@ class Post < ApplicationRecord
   def spam_flag_pending?
     flags.any? { |flag| flag.post_flag_type&.name == "it's spam" && !flag.status }
   end
-  
+
   # @param user [User, Nil]
   # @return [Boolean] whether the given user can view this post
   def can_access?(user)

--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -149,10 +149,13 @@
 
 	<% if post.spam_flag_pending? && user_signed_in? %>
 	<div class="notice has-margin-2">
+	  <% if post.user == current_user %>
+	  <p>Your post has been flagged by members of our community. Please review our <a href="/help/spam">guidelines for promotional content</a>.</p>
+	  <% else %>
 	  <p><strong>Possible spam:</strong> this post has pending flags for spam.  Be careful when following links.</p>
+	  <% end %>
 	</div>
 	<% end %>
-
       <% if post_type.is_public_editable && post.pending_suggested_edit? %>
         <% if check_your_post_privilege(post, 'edit_posts') %>
           <div class="notice h-p-2">

--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -145,7 +145,13 @@
             on <%= post.locked_at.strftime('%b %e, %Y at %H:%M') %>.
           </p>
         </div>
-      <% end %>
+	<% end %>
+
+	<% if post.spam_flag_pending? && user_signed_in? %>
+	<div class="notice has-margin-2">
+	  <p><strong>Possible spam:</strong> this post has pending flags for spam.  Be careful when following links.</p>
+	</div>
+	<% end %>
 
       <% if post_type.is_public_editable && post.pending_suggested_edit? %>
         <% if check_your_post_privilege(post, 'edit_posts') %>
@@ -163,10 +169,15 @@
               <%= link_to 'pending review', suggested_edit_url(post.pending_suggested_edit.id) %></strong>.</p>
           </div>
         <% end %>
-      <% end %>
+	<% end %>
 
-      <div class="post--body">
-        <%= raw(sanitize(post.body, scrubber: scrubber)) %>
+	<div class="post--body">
+	  <% effective_post = raw(sanitize(post.body, scrubber: scrubber)) %>
+	  <% if post.spam_flag_pending? && !user_signed_in? %>
+	    <%= sanitize(effective_post, attributes: %w()) %>
+	  <% else %>
+            <%= effective_post %>
+	  <% end %>
 
         <% been_edited = post.last_edited_by_id != nil %>
         <% if been_edited then last_edited_by_self = post.user_id == post.last_edited_by_id end %>


### PR DESCRIPTION
If a post has pending spam flags, warn logged-in users and suppress links for anonymous users.  There are currently no exceptions for the status of the target user; should there be?  (Does this allow someone to harass curators by decorating their posts with warnings until the flags get declined?)

Fixes https://github.com/codidact/qpixel/issues/1381.
