### PR TITLE
Support only Ruby 3.1 onwards

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
             bundle exec rails test
       - store_test_results:
           path: "~/qpixel/test/reports"
-  system-test-ruby31:
+  system-test-ruby32:
     docker:
       - image: cimg/ruby:3.2-browsers
       - image: cimg/mysql:8.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,137 +1,5 @@
 version: 2.1
 jobs:
-  test-ruby27:
-    docker:
-      - image: cimg/ruby:2.7-node
-      - image: cimg/mysql:8.0
-        command: [--default-authentication-plugin=mysql_native_password]
-        environment:
-          MYSQL_ROOT_HOST: '%'
-          MYSQL_ROOT_PASSWORD: 'root'
-          MYSQL_DATABASE: 'qpixel_test'
-      - image: cimg/redis:7.0
-
-    working_directory: ~/qpixel
-
-    steps:
-      - run:
-          name: Install packages
-          command: |
-            sudo apt-get --allow-releaseinfo-change -qq update
-            sudo apt-get -y install git libmariadb-dev libmagickwand-dev
-      - checkout
-      - restore_cache:
-          keys:
-            - qpixel-ruby27-{{ checksum "Gemfile.lock" }}
-            - qpixel-ruby27-
-      - run:
-          name: Install Bundler & gems
-          command: |
-            gem install bundler
-            bundle install --path=~/gems
-      - run:
-          name: Clean unnecessary gems
-          command: |
-            bundle clean --force
-      - save_cache:
-          key: qpixel-ruby27-{{ checksum "Gemfile.lock" }}
-          paths:
-            - ~/gems
-      - run:
-          name: Copy key
-          command: |
-            if [ -z "$MASTER_KEY" ]; then rm config/credentials.yml.enc; else echo "$MASTER_KEY" > config/master.key; fi
-      - run:
-          name: Prepare config & database
-          environment:
-            RAILS_ENV: test
-          command: |
-            cp config/database.sample.yml config/database.yml
-            cp config/storage.sample.yml config/storage.yml
-            bundle exec rails db:create
-            bundle exec rails db:schema:load
-            bundle exec rails db:migrate
-            bundle exec rails test:prepare
-      - run:
-          name: Current revision
-          command: |
-            git rev-parse $(git rev-parse --abbrev-ref HEAD)
-      - run:
-          name: Coveralls token
-          command: |
-            if [ -z "$COVERALLS_REPO_TOKEN" ]; then echo "Skipping coveralls"; else echo "repo_token: $COVERALLS_REPO_TOKEN" > .coveralls.yml; fi
-      - run:
-          name: Test
-          command: |
-            bundle exec rails test
-      - store_test_results:
-          path: "~/qpixel/test/reports"
-  system-test-ruby27:
-    docker:
-      - image: cimg/ruby:2.7-browsers
-      - image: cimg/mysql:8.0
-        command: [--default-authentication-plugin=mysql_native_password]
-        environment:
-          MYSQL_ROOT_HOST: '%'
-          MYSQL_ROOT_PASSWORD: 'root'
-          MYSQL_DATABASE: 'qpixel_test'
-      - image: cimg/redis:7.0
-
-    working_directory: ~/qpixel
-
-    steps:
-      - run:
-          name: Install packages
-          command: |
-            sudo apt-get --allow-releaseinfo-change -qq update
-            sudo apt-get -y install git libmariadb-dev libmagickwand-dev
-      - checkout
-      - restore_cache:
-          keys:
-            - qpixel-ruby27-{{ checksum "Gemfile.lock" }}
-            - qpixel-ruby27-
-      - run:
-          name: Install Bundler & gems
-          command: |
-            gem install bundler
-            bundle install --path=~/gems
-      - run:
-          name: Clean unnecessary gems
-          command: |
-            bundle clean --force
-      - save_cache:
-          key: qpixel-ruby27-{{ checksum "Gemfile.lock" }}
-          paths:
-            - ~/gems
-      - run:
-          name: Copy key
-          command: |
-            if [ -z "$MASTER_KEY" ]; then rm config/credentials.yml.enc; else echo "$MASTER_KEY" > config/master.key; fi
-      - run:
-          name: Prepare config & database
-          environment:
-            RAILS_ENV: test
-          command: |
-            cp config/database.sample.yml config/database.yml
-            cp config/storage.sample.yml config/storage.yml
-            bundle exec rails db:create
-            bundle exec rails db:schema:load
-            bundle exec rails db:migrate
-            bundle exec rails test:prepare
-      - run:
-          name: Current revision
-          command: |
-            git rev-parse $(git rev-parse --abbrev-ref HEAD)
-      - run:
-          name: Test
-          command: |
-            bundle exec rails test:system
-      - store_test_results:
-          path: "~/qpixel/test/reports"
-      - store_artifacts:
-          path: "~/qpixel/tmp/screenshots"
-          when: on_fail
-
   test-ruby31:
     docker:
       - image: cimg/ruby:3.1-node
