### PR TITLE
New user comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -32,7 +32,12 @@ class CommentsController < ApplicationController
 
     pings = check_for_pings @comment_thread, body
 
-    return if comment_rate_limited
+    rate_limited, limit_message = helpers.comment_rate_limited?(current_user, @post)
+    if rate_limited
+      flash[:danger] = limit_message
+      redirect_to helpers.generic_share_link(@post)
+      return
+    end
 
     success = ActiveRecord::Base.transaction do
       @comment_thread.save!
@@ -76,7 +81,12 @@ class CommentsController < ApplicationController
     @comment = Comment.new(post: @post, content: body, user: current_user,
                            comment_thread: @comment_thread, has_reference: false)
 
-    return if comment_rate_limited
+    rate_limited, limit_message = helpers.comment_rate_limited?(current_user, @post)
+    if rate_limited
+      flash[:danger] = limit_message
+      redirect_to helpers.generic_share_link(@post)
+      return
+    end
 
     if @comment.save
       apply_pings pings
@@ -323,30 +333,5 @@ class CommentsController < ApplicationController
                                "on the post '#{title}'",
                                helpers.comment_link(@comment))
     end
-  end
-
-  def comment_rate_limited
-    recent_comments = Comment.where(created_at: 24.hours.ago..DateTime.now, user: current_user).where \
-                             .not(post: Post.includes(:parent).where(parents_posts: { user_id: current_user.id })) \
-                             .where.not(post: Post.where(user_id: current_user.id)).count
-    max_comments_per_day = SiteSetting[current_user.privilege?('unrestricted') ? 'RL_Comments' : 'RL_NewUserComments']
-
-    if (!@post.user_id == current_user.id || @post&.parent&.user_id == current_user.id) \
-       && recent_comments >= max_comments_per_day
-      comment_limit_msg = "You have used your daily comment limit of #{recent_comments} comments. " \
-                          'Come back tomorrow to continue commenting. Comments on own posts and on answers ' \
-                          'to own posts are exempt.'
-
-      if recent_comments.zero? && !current_user.privilege?('unrestricted')
-        comment_limit_msg = 'New users can only comment on their own posts and on answers to them.'
-      end
-
-      AuditLog.rate_limit_log(event_type: 'comment', related: @comment, user: current_user,
-                              comment: "limit: #{max_comments_per_day}\n\comment:\n#{@comment.attributes_print}")
-
-      render json: { status: 'failed', message: comment_limit_msg }, status: :forbidden
-      return true
-    end
-    false
   end
 end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -92,16 +92,16 @@ module CommentsHelper
     max_comments_per_day = SiteSetting[user.privilege?('unrestricted') ? 'RL_Comments' : 'RL_NewUserComments']
 
     if post.user_id != user.id && post.parent&.user_id != user.id
-      if recent_comments >= max_comments_per_day
-        message = "You have used your daily comment limit of #{recent_comments} comments. Come back tomorrow to " \
-                  'continue commenting. Comments on your own posts and on answers to own posts are exempt.'
+      if !user.privilege?('unrestricted')
+        message = 'As a new user, you can only comment on your own posts and on answers to them.'
         if create_audit_log
           AuditLog.rate_limit_log(event_type: 'comment', related: post, user: user,
                                   comment: "limit: #{max_comments_per_day}")
         end
         [true, message]
-      elsif !user.privilege?('unrestricted')
-        message = 'As a new user, you can only comment on your own posts and on answers to them.'
+      elsif recent_comments >= max_comments_per_day
+        message = "You have used your daily comment limit of #{recent_comments} comments. Come back tomorrow to " \
+                  'continue commenting. Comments on your own posts and on answers to own posts are exempt.'
         if create_audit_log
           AuditLog.rate_limit_log(event_type: 'comment', related: post, user: user,
                                   comment: "limit: #{max_comments_per_day}")

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -89,7 +89,7 @@ module CommentsHelper
     recent_comments = Comment.where(created_at: 24.hours.ago..DateTime.now, user: user).where \
                              .not(post: Post.includes(:parent).where(parents_posts: { user_id: user.id })) \
                              .where.not(post: Post.where(user_id: user.id)).count
-    max_comments_per_day = SiteSetting[user.ability?('unrestricted') ? 'RL_Comments' : 'RL_NewUserComments']
+    max_comments_per_day = SiteSetting[user.privilege?('unrestricted') ? 'RL_Comments' : 'RL_NewUserComments']
 
     if post.user_id != user.id && post.parent&.user_id != user.id
       if recent_comments >= max_comments_per_day
@@ -100,7 +100,7 @@ module CommentsHelper
                                   comment: "limit: #{max_comments_per_day}")
         end
         [true, message]
-      elsif !user.ability?('unrestricted')
+      elsif !user.privilege?('unrestricted')
         message = 'As a new user, you can only comment on your own posts and on answers to them.'
         if create_audit_log
           AuditLog.rate_limit_log(event_type: 'comment', related: post, user: user,

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -40,6 +40,27 @@ question_two:
   upvote_count: 0
   downvote_count: 0
 
+new_user_question:
+  post_type: question
+  title: Q1 - This is test question number one
+  body: This is the body of test question one. Note that we did not include any markdown or HTML in here.
+  body_markdown: This is the body of test question one. Note that we did not include any markdown or HTML in here.
+  tags_cache:
+    - discussion
+    - support
+    - bug
+  tags:
+    - discussion
+    - support
+    - bug
+  score: 0.5
+  user: basic_user
+  community: sample
+  category: main
+  license: cc_by_sa
+  upvote_count: 0
+  downvote_count: 0
+
 bad_answers:
   post_type: question
   title: Q3B - This question has bad answers

--- a/test/fixtures/user_abilities.yml
+++ b/test/fixtures/user_abilities.yml
@@ -53,3 +53,7 @@ d_ep:
 d_et:
   community_user: sample_deleter
   ability: edit_tags
+
+b_eo:
+  community_user: sample_basic_user
+  ability: everyone

--- a/test/helpers/comments_helper_test.rb
+++ b/test/helpers/comments_helper_test.rb
@@ -48,4 +48,16 @@ class CommentsHelperTest < ActionView::TestCase
       assert_equal expect, render_comment_helpers(+input, users(:standard_user))
     end
   end
+
+  test 'comment_rate_limited prevents new users commenting on others posts' do
+    rate_limited, limit_message = comment_rate_limited? users(:basic_user), posts(:question_one)
+    assert_equal true, rate_limited
+    assert_equal 'As a new user, you can only comment on your own posts and on answers to them.', limit_message
+  end
+
+  test 'comment_rate_limited allows new user to comment on own post' do
+    rate_limited, limit_message = comment_rate_limited? users(:basic_user), posts(:new_user_question)
+    assert_equal false, rate_limited
+    assert_equal nil, limit_message
+  end
 end


### PR DESCRIPTION
Update the comment rate limiting code so the logic is easier to follow. Adds tests for the rate limit helper to ensure it's returning the right thing. Also changes from a `render json` to a `redirect` with flash so that the raw JSON error message isn't displayed.

I haven't been able to run and test this myself, so I'm relying on the automated testing. If anyone is able to test manually when reviewing that would be useful.

Closes #1538, #1577