### PR TITLE
Null-safe usernames

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -118,7 +118,7 @@ module UsersHelper
     elsif deleted_user?(user)
       link_to 'deleted user', '#', link_opts_reduced
     else
-      link_to user.rtl_safe_username, user_url(user, **url_opts), link_opts_reduced
+      link_to user&.rtl_safe_username, user_url(user, **url_opts), link_opts_reduced
     end
   end
 

--- a/app/views/reactions/_list.html.erb
+++ b/app/views/reactions/_list.html.erb
@@ -8,11 +8,8 @@
             <%= rt.on_post_label %>
             <% rr.each_with_index do |r, i| %>
                 <% next if i >= reaction_shown_count %>
-                <span dir="ltr"><%=
-                    r.user.rtl_safe_username
-                %></span><%=
-                    ((i < rr.size - 1 && i + 1 != reaction_shown_count) ? ', ' : '')
-                %>
+                <span dir="ltr"><%= rtl_safe_username r.user %></span>
+                <%= ((i < rr.size - 1 && i + 1 != reaction_shown_count) ? ', ' : '') %>
             <% end %>
             <% if rr.size > reaction_shown_count %>
                 and <%=
@@ -47,7 +44,7 @@
                     <% rr.each do |r| %>
                     <tr>
                         <td>
-                            <%= link_to r.user.rtl_safe_username, user_path(r.user), dir: 'ltr'%>
+                            <%= link_to rtl_safe_username(r.user), user_path(r.user), dir: 'ltr'%>
                         </td>
                         <td class="comment-col">
                             <% if r.comment %>

--- a/app/views/subscription_mailer/subscription.text.erb
+++ b/app/views/subscription_mailer/subscription.text.erb
@@ -10,7 +10,7 @@ score <%= " +-"[question.score <=> 0] + question.score.to_s %>: <%= question.tit
 <%= post_url(question, host: @subscription.community.host) %>
 
 <%= question.body.first(150).gsub(/<\/?[^>]+>/, '') %><%= question.body.length > 150 ? '...' : '' %>
-— "<%= question.user.rtl_safe_username %>" (<%= user_url(question.user, host: @subscription.community.host) %>),
+— "<%= rtl_safe_username question.user %>" (<%= user_url(question.user, host: @subscription.community.host) %>),
    <%= time_ago_in_words(question.created_at) %> ago
 
 ----------------------------------


### PR DESCRIPTION
Found a few more instances of `rtl_safe_username` being used directly instead of the safer helper - this switches them over.