### PR TITLE
Use numeric inputs for two-factor codes

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,7 +1,7 @@
 <meta charset="utf-8" />
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<% desc = "#{SiteSetting['SiteName']} on Codidact - open, community-run Q&A knowledge sharing" %>
+<% desc = "#{SiteSetting['SiteName']} on #{ENV.fetch('NETWORK_NAME', 'Codidact')} - open, community-run Q&A knowledge sharing" %>
 <meta name="description" content="<%= content_for?(:description) ? content_for(:description) : desc %>" />
 
 <% page_title = (Rails.env.development? ? '[DEV] ' : '') +

--- a/app/views/two_factor/disable_code.html.erb
+++ b/app/views/two_factor/disable_code.html.erb
@@ -5,7 +5,8 @@
 <%= form_tag two_factor_confirm_disable_path do %>
   <div class="form-group">
     <%= label_tag 'code', 'Code', class: 'form-element' %>
-    <%= text_field_tag 'code', '', class: 'form-element' %>
+    <%= number_field_tag 'code', '', class: 'form-element', autocomplete: 'one-time-code', autofocus: 'true',
+        inputmode: 'numeric' %>
   </div>
 
   <%= submit_tag 'Confirm', class: 'button is-filled' %>

--- a/app/views/two_factor/enable_code.html.erb
+++ b/app/views/two_factor/enable_code.html.erb
@@ -15,7 +15,8 @@
 <%= form_tag two_factor_confirm_enable_path, autocomplete: 'off' do %>
   <div class="field">
     <%= label_tag 'code', 'Code', class: 'form-element' %>
-    <%= number_field_tag 'code', '', class: 'form-element', autocomplete: 'one-time-code' %>
+    <%= number_field_tag 'code', '', class: 'form-element', autocomplete: 'one-time-code', autofocus: 'true',
+        inputmode: 'numeric' %>
   </div>
 
   <%= submit_tag 'Confirm', class: 'button is-filled' %>

--- a/app/views/users/sessions/verify_2fa.html.erb
+++ b/app/views/users/sessions/verify_2fa.html.erb
@@ -9,7 +9,7 @@
 
   <div class="form-group">
     <%= label_tag 'code', 'Code', class: 'form-element' %>
-    <%= text_field_tag 'code', '', class: 'form-element', autocomplete: 'one-time-code', autofocus: 'true' %>
+    <%= number_field_tag 'code', '', class: 'form-element', autocomplete: 'one-time-code', autofocus: 'true', inputmode: 'numeric' %>
   </div>
 
   <div class="actions">


### PR DESCRIPTION
Closes #1575.

Changes the two-factor code inputs to autocomplete OTC, autofocus, numeric input mode, and input type "number". This should trigger mobile devices to use numeric keypads.