### PR TITLE
RAILS_ENV should be set to test not only during prep when running CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,8 @@ jobs:
             git rev-parse $(git rev-parse --abbrev-ref HEAD)
       - run:
           name: Test
+          environment:
+            RAILS_ENV: test
           command: |
             bundle exec rails test
       - store_test_results:
@@ -122,6 +124,8 @@ jobs:
             git rev-parse $(git rev-parse --abbrev-ref HEAD)
       - run:
           name: Test
+          environment:
+            RAILS_ENV: test
           command: |
             bundle exec rails test:system
       - store_test_results:
@@ -188,6 +192,8 @@ jobs:
             git rev-parse $(git rev-parse --abbrev-ref HEAD)
       - run:
           name: Test
+          environment:
+            RAILS_ENV: test
           command: |
             bundle exec rails test
       - store_test_results:
@@ -251,6 +257,8 @@ jobs:
             git rev-parse $(git rev-parse --abbrev-ref HEAD)
       - run:
           name: Test
+          environment:
+            RAILS_ENV: test
           command: |
             bundle exec rails test:system
       - store_test_results:


### PR DESCRIPTION
While we set up our tests with `RAILS_ENV` set to `true`, we run the actual tests without the env set. This causes Spring to be used and, what's more important, for SimpleCov to be initialized after it is run. This makes our Coverage reports incorrect (see, for example, lack of coverage increase for helpers and a significant bump in coverage in this exact PR).