### PR TITLE
Fix OpenGraph tags

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -67,5 +67,5 @@
   <meta property="og:url" content="<%= request.original_url %>" />
   <meta property="og:title" content="<%= page_title %>" />
   <meta property="og:description" content="<%= content_for?(:description) ? content_for(:description) : desc %>" />
-  <meta property="og:image" content="<%= "https://#{RequestContext.community.host}#{SiteSetting['SiteLogoPath']}" %>" />
+  <meta property="og:image" content="<%= "#{SiteSetting['SiteLogoPath']}" %>" />
 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -14,7 +14,7 @@
   <meta property="og:url" content="<%= post_url(@post) %>" />
   <meta property="og:title" content="<%= @post.title %>" />
   <meta property="og:description" content="<%= @post.body_plain[0..150].strip %>..." />
-  <meta property="og:image" content="<%= "https://#{RequestContext.community.host}#{SiteSetting['SiteLogoPath']}" %>" />
+  <meta property="og:image" content="<%= "#{SiteSetting['SiteLogoPath']}" %>" />
 <% end %>
 
 <%= render 'posts/expanded', post: @post, float_notice: false %>


### PR DESCRIPTION
Closes #1391.

Adds missing `og` tags and fixes the broken `og:image` tags.