### PR TITLE
alert mods if a user has past warnings/suspensions

### DIFF
--- a/app/models/community_user.rb
+++ b/app/models/community_user.rb
@@ -30,6 +30,10 @@ class CommunityUser < ApplicationRecord
     false
   end
 
+  def latest_warning
+    mod_warnings&.order(created_at: 'desc').first.created_at
+  end
+
   # Calculation functions for privilege scores
   # These are quite expensive, so we'll cache them for a while
   def post_score

--- a/app/models/community_user.rb
+++ b/app/models/community_user.rb
@@ -31,7 +31,7 @@ class CommunityUser < ApplicationRecord
   end
 
   def latest_warning
-    mod_warnings&.order(created_at: 'desc').first.created_at
+    mod_warnings&.order(created_at: 'desc')&.first&.created_at
   end
 
   # Calculation functions for privilege scores

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -86,13 +86,13 @@
         <% end %>
       </div>
 
-<% if moderator? && @user.community_user.mod_warnings&.size.positive? %>
-<div class="notice is-info h-m-b-4">
-  <p><%= pluralize(@user.community_user.mod_warnings.count, 'message') %> sent,
-  most recent: <%= time_ago_in_words(@user.community_user.latest_warning) %> ago
-  </p>
-</div>
-<% end %>
+      <% if moderator? && @user.community_user.mod_warnings&.size.positive? %>
+      <div class="notice is-info h-m-b-4">
+	<p><%= pluralize(@user.community_user.mod_warnings.count, 'message') %> sent,
+	  most recent: <%= time_ago_in_words(@user.community_user.latest_warning) %> ago
+	</p>
+      </div>
+      <% end %>
 
       <div class="user-profile-heading-container">
         <h2 class="user-profile-heading">Posts</h2>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -20,14 +20,6 @@
   </div>
 <% end %>
 
-<% if moderator? && @user.community_user.mod_warnings&.size.positive? %>
-<div class="notice is-info h-m-b-4">
-  <p><%= pluralize(@user.community_user.mod_warnings.count, 'message') %> sent,
-  most recent: <%= time_ago_in_words(@user.community_user.latest_warning) %> ago
-  </p>
-</div>
-<% end %>
-
 <div class="grid <%= deleted_user?(@user) ? 'deleted-content' : '' %>">
   <div class="grid--cell is-9-lg is-12">
     <div class="h-p-0 h-p-t-0">
@@ -93,6 +85,14 @@
           <% end %>
         <% end %>
       </div>
+
+<% if moderator? && @user.community_user.mod_warnings&.size.positive? %>
+<div class="notice is-info h-m-b-4">
+  <p><%= pluralize(@user.community_user.mod_warnings.count, 'message') %> sent,
+  most recent: <%= time_ago_in_words(@user.community_user.latest_warning) %> ago
+  </p>
+</div>
+<% end %>
 
       <div class="user-profile-heading-container">
         <h2 class="user-profile-heading">Posts</h2>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -20,6 +20,14 @@
   </div>
 <% end %>
 
+<% if moderator? && @user.community_user.mod_warnings&.size.positive? %>
+<div class="notice is-info h-m-b-4">
+  <p><%= pluralize(@user.community_user.mod_warnings.count, 'message') %> sent,
+  most recent: <%= time_ago_in_words(@user.community_user.latest_warning) %> ago
+  </p>
+</div>
+<% end %>
+
 <div class="grid <%= deleted_user?(@user) ? 'deleted-content' : '' %>">
   <div class="grid--cell is-9-lg is-12">
     <div class="h-p-0 h-p-t-0">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -64,14 +64,18 @@
           <% end %>
         <% end %>
         <% if current_user&.is_moderator %>
-          <a href="<%= mod_user_path(@user) %>" class="button is-danger is-outlined is-small" data-drop="#mod-tools-drop"><i class="fas fa-shield-alt"></i> Moderator Tools</a>
+          <a href="<%= mod_user_path(@user) %>" class="button is-danger is-outlined is-small" data-drop="#mod-tools-drop"><i class="fas fa-shield-alt"></i> Moderator Tools <% if @user.community_user.mod_warnings&.size.positive? %> (<%= pluralize(@user.community_user.mod_warnings.count, 'message') %>) <% end %></a> 
           <div class="droppanel" id="mod-tools-drop">
             <div class="droppanel--header">quick actions</div>
             <div class="droppanel--menu">
               <a href="/users/<%= @user.id %>/mod/activity-log">full activity log</a>
               <a href="/users/<%= @user.id %>/mod/annotations">annotations on user</a>
               <a href="/users/<%= @user.id %>/mod/privileges">privileges</a>
-              <a href="/warning/log/<%= @user.id %>">warnings and suspensions sent to user <% if @user.community_user.suspended? %><em>(includes lifting the suspension)</em><% end %></a>
+              <a href="/warning/log/<%= @user.id %>">warnings and suspensions sent to user
+		<% if @user.community_user.suspended? %><em>(includes lifting the suspension)</em>
+		<% elsif @user.community_user.mod_warnings&.size.positive? %>
+		(latest <%= time_ago_in_words(@user.community_user.latest_warning) %> ago)
+		<% end %></a>
               <a href="/warning/new/<%= @user.id %>">warn or suspend user</a>
             </div>
             <div class="h-m-t-6">
@@ -85,14 +89,6 @@
           <% end %>
         <% end %>
       </div>
-
-      <% if moderator? && @user.community_user.mod_warnings&.size.positive? %>
-      <div class="notice is-info h-m-b-4">
-	<p><%= pluralize(@user.community_user.mod_warnings.count, 'message') %> sent,
-	  most recent: <%= time_ago_in_words(@user.community_user.latest_warning) %> ago
-	</p>
-      </div>
-      <% end %>
 
       <div class="user-profile-heading-container">
         <h2 class="user-profile-heading">Posts</h2>


### PR DESCRIPTION
Small mod assist: on the user page, if there have been warning or suspension messages, show the number and how recent to mods.  This information is already available if you go into the mod tools, but some mods have found it helpful to have a heads-up that there's something to see.

Totally open to better ways to present this!

Suspended user (to show interaction with suspension notice):

![screenshot: notice appears after profile text/buttons and just before posts](https://github.com/user-attachments/assets/51214173-27c4-4aef-b143-3a5ed29f14b1)

Non-suspended user (only warnings or inactive suspensions here):

![screenshot](https://github.com/user-attachments/assets/3febbb2b-e6a0-4e16-884c-008f15ce942e)

