### PR TITLE
make avatar in usercard clickable

### DIFF
--- a/app/views/users/_common_card.html.erb
+++ b/app/views/users/_common_card.html.erb
@@ -21,7 +21,9 @@
 <% else %>
   <div class="user-card">
     <div class="user-card--avatar">
+      <%= link_to user_path(user), class: small ? :'user-card--link-small' :'user-card--link' do %>
       <img alt="user card" src="<%= avatar_url(user, 48) %>" height="48" width="48" class="has-float-left" />
+      <% end %>
     </div>
     <div class="user-card--content">
       <% data = {} %>

--- a/app/views/users/_common_card.html.erb
+++ b/app/views/users/_common_card.html.erb
@@ -22,7 +22,7 @@
   <div class="user-card">
     <div class="user-card--avatar">
       <%= link_to user_path(user), class: small ? :'user-card--link-small' :'user-card--link' do %>
-      <img alt="user card" src="<%= avatar_url(user, 48) %>" height="48" width="48" class="has-float-left" />
+        <img alt="user card" src="<%= avatar_url(user, 48) %>" height="48" width="48" class="has-float-left" />
       <% end %>
     </div>
     <div class="user-card--content">


### PR DESCRIPTION
Fixes https://github.com/codidact/qpixel/issues/1477.

We do not want the entire usercard to be a link to the profile, because someday different elements there might link to different places.  (The stats could link to the relevant part of the profile, but more likely, we might add top tags later.)  This change preserves the name link and adds the avatar link, rather than wrapping the whole card.
