### PR TITLE
Link to deleted users for moderators

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -113,7 +113,7 @@ module UsersHelper
   def user_link(user, url_opts = {}, **link_opts)
     anchortext = link_opts[:anchortext]
     link_opts_reduced = { dir: 'ltr' }.merge(link_opts).except(:anchortext)
-    if deleted_user?(user) || user.nil?
+    if user.nil? || (deleted_user?(user) && !moderator?)
       link_to 'deleted user', '#', link_opts_reduced
     elsif !anchortext.nil?
       link_to anchortext, user_url(user, **url_opts), { dir: 'ltr' }.merge(link_opts)

--- a/app/views/post_history/post.html.erb
+++ b/app/views/post_history/post.html.erb
@@ -15,7 +15,7 @@
       <span class="has-color-tertiary-600 history-meta">
         <span>
           by
-          <% if deleted_user? event.user %>
+          <% if deleted_user?(event.user) && !moderator? %>
             (deleted user)
           <% else %>
             <img class="avatar-16" alt="user avatar" src="<%= avatar_url(event.user) %>" height="16" width="16" />

--- a/app/views/users/_common_card.html.erb
+++ b/app/views/users/_common_card.html.erb
@@ -9,7 +9,7 @@
 <% ckb ||= false %>
 <% small ||= false %>
 
-<% if user.nil? || deleted_user?(user) %>
+<% if user.nil? || (deleted_user?(user) && !moderator?) %>
   <div class="user-card deleted-content">
     <div class="user-card--avatar">
       <span class="avatar--deleted"><i class="fas fa-user-times"></i></span>
@@ -19,7 +19,7 @@
     </div>
   </div>
 <% else %>
-  <div class="user-card">
+  <div class="user-card <%= deleted_user?(user) ? 'deleted-content' : '' %>">
     <div class="user-card--avatar">
       <img alt="user card" src="<%= avatar_url(user, 48) %>" height="48" width="48" class="has-float-left" />
     </div>

--- a/app/views/users/_deleted.html.erb
+++ b/app/views/users/_deleted.html.erb
@@ -7,4 +7,10 @@
   <p>
     This <%= deletion_type %> is deleted. You have access to this page as a moderator, but this is not public information.
   </p>
+  <% deleted_object = user.deleted? ? user : user.community_user %>
+  <p class="has-font-size-caption">
+    <%= deletion_type.capitalize %> deleted
+    <span title="<%= deleted_object.deleted_at %>"><%= time_ago_in_words(deleted_object.deleted_at) %> ago</span>
+    by <%= link_to deleted_object.deleted_by.username, user_path(deleted_object.deleted_by) %>.
+  </p>
 </div>

--- a/test/helpers/users_helper_test.rb
+++ b/test/helpers/users_helper_test.rb
@@ -14,4 +14,22 @@ class UsersHelperTest < ActionView::TestCase
       assert_equal exp, avatar_url(usr)
     end
   end
+
+  test 'user_link' do
+    standard_user = users(:standard_user)
+
+    expected = [
+      [{
+        href: "http://test.host/users/#{standard_user.id}",
+        text: standard_user.rtl_safe_username
+      }, standard_user],
+      [{ href: '#', text: 'deleted user' }, nil]
+    ]
+
+    expected.each do |exp, usr|
+      link = Nokogiri::HTML4(user_link(usr)).at_css('a')
+      assert_equal exp[:href], link.attribute('href').value
+      assert_equal exp[:text], link.text
+    end
+  end
 end

--- a/test/helpers/users_helper_test.rb
+++ b/test/helpers/users_helper_test.rb
@@ -15,6 +15,12 @@ class UsersHelperTest < ActionView::TestCase
     end
   end
 
+  test 'user_link should return placeholder link if user is nil' do
+    link = Nokogiri::HTML4(user_link(nil)).at_css('a')
+    assert_equal '#', link.attribute('href').value
+    assert_equal 'deleted user', link.text
+  end
+
   test 'user_link' do
     standard_user = users(:standard_user)
 
@@ -22,8 +28,7 @@ class UsersHelperTest < ActionView::TestCase
       [{
         href: "http://test.host/users/#{standard_user.id}",
         text: standard_user.rtl_safe_username
-      }, standard_user],
-      [{ href: '#', text: 'deleted user' }, nil]
+      }, standard_user]
     ]
 
     expected.each do |exp, usr|


### PR DESCRIPTION
Closes #1416.

Makes links to deleted users work for moderators. User cards retain the 'deleted' style but will show the sanitised username and profile image as normal.