### PR TITLE
Fix numeric stats column wrapping in user sidebar

### DIFF
--- a/app/assets/stylesheets/tables.scss
+++ b/app/assets/stylesheets/tables.scss
@@ -1,0 +1,5 @@
+.table {
+  &.fixed {
+    table-layout: fixed;
+  }
+}

--- a/app/assets/stylesheets/utilities.scss
+++ b/app/assets/stylesheets/utilities.scss
@@ -345,6 +345,12 @@ span.spoiler {
   overflow: hidden;
 }
 
+.overflow-ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .transparent {
   opacity: 0;
 }

--- a/app/assets/stylesheets/utilities.scss
+++ b/app/assets/stylesheets/utilities.scss
@@ -155,22 +155,55 @@ div:hover > .copy-button {
 }
 
 @keyframes shake {
-  0% { transform: translate(-5px); }
-  10% { transform: translate(5px); }
-  20% { transform: translate(-5px); }
-  30% { transform: translate(5px); }
-  40% { transform: translate(-5px); }
-  50% { transform: translate(5px); }
-  60% { transform: translate(-5px); }
-  70% { transform: translate(5px); }
-  80% { transform: translate(-5px); }
-  90% { transform: translate(5px); }
-  100% { transform: translate(-5px); }
+  0% {
+    transform: translate(-5px);
+  }
+
+  10% {
+    transform: translate(5px);
+  }
+
+  20% {
+    transform: translate(-5px);
+  }
+
+  30% {
+    transform: translate(5px);
+  }
+
+  40% {
+    transform: translate(-5px);
+  }
+
+  50% {
+    transform: translate(5px);
+  }
+
+  60% {
+    transform: translate(-5px);
+  }
+
+  70% {
+    transform: translate(5px);
+  }
+
+  80% {
+    transform: translate(-5px);
+  }
+
+  90% {
+    transform: translate(5px);
+  }
+
+  100% {
+    transform: translate(-5px);
+  }
 }
 
 .diff {
   .diff-section {
-    .diff-old, 
+
+    .diff-old,
     .diff-new {
       overflow: scroll;
     }
@@ -189,7 +222,8 @@ div:hover > .copy-button {
       min-height: 20px;
       white-space: pre-wrap;
 
-      del, ins {
+      del,
+      ins {
         text-decoration: none;
         overflow-wrap: break-word;
       }
@@ -283,7 +317,8 @@ span.spoiler {
     color: lighten($primary, 30%);
   }
 
-  &:hover span, &:active span {
+  &:hover span,
+  &:active span {
     transition: all 0.2s ease;
     visibility: visible;
     color: $key;

--- a/app/assets/stylesheets/utilities.scss
+++ b/app/assets/stylesheets/utilities.scss
@@ -345,12 +345,6 @@ span.spoiler {
   overflow: hidden;
 }
 
-.table {
-  &.fixed {
-    table-layout: fixed;
-  }
-}
-
 .transparent {
   opacity: 0;
 }

--- a/app/assets/stylesheets/utilities.scss
+++ b/app/assets/stylesheets/utilities.scss
@@ -4,6 +4,22 @@
   box-shadow: 0.1em 0.1em 0.2em $muted-graphic;
 }
 
+.flex {
+  display: flex;
+
+  &.items-center {
+    align-items: center;
+  }
+}
+
+.gap-sm {
+  gap: 0.5em;
+}
+
+.gap-md {
+  gap: 1em;
+}
+
 .flex-row-always {
   display: flex;
   flex-direction: row;
@@ -327,6 +343,12 @@ span.spoiler {
 
 .clearfix {
   overflow: hidden;
+}
+
+.table {
+  &.fixed {
+    table-layout: fixed;
+  }
 }
 
 .transparent {

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -148,4 +148,20 @@ module UsersHelper
       User.find(user_id)
     end
   end
+
+  # Extracts posts count for a given post type
+  # @param user_posts [Hash{Integer => Integer}] post counts by post type
+  # @param type [PostType] post type to extract count for
+  # @return [Integer] posts count
+  def posts_for(user_posts, type)
+    user_posts[type.post_type_id] || 0
+  end
+
+  # Extracts votes count for a given post type
+  # @param user_votes [Hash{Integer => Integer}] vote counts by post type
+  # @param type [PostType] post type to extract count for
+  # @return [Integer] votes count
+  def votes_for(user_votes, type)
+    user_votes[type.post_type_id] || 0
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -361,5 +361,23 @@ class User < ApplicationRecord
     save
   end
 
+  # Gets user's post counts by post type
+  # @return [Hash{Integer => Integer}]
+  def posts_by_post_type
+    posts.undeleted.group(Arel.sql('posts.post_type_id')).count(Arel.sql('posts.post_type_id'))
+  end
+
+  # Gets user's vote counts by vote type
+  # @return [Hash{Integer => Integer}]
+  def votes_by_type
+    votes.group(:vote_type).count(:vote_type)
+  end
+
+  # Gets user's vote counts by post type
+  # @return [Hash{Integer => Integer}]
+  def votes_by_post_type
+    votes.joins(:post).group(Arel.sql('posts.post_type_id')).count(Arel.sql('posts.post_type_id'))
+  end
+
   # rubocop:enable Naming/PredicateName
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -142,9 +142,7 @@
 
     <table class="table is-full-width">
       <tr>
-      </tr>
-      <tr>
-        <td colspan="2"><i class="fas fa-award" style="font-size:19px;"></i>&nbsp; Reputation</td>
+        <td colspan="2"><i class="fas fa-award" style="font-size:19px;"></i> Reputation</td>
         <td><%= @user.reputation %></td>
       </tr>
       <tr>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -143,23 +143,23 @@
     <table class="table fixed is-full-width">
       <tr>
         <td colspan="2"><i class="fas fa-award" style="font-size:19px;"></i> Reputation</td>
-        <td><%= @user.reputation %></td>
+        <td class="overflow-ellipsis" title="<%= @user.reputation %>"><%= @user.reputation %></td>
       </tr>
       <tr>
         <td colspan="2"><i class="far fa-fw fa-comment-alt"></i> Number of top-level posts</td>
-        <td><%= @user.metric '1' %></td>
+        <td class="overflow-ellipsis" title="<%= @user.metric '1' %>"><%= @user.metric '1' %></td>
       </tr>
       <tr>
         <td colspan="2"><i class="fas fa-fw fa-reply-all"></i> Number of answers</td>
-        <td><%= @user.metric '2' %></td>
+        <td class="overflow-ellipsis" title="<%= @user.metric '2' %>"><%= @user.metric '2' %></td>
       </tr>
       <tr>
         <td colspan="2"><i class="fas fa-fw fa-star-half-alt"></i> Sum of received votes (up minus down)</td>
-        <td><%= @user.metric 's' %></td>
+        <td class="overflow-ellipsis" title="<%= @user.metric 's' %>"><%= @user.metric 's' %></td>
       </tr>
       <tr>
         <td colspan="2"><i class="fas fa-fw fa-pen"></i> Number of edits made</td>
-        <td><%= @user.metric 'E' %></td>
+        <td class="overflow-ellipsis" title="<%= @user.metric 'E' %>"><%= @user.metric 'E' %></td>
       </tr>
       <% if current_user&.id == @user.id || current_user&.is_moderator %>
         <tr><td colspan="3">User since <%= @user.created_at %></td></tr>
@@ -196,50 +196,50 @@
 
     <h2>Statistics</h2>
     <%
-      posts_by_post_type = @user.posts.undeleted.group(Arel.sql('posts.post_type_id')).count(Arel.sql('posts.post_type_id'))
+      posts_by_post_type = @user.posts_by_post_type
     %>
     <table class="table fixed is-full-width">
       <tr>
-        <th colspan="3">
-          Posts
-        </th>
+        <th colspan="3">Posts</th>
       </tr>
       <tr>
         <td colspan="2">Count</td>
-        <td>
+        <td class="overflow-ellipsis" title="<%= @user.posts.undeleted.count %>">
           <%= @user.posts.undeleted.count %>
         </td>
       </tr>
       <tr>
         <td colspan="2">Questions</td>
-        <td><%= posts_by_post_type[Question.post_type_id] || 0 %></td>
+        <td class="overflow-ellipsis" title="<%= posts_for(posts_by_post_type, Question) %>">
+          <%= posts_for(posts_by_post_type, Question) %>
+        </td>
       </tr>
       <tr>
         <td colspan="2">Answers</td>
-        <td><%= posts_by_post_type[Answer.post_type_id] || 0 %></td>
+        <td class="overflow-ellipsis" title="<%= posts_for(posts_by_post_type, Answer) %>">
+          <%= posts_for(posts_by_post_type, Answer) %>
+        </td>
       </tr>
       <tr>
         <td colspan="2">Articles</td>
-        <td><%= posts_by_post_type[Article.post_type_id] || 0 %></td>
+        <td class="overflow-ellipsis" title="<%= posts_for(posts_by_post_type, Article) %>">
+          <%= posts_for(posts_by_post_type, Article) %>
+        </td>
       </tr>
     </table>
 
     <br>
     <table class="table fixed is-full-width">
       <%
-        votes_by_type = @user.votes.group(:vote_type).count(:vote_type)
-        votes_by_post_type = @user.votes.joins(:post).group(Arel.sql('posts.post_type_id')).count(Arel.sql('posts.post_type_id'))
+        votes_by_type = @user.votes_by_type
+        votes_by_post_type = @user.votes_by_post_type
       %>
       <tr>
-        <th colspan="3">
-          Votes cast
-        </th>
+        <th colspan="3">Votes cast</th>
       </tr>
       <tr>
         <td colspan="2">Count</td>
-        <td>
-          <%= @user.votes.count %>
-        </td>
+        <td class="overflow-ellipsis" title="<%= @user.votes.count %>"><%= @user.votes.count %></td>
       </tr>
       <% if @user.id == current_user&.id || current_user&.is_admin %>
       <tr>
@@ -250,7 +250,7 @@
             </svg>Upvotes
           </div>
         </td>
-        <td><%= votes_by_type[1] || 0 %></td>
+        <td class="overflow-ellipsis" title="<%= votes_by_type[1] || 0 %>"><%= votes_by_type[1] || 0 %></td>
       </tr>
       <tr>
         <td colspan="2">
@@ -260,32 +260,36 @@
             </svg>Downvotes
           </div>
         </td>
-        <td><%= votes_by_type[-1] || 0 %></td>
+        <td class="overflow-ellipsis" title="<%= votes_by_type[-1] || 0 %>"><%= votes_by_type[-1] || 0 %></td>
       </tr>
       <tr>
         <td colspan="2">on Question</td>
-        <td><%= votes_by_post_type[Question.post_type_id] || 0 %></td>
+        <td class="overflow-ellipsis" title="<%= votes_for(votes_by_post_type, Question) %>">
+          <%= votes_for(votes_by_post_type, Question) %>
+        </td>
       </tr>
       <tr>
         <td colspan="2">on Answer</td>
-        <td><%= votes_by_post_type[Answer.post_type_id] || 0 %></td>
+        <td class="overflow-ellipsis" title="<%= votes_for(votes_by_post_type, Answer) %>">
+          <%= votes_for(votes_by_post_type, Answer) %>
+        </td>
       </tr>
       <tr>
         <td colspan="2">on Article</td>
-        <td><%= votes_by_post_type[Article.post_type_id] || 0 %></td>
+        <td class="overflow-ellipsis" title="<%= votes_for(votes_by_post_type, Article) %>">
+          <%= votes_for(votes_by_post_type, Article) %>
+        </td>
       </tr>
       <% end %>
     </table>
     <br>
     <table class="table fixed is-full-width">
       <tr>
-        <th colspan="3">
-          Flags raised
-        </th>
+        <th colspan="3">Flags raised</th>
       </tr>
       <tr>
         <td colspan="2">Count</td>
-        <td>
+        <td class="overflow-ellipsis" title="<%= @user.flags.count %>">
           <% if current_user&.id == @user.id || moderator? %>
             <%= link_to @user.flags.count, flag_history_path(@user.id), class: 'is-muted',
                         'aria-label': "View flag history for #{@user.flags.count} flags" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -140,7 +140,7 @@
       <% end %>
     </div>
 
-    <table class="table is-full-width">
+    <table class="table fixed is-full-width">
       <tr>
         <td colspan="2"><i class="fas fa-award" style="font-size:19px;"></i> Reputation</td>
         <td><%= @user.reputation %></td>
@@ -161,16 +161,11 @@
         <td colspan="2"><i class="fas fa-fw fa-pen"></i> Number of edits made</td>
         <td><%= @user.metric 'E' %></td>
       </tr>
+      <% if current_user&.id == @user.id || current_user&.is_moderator %>
+        <tr><td colspan="3">User since <%= @user.created_at %></td></tr>
+      <% end %>
     </table>
-    
-    <% if current_user&.id == @user.id || current_user&.is_moderator %>
-    <table class="table is-full-width">
-      <tr>
-        <td>User since <%= @user.created_at %></td>
-      </tr>
-    </table>
-    <% end %>
-
+  
     <% unless @abilities.empty? %>
       <h2>Earned Abilities</h2>
 
@@ -203,7 +198,7 @@
     <%
       posts_by_post_type = @user.posts.undeleted.group(Arel.sql('posts.post_type_id')).count(Arel.sql('posts.post_type_id'))
     %>
-    <table class="table is-full-width">
+    <table class="table fixed is-full-width">
       <tr>
         <th colspan="3">
           Posts
@@ -230,7 +225,7 @@
     </table>
 
     <br>
-    <table class="table is-full-width">
+    <table class="table fixed is-full-width">
       <%
         votes_by_type = @user.votes.group(:vote_type).count(:vote_type)
         votes_by_post_type = @user.votes.joins(:post).group(Arel.sql('posts.post_type_id')).count(Arel.sql('posts.post_type_id'))
@@ -248,24 +243,22 @@
       </tr>
       <% if @user.id == current_user&.id || current_user&.is_admin %>
       <tr>
-        <td class="has-color-tertiary-600">
-          <svg width="1em" height="0.67em" viewbox="0 0 100 50">
-            <path d="M50,0 L100,50 L0,50 Z" fill="currentColor" />
-          </svg>
-        </td>
-        <td>
-          Upvotes
+        <td colspan="2">
+          <div class="flex items-center gap-sm">
+            <svg class="has-color-tertiary-600" width="1em" height="0.67em" viewbox="0 0 100 50">
+              <path d="M50,0 L100,50 L0,50 Z" fill="currentColor" />
+            </svg>Upvotes
+          </div>
         </td>
         <td><%= votes_by_type[1] || 0 %></td>
       </tr>
       <tr>
-        <td class="has-color-tertiary-600">
-          <svg width="1em" height="0.67em" viewbox="0 0 100 50">
-            <path d="M0,0 L100,0 L50,50 Z" fill="currentColor" />
-          </svg>
-        </td>
-        <td>
-          Downvotes
+        <td colspan="2">
+          <div class="flex items-center gap-sm">
+            <svg class="has-color-tertiary-600" width="1em" height="0.67em" viewbox="0 0 100 50">
+              <path d="M0,0 L100,0 L50,50 Z" fill="currentColor" />
+            </svg>Downvotes
+          </div>
         </td>
         <td><%= votes_by_type[-1] || 0 %></td>
       </tr>
@@ -284,7 +277,7 @@
       <% end %>
     </table>
     <br>
-    <table class="table is-full-width">
+    <table class="table fixed is-full-width">
       <tr>
         <th colspan="3">
           Flags raised


### PR DESCRIPTION
Closes #1590 

I opted for a combination of using:
- fixed table layout;
- disabled wrapping for the stats column (always the right one);
- clipping the content of the stats column on overflow (with ellipsis);
- showing a toolitp with the full value on hover;

The above should be enough to address the issue and it also has an extra benefit of improving layout alignment across the sidebar:

![Screenshot from 2025-04-02 01-03-17](https://github.com/user-attachments/assets/95c8d156-479d-4f0c-8c8d-5014d0aaa4a4)

The PR also comes with a bunch of other minor improvements (general view cleanup, several methods & helpers moving logic where it belongs - to models & helpers)