@@ -264,9 +132,16 @@ jobs:
           path: "~/qpixel/tmp/screenshots"
           when: on_fail
 
-  rubocop:
+  test-ruby32:
     docker:
-      - image: cimg/ruby:3.1-node
+      - image: cimg/ruby:3.2-node
+      - image: cimg/mysql:8.0
+        command: [ --default-authentication-plugin=mysql_native_password ]
+        environment:
+          MYSQL_ROOT_HOST: '%'
+          MYSQL_ROOT_PASSWORD: 'root'
+          MYSQL_DATABASE: 'qpixel_test'
+      - image: cimg/redis:7.0
 
     working_directory: ~/qpixel
 
@@ -279,8 +154,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - qpixel-ruby31-{{ checksum "Gemfile.lock" }}
-            - qpixel-ruby31-
+            - qpixel-ruby32-{{ checksum "Gemfile.lock" }}
+            - qpixel-ruby32-
       - run:
           name: Install Bundler & gems
           command: |
@@ -291,7 +166,132 @@ jobs:
           command: |
             bundle clean --force
       - save_cache:
-          key: qpixel-ruby31-{{ checksum "Gemfile.lock" }}
+          key: qpixel-ruby32-{{ checksum "Gemfile.lock" }}
+          paths:
+            - ~/gems
+      - run:
+          name: Copy key
+          command: |
+            if [ -z "$MASTER_KEY" ]; then rm config/credentials.yml.enc; else echo "$MASTER_KEY" > config/master.key; fi
+      - run:
+          name: Prepare config & database
+          environment:
+            RAILS_ENV: test
+          command: |
+            cp config/database.sample.yml config/database.yml
+            cp config/storage.sample.yml config/storage.yml
+            bundle exec rails db:create
+            bundle exec rails db:schema:load
+            bundle exec rails db:migrate
+            bundle exec rails test:prepare
+      - run:
+          name: Current revision
+          command: |
+            git rev-parse $(git rev-parse --abbrev-ref HEAD)
+      - run:
+          name: Coveralls token
+          command: |
+            if [ -z "$COVERALLS_REPO_TOKEN" ]; then echo "Skipping coveralls"; else echo "repo_token: $COVERALLS_REPO_TOKEN" > .coveralls.yml; fi
+      - run:
+          name: Test
+          command: |
+            bundle exec rails test
+      - store_test_results:
+          path: "~/qpixel/test/reports"
+  system-test-ruby31:
+    docker:
+      - image: cimg/ruby:3.2-browsers
+      - image: cimg/mysql:8.0
+        command: [ --default-authentication-plugin=mysql_native_password ]
+        environment:
+          MYSQL_ROOT_HOST: '%'
+          MYSQL_ROOT_PASSWORD: 'root'
+          MYSQL_DATABASE: 'qpixel_test'
+      - image: cimg/redis:7.0
+
+    working_directory: ~/qpixel
+
+    steps:
+      - run:
+          name: Install packages
+          command: |
+            sudo apt-get --allow-releaseinfo-change -qq update
+            sudo apt-get -y install git libmariadb-dev libmagickwand-dev
+      - checkout
+      - restore_cache:
+          keys:
+            - qpixel-ruby32-{{ checksum "Gemfile.lock" }}
+            - qpixel-ruby32-
+      - run:
+          name: Install Bundler & gems
+          command: |
+            gem install bundler
+            bundle install --path=~/gems
+      - run:
+          name: Clean unnecessary gems
+          command: |
+            bundle clean --force
+      - save_cache:
+          key: qpixel-ruby32-{{ checksum "Gemfile.lock" }}
+          paths:
+            - ~/gems
+      - run:
+          name: Copy key
+          command: |
+            if [ -z "$MASTER_KEY" ]; then rm config/credentials.yml.enc; else echo "$MASTER_KEY" > config/master.key; fi
+      - run:
+          name: Prepare config & database
+          environment:
+            RAILS_ENV: test
+          command: |
+            cp config/database.sample.yml config/database.yml
+            cp config/storage.sample.yml config/storage.yml
+            bundle exec rails db:create
+            bundle exec rails db:schema:load
+            bundle exec rails db:migrate
+            bundle exec rails test:prepare
+      - run:
+          name: Current revision
+          command: |
+            git rev-parse $(git rev-parse --abbrev-ref HEAD)
+      - run:
+          name: Test
+          command: |
+            bundle exec rails test:system
+      - store_test_results:
+          path: "~/qpixel/test/reports"
+      - store_artifacts:
+          path: "~/qpixel/tmp/screenshots"
+          when: on_fail
+
+  rubocop:
+    docker:
+      - image: cimg/ruby:3.2-node
+
+    working_directory: ~/qpixel
+
+    steps:
+      - run:
+          name: Install packages
+          command: |
+            sudo apt-get --allow-releaseinfo-change -qq update
+            sudo apt-get -y install git libmariadb-dev libmagickwand-dev
+      - checkout
+      - restore_cache:
+          keys:
+            - qpixel-ruby32-{{ checksum "Gemfile.lock" }}
+            - qpixel-ruby32-
+      - run:
+          name: Install Bundler & gems
+          command: |
+            gem install bundler
+            bundle install --path=~/gems
+      - run:
+          name: Clean unnecessary gems
+          command: |
+            bundle clean --force
+      - save_cache:
+          key: qpixel-ruby32-{{ checksum "Gemfile.lock" }}
           paths:
             - ~/gems
       - run:
