### PR TITLE
Show category header for suggested edits

### DIFF
--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -9,7 +9,8 @@ module CategoriesHelper
     (defined?(@category) && !@category&.id.nil? && !current_page?(new_category_url)) ||
       (defined?(@post) && !@post&.category.nil?) ||
       (defined?(@question) && !@question&.category.nil?) ||
-      (defined?(@article) && !@article&.category.nil?)
+      (defined?(@article) && !@article&.category.nil?) ||
+      (defined?(@edit) && !@edit&.post&.category&.nil?)
   end
 
   def current_category
@@ -21,6 +22,8 @@ module CategoriesHelper
                             @question.category
                           elsif defined?(@article) && !@article&.category.nil?
                             @article.category
+                          elsif defined?(@edit) && !@edit&.post&.category.nil?
+                            @edit.post.category
                           end
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -48,7 +48,7 @@ class Post < ApplicationRecord
                                    user: :avatar_attachment)
                         }
 
-  before_validation :update_tag_associations, if: -> { post_type.has_tags }
+  before_validation :update_tag_associations, if: -> { post_type&.has_tags }
   after_create :create_initial_revision
   after_save :check_attribution_notice
   after_save :modify_author_reputation


### PR DESCRIPTION
Fixes https://github.com/codidact/qpixel/issues/1408, obsoletes https://github.com/codidact/qpixel/issues/1407.

The presence of the header is controlled by a helper class, so the solution turned out to be to expand what that helper can handle, instead of attacking it from the other side (the view) where I started.

Related Collab post: https://collab.codidact.org/posts/293511
