### PR TITLE
Followup fix for cache & global site setttings handling

### DIFF
--- a/app/assets/stylesheets/site_settings.scss
+++ b/app/assets/stylesheets/site_settings.scss
@@ -1,4 +1,5 @@
 .site-setting--value {
   min-height: 1em;
   min-width: 2em;
+  overflow-wrap: anywhere;
 }

--- a/app/controllers/site_settings_controller.rb
+++ b/app/controllers/site_settings_controller.rb
@@ -49,9 +49,22 @@ class SiteSettingsController < ApplicationController
   # Deletes cache for a given site setting for a given community
   # @param [SiteSetting] setting site setting to clear cache for
   # @param [String, nil] community_id community id to clear cache for
-  # @return [void]
+  # @return [Boolean]
   def clear_cache(setting, community_id)
     Rails.cache.delete("SiteSettings/#{community_id}/#{setting.name}", include_community: false)
+  end
+
+  # Actually creates a given site setting
+  # @param [SiteSetting] setting site setting to create
+  # @param [String, nil] community_id community id to create a setting for
+  # @return [SiteSetting]
+  def do_create(setting, community_id)
+    SiteSetting.create(name: setting.name,
+                       community_id: community_id,
+                       value: '',
+                       value_type: setting.value_type,
+                       category: setting.category,
+                       description: setting.description)
   end
 
   def update
@@ -64,9 +77,7 @@ class SiteSettingsController < ApplicationController
                  matches = SiteSetting.unscoped.where(community_id: RequestContext.community_id, name: params[:name])
                  if matches.count.zero?
                    global = SiteSetting.unscoped.where(community_id: nil, name: params[:name]).first
-                   SiteSetting.create(name: global.name, community_id: RequestContext.community_id, value: '',
-                                      value_type: global.value_type, category: global.category,
-                                      description: global.description)
+                   do_create(global, RequestContext.community_id)
                  else
                    matches.first
                  end

--- a/app/controllers/site_settings_controller.rb
+++ b/app/controllers/site_settings_controller.rb
@@ -91,7 +91,13 @@ class SiteSettingsController < ApplicationController
 
     audit_update(current_user, before, @setting)
 
-    clear_cache(@setting, RequestContext.community_id)
+    if @setting.global?
+      Community.all.each do |c|
+        clear_cache(@setting, c.id)
+      end
+    else
+      clear_cache(@setting, RequestContext.community_id)
+    end
 
     render json: { status: 'OK', setting: @setting&.as_json&.merge(typed: @setting.typed) }
   end

--- a/app/controllers/site_settings_controller.rb
+++ b/app/controllers/site_settings_controller.rb
@@ -4,6 +4,14 @@ class SiteSettingsController < ApplicationController
   before_action :verify_admin
   before_action :verify_global_admin, only: [:global]
 
+  # Checks if a given user has access to site settings on a given community
+  # @param [User] user user to check access for
+  # @param [String] community_id id of the community to check access on
+  # @return [Boolean]
+  def access?(user, community_id)
+    community_id.present? || user.is_global_admin
+  end
+
   def index
     # The weird argument to sort_by here sorts without throwing errors on nil values -
     # see https://stackoverflow.com/a/35539062/3160466. 0:1,c sorts nil last, to switch
@@ -39,7 +47,7 @@ class SiteSettingsController < ApplicationController
   end
 
   def update
-    if params[:community_id].blank? && !current_user.is_global_admin
+    unless access?(current_user, params[:community_id])
       not_found
       return
     end

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -30,6 +30,13 @@ class SiteSetting < ApplicationRecord
       SiteSetting.where(name: name).count.positive?
   end
 
+  # Checks whether the setting is a global site setting
+  # @return [Boolean]
+  #
+  def global?
+    community_id.nil?
+  end
+
   def typed
     SettingConverter.new(value).send("as_#{value_type.downcase}")
   end

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -32,7 +32,6 @@ class SiteSetting < ApplicationRecord
 
   # Checks whether the setting is a global site setting
   # @return [Boolean]
-  #
   def global?
     community_id.nil?
   end

--- a/app/views/site_settings/index.html.erb
+++ b/app/views/site_settings/index.html.erb
@@ -17,15 +17,13 @@
         <% settings.each do |setting| %>
           <tr>
             <td>
-              <h4>
-                <%= setting.name %>
-                <% if setting.global? %>
-                  <span class="badge is-tag is-master-tag">global</span>
-                <% else %>
-                  <span class="badge is-tag">site</span>
-                <% end %>
-                <span class="badge is-tag"><%= setting.value_type %></span>
-              </h4>
+              <% if setting.global? %>
+                <span class="badge is-tag is-master-tag">global</span>
+              <% else %>
+                <span class="badge is-tag">site</span>
+              <% end %>
+              <span class="badge is-tag"><%= setting.value_type %></span>
+              <h4><%= setting.name %></h4>
               <div class="form-caption"><%= setting.description %></div>
             </td>
             <td class="site-setting--value js-setting-value" data-type="<%= setting.value_type %>" data-name="<%= setting.name %>"

--- a/app/views/site_settings/index.html.erb
+++ b/app/views/site_settings/index.html.erb
@@ -19,7 +19,7 @@
             <td>
               <h4>
                 <%= setting.name %>
-                <% if setting.community_id.nil? %>
+                <% if setting.global? %>
                   <span class="badge is-tag is-master-tag">global</span>
                 <% else %>
                   <span class="badge is-tag">site</span>


### PR DESCRIPTION
This PR follows up #1517 and #1516 ensuring that:

- global site settings clear cache for _all_ communities, not just the current one;
- adds proper methods for SiteSettingsController's actions (`access?`, `audit_update`, `clear_cache`, `do_create` methods);
- adds `global?` method on the SiteSetting model;
- fixes overflow of site setting values when the `<details>` element is opened (it's a crude fix for now via `overflow-wrap` - we should make HTML-valued settings use code blocks instead);

Site setting value overflow before the fix:

![Screenshot from 2025-01-26 22-13-56](https://github.com/user-attachments/assets/8f9c45f2-de74-4975-9291-c04cfc527567)

And lack thereof after:

![Screenshot from 2025-01-26 22-23-42](https://github.com/user-attachments/assets/de1cba61-ff2b-47b4-b237-8f59553aed89)

