### PR TITLE
clarify thread name in comment notifications

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -319,7 +319,7 @@ class CommentsController < ApplicationController
       next if user.id == @comment.post.user_id
 
       title = @post.parent.nil? ? @post.title : @post.parent.title
-      user.create_notification("You were mentioned in a comment to #{@comment_thread.title} " \
+      user.create_notification("You were mentioned in a comment in the thread '#{@comment_thread.title}' " \
                                "on the post '#{title}'",
                                helpers.comment_link(@comment))
     end


### PR DESCRIPTION
Request from https://meta.codidact.com/posts/292846 to make it more clear what part of the notification is the thread name.

![Screenshot](https://github.com/user-attachments/assets/1a32ce9c-29e6-4120-b586-d90abb00b2a4)

