### PR TITLE
Add additional post history events

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -555,7 +555,7 @@ class PostsController < ApplicationController
     end
 
     ApplicationRecord.transaction do
-      @post.update locked: true, locked_by: current_user,
+      @post.update! locked: true, locked_by: current_user,
                    locked_at: DateTime.now, locked_until: end_date
       PostHistory.post_locked @post, current_user, before: end_date.nil? ? '' : "Locked until: #{end_date.iso8601}"
     end
@@ -570,7 +570,7 @@ class PostsController < ApplicationController
     end
 
     ApplicationRecord.transaction do
-      @post.update locked: false, locked_by: nil,
+      @post.update! locked: false, locked_by: nil,
                    locked_at: nil, locked_until: nil
       PostHistory.post_unlocked @post, current_user
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -556,7 +556,7 @@ class PostsController < ApplicationController
 
     ApplicationRecord.transaction do
       @post.update! locked: true, locked_by: current_user,
-                   locked_at: DateTime.now, locked_until: end_date
+                    locked_at: DateTime.now, locked_until: end_date
       PostHistory.post_locked @post, current_user, before: end_date.nil? ? '' : "Locked until: #{end_date.iso8601}"
     end
     render json: { status: 'success', success: true }
@@ -571,7 +571,7 @@ class PostsController < ApplicationController
 
     ApplicationRecord.transaction do
       @post.update! locked: false, locked_by: nil,
-                   locked_at: nil, locked_until: nil
+                    locked_at: nil, locked_until: nil
       PostHistory.post_unlocked @post, current_user
     end
     render json: { status: 'success', success: true }

--- a/db/seeds/post_history_types.yml
+++ b/db/seeds/post_history_types.yml
@@ -11,3 +11,6 @@
 - name: nominated_for_promotion
 - name: promotion_removed
 - name: history_hidden
+- name: category_changed
+- name: post_locked
+- name: post_unlocked


### PR DESCRIPTION
Closes #475.

Adds additional post history events for locks, unlocks, and category changes.