@@ -301,7 +301,7 @@ jobs:
 
   deploy:
     docker:
-      - image: cimg/ruby:3.1-node
+      - image: cimg/ruby:3.2-node
 
     working_directory: ~/qpixel
 
@@ -319,17 +319,15 @@ jobs:
 workflows:
   test_lint:
     jobs:
-      - test-ruby27
       - test-ruby31
-      - system-test-ruby27
       - system-test-ruby31
+      - test-ruby32
+      - system-test-ruby32
       - rubocop
       - deploy:
           requires:
-            - test-ruby27
-            - test-ruby31
-            - system-test-ruby27
-            - system-test-ruby31
+            - test-ruby32
+            - system-test-ruby32
             - rubocop
           filters:
             branches:

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '>= 2.7', '< 4'
+ruby '~> 3.1.0'
 
 # Essential gems: servers, adapters, Rails + Rails requirements
 gem 'coffee-rails', '~> 5.0.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '~> 3.1.0'
+ruby '>= 3.1', '< 3.3'
 
 # Essential gems: servers, adapters, Rails + Rails requirements
 gem 'coffee-rails', '~> 5.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -453,7 +453,7 @@ DEPENDENCIES
   will_paginate-bootstrap (~> 1.0)
 
 RUBY VERSION
-   ruby 2.7.6p219
+   ruby 3.1.6p260
 
 BUNDLED WITH
    2.4.13

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -13,7 +13,7 @@ If you don't already have Ruby installed, use [RVM](https://rvm.io/) or
 [rbenv](https://github.com/rbenv/rbenv#installation) to install it before following
 these instructions.
 
-QPixel is tested with Ruby 3 (and works with Ruby 2.7 as of December 2022).
+QPixel is tested with Ruby 3.1 and 3.2. Note that Ruby 3.1 reaches end of life on 2025-03-31.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -5,15 +5,9 @@
 </div>
 <br>
 <p align="center">
-  <a href="https://circleci.com/gh/codidact/qpixel">
-    <img src="https://circleci.com/gh/codidact/qpixel.svg?style=svg" alt="CircleCI Build Status">
-  </a>
-  <a href="https://coveralls.io/github/codidact/qpixel">
-    <img src="https://coveralls.io/repos/github/codidact/qpixel/badge.svg" alt="Coverage Status">
-  </a>
-  <a href="https://zenodo.org/badge/latestdoi/237078806">
-    <img src="https://zenodo.org/badge/237078806.svg" alt="DOI">
-  </a>
+  <a href="https://circleci.com/gh/codidact/qpixel"><img src="https://circleci.com/gh/codidact/qpixel.svg?style=svg" alt="CircleCI Build Status"></a>
+  <a href="https://coveralls.io/github/codidact/qpixel"><img src="https://coveralls.io/repos/github/codidact/qpixel/badge.svg" alt="Coverage Status"></a>
+  <a href="https://zenodo.org/badge/latestdoi/237078806"><img src="https://zenodo.org/badge/237078806.svg" alt="DOI"></a>
 </p>
 
 Rails-based version of our core software, powering [codidact.com](https://codidact.com). Currently under active development towards MVP.

--- a/docker/README.md
+++ b/docker/README.md
@@ -79,14 +79,14 @@ After about 20 seconds, check to make sure the server is running (and verify por
 
 ```
 qpixel_uwsgi_1  | => Booting Puma
-qpixel_uwsgi_1  | => Rails 7.0.4 application starting in development 
-qpixel_uwsgi_1  | => Run `rails server -h` for more startup options
+qpixel_uwsgi_1  | => Rails 7.0.8.7 application starting in development 
+qpixel_uwsgi_1  | => Run `bin/rails server --help` for more startup options
 qpixel_uwsgi_1  | Puma starting in single mode...
-qpixel_uwsgi_1  | * Puma version: 5.6.5 (ruby 2.7.6-p219) ("Birdie's Version")
-qpixel_uwsgi_1  | * Min threads: 5
-qpixel_uwsgi_1  | * Max threads: 5
-qpixel_uwsgi_1  | * Environment: development
-qpixel_uwsgi_1  | *         PID: 49
+qpixel_uwsgi_1  | * Puma version: 5.6.9 (ruby 3.1.2-p20) ("Birdie's Version")
+qpixel_uwsgi_1  | *  Min threads: 5
+qpixel_uwsgi_1  | *  Max threads: 5
+qpixel_uwsgi_1  | *  Environment: development
+qpixel_uwsgi_1  | *          PID: 99
 qpixel_uwsgi_1  | * Listening on http://0.0.0.0:3000
 qpixel_uwsgi_1  | Use Ctrl-C to stop
 ```


### PR DESCRIPTION
Currently we test Ruby 2.7 and Ruby 3.1. Ruby 3.1 will reach end of life on 2025-03-31, and Ruby 2.7 has already passed end of life.

This pull request stops testing Ruby 2.7 and starts testing Ruby 3.2. The intention is that we will continue to test the oldest minor version that is still supported (has not reached end of life) plus the minor version after that, so that the tests ensure we are always ready to stop using a version when it reaches end of life.

For example, on 2025-04-01 when Ruby 3.1 is no longer supported, we can switch from testing 3.1 and 3.2 to testing 3.2 and 3.3.