### PR TITLE
Fix Nokogiri dependency issue due to bump to 1.8.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,7 @@ GEM
     mime-types-data (3.2022.0105)
     mini_magick (4.11.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.8)
     minitest (5.16.3)
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
@@ -217,7 +218,8 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.7.3)
-    nokogiri (1.18.3-x86_64-linux-gnu)
+    nokogiri (1.18.3)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     omniauth (2.1.0)
       hashie (>= 3.4.6)


### PR DESCRIPTION
Dependabot PR responsible for the issue: #1532

Relevant change happened in [Nokogiri 1.8.0](https://github.com/sparklemotion/nokogiri/blob/main/CHANGELOG.md#v1180--2024-12-25). Should fix #1551