### PR TITLE
Fix .comment-meta width issue

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -74,6 +74,10 @@
 
 .post--comments-container {
   margin-bottom: 1rem;
+  .comment-meta {
+      min-width: 100%;
+      box-sizing: content-box;
+  }
 }
 
 .post--comments-thread.is-inline {


### PR DESCRIPTION
#1558 introduced a [`max-width` condition](https://github.com/codidact/qpixel/pull/1558/files#diff-ab4ea0c322b2990cbb02c30bdc9f8739c62a39c617b8aa33647aa36c8e05200aR224-R226) that, for reasons I don't understand and likely never will, caused comment boxes to start underflowing:

![Screenshot showing a comment with the meta header not taking up the full available width](https://github.com/user-attachments/assets/695e83c8-3840-4192-97de-d9ff3b2c24ae)

Fix verified in:
* `/thread/{id}`
    * Selected thread + when embedded on that page
* `/posts/{id}`

This PR fixes this bug. AFAIK, it has not been reported anywhere (yet).