### PR TITLE
cleaning up after dependabot's breaking of nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,7 @@ GEM
     mime-types-data (3.2022.0105)
     mini_magick (4.11.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.8)
     minitest (5.16.3)
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
@@ -217,7 +218,8 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.7.3)
-    nokogiri (1.18.4-x86_64-linux-gnu)
+    nokogiri (1.18.6)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     omniauth (2.1.0)
       hashie (>= 3.4.6)


### PR DESCRIPTION
This is basically a copy of #1552 because the issue resurfaced due to #1564 switching generic `nokogiri` back to `x86_64-linux-gnu` (which is incorrect and breaks Docker setup, see #1551 for details).

Related issues (I am not sure what we need to do to prevent Dependabot from doing this yet):

- https://github.com/dependabot/dependabot-core/issues/3299;
- https://github.com/dependabot/dependabot-core/issues/5917;