### PR TITLE
Remove server.pid in the entrypoint if present

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,6 +15,11 @@ fi
 # If this isn't done again, there is a 500 error on the first page about posts
 rails db:seed
 
+
+if [ -f '/code/tmp/pids/server.pid' ]; then
+    rm -rf /code/tmp/pids/server.pid
+fi
+
 # we don't start the server immediately in dev mode
 if [[ "$1" != 'dev' ]]; then
     rails server -b 0.0.0.0


### PR DESCRIPTION
closes #1555 

If a `uwsgi` container is stopped with Rails running (for example, when using the out of the box `Dockerfile`), the `/code/tmp/pids/server.pid` file tracking the process id for the server is not cleaned up. If one then starts the container again without rebuilding, the server fails to start as the startup process thinks another instance is still running. At best, it's an inconvenience, at worst, it crashes the container.