### PR TITLE
user search should match any substring, not just initial substring

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,7 +52,7 @@ class User < ApplicationRecord
   end
 
   def self.search(term)
-    where('username LIKE ?', "#{sanitize_sql_like(term)}%")
+    where('username LIKE ?', "%#{sanitize_sql_like(term)}%")
   end
 
   def inspect

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,6 +1,22 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
+  test 'search should correctly narrow down users by username' do
+    users = User.search('deleted')
+
+    users.each do |u|
+      assert_equal true, u.username.include?('deleted')
+    end
+  end
+
+  test 'search should match any substring in usernames' do
+    users = User.search('oderat')
+
+    users.each do |u|
+      assert_equal true, u.username.include?('oderat')
+    end
+  end
+
   test 'users should be destructible in a single call' do
     assert_nothing_raised do
       users(:standard_user).destroy!


### PR DESCRIPTION
Made the `LIKE` behavior for user search align with that for tag search, so you can match a substring from the middle of the name and not just the initial substring.  One-character fix.
