### PR TITLE
Move bulleted/ordered list and tables editor buttons to the first level

### DIFF
--- a/app/helpers/markdown_tools_helper.rb
+++ b/app/helpers/markdown_tools_helper.rb
@@ -22,6 +22,7 @@ module MarkdownToolsHelper
     attribs.merge! href: 'javascript:void(0)',
                    class: "#{attribs[:class] || ''} button is-muted is-outlined js-markdown-tool",
                    data_action: action,
+                   draggable: false,
                    aria_label: label,
                    title: label,
                    role: 'button'
@@ -42,6 +43,7 @@ module MarkdownToolsHelper
     attribs.merge! href: 'javascript:void(0)',
                    class: "#{attribs[:class] || ''}js-markdown-tool",
                    data_action: action,
+                   draggable: false,
                    aria_label: label,
                    title: label,
                    role: 'button'

--- a/app/views/shared/_markdown_tools.html.erb
+++ b/app/views/shared/_markdown_tools.html.erb
@@ -58,11 +58,14 @@
     <%= md_button label: 'Insert image', class: 'is-icon-only', data_modal: '#markdown-image-upload' do %>
       <i class="fas fa-fw fa-images"></i>
     <% end %>
+    <%= md_button action: 'table', label: 'Insert table', class: 'is-icon-only' do %>
+      <i class="fas fa-fw fa-table"></i>
+    <% end %>
   </div>
 
   <div class="button-list is-gutterless">
     <a href="javascript:void(0)" class="button is-outlined is-muted is-icon-only" data-drop="#markdown-tools"
-       data-drop-self-class-toggle="is-active" aria-label="Tools" title="Tools: tables, headings, lines" role="button">
+       data-drop-self-class-toggle="is-active" aria-label="Tools" title="Tools: headings, lines" role="button">
       <i class="fas fa-tools"></i>
     </a>
 
@@ -73,9 +76,6 @@
         <% end %>
         <%= md_list_item action: 'hr', label: 'Horizontal line' do %>
           <i class="fas fa-fw fa-level-down-alt"></i> Horizontal line
-        <% end %>
-        <%= md_list_item action: 'table', label: 'Table' do %>
-          <i class="fas fa-fw fa-table"></i> Table
         <% end %>
       </div>
     </div>

--- a/app/views/shared/_markdown_tools.html.erb
+++ b/app/views/shared/_markdown_tools.html.erb
@@ -40,6 +40,15 @@
   </div>
 
   <div class="button-list is-gutterless">
+    <%= md_button action: 'bullet', label: 'Bullet list', class: 'is-icon-only' do %>
+      <i class="fas fa-fw fa-list-ul"></i>
+    <% end %>
+    <%= md_button action: 'numbered', label: 'Numbered list', class: 'is-icon-only' do %>
+      <i class="fas fa-fw fa-list-ol"></i>
+    <% end %>
+  </div>
+
+  <div class="button-list is-gutterless">
     <%= md_button label: 'Link', class: 'is-icon-only', data_modal: '#markdown-link-insert' do %>
       <i class="fas fa-fw fa-link"></i>
     <% end %>
@@ -59,12 +68,6 @@
 
     <div class="droppanel" id="markdown-tools">
       <div class="droppanel--menu has-font-size-base">
-        <%= md_list_item action: 'bullet', label: 'Bullet list' do %>
-          <i class="fas fa-fw fa-list-ul"></i> Bullet list
-        <% end %>
-        <%= md_list_item action: 'numbered', label: 'Numbered list' do %>
-          <i class="fas fa-fw fa-list-ol"></i> Numbered list
-        <% end %>
         <%= md_list_item action: 'heading', label: 'Heading' do %>
           <i class="fas fa-fw fa-heading"></i> Heading
         <% end %>


### PR DESCRIPTION
Re: meta:293936 (doesn't close it, but related) and meta:293940 (partially addresses it)

~~Unfortunately, it competes with #1618 and will make it obsolete if merged.~~ (merged in as per discussion)

# Rationale

It's very unusual for editor tools to not show list management buttons at first level, so I think we should not reinvent the wheel. Examples:

GitHub editor tools:
![2025-05-12_01-59](https://github.com/user-attachments/assets/6af6edd8-5880-4fd7-8e1d-d41a210b0415)

Stack Overflow editor tools:
![2025-05-12_02-00](https://github.com/user-attachments/assets/b3d8e2f8-8b92-4620-b8a8-dfa961f8ba5c)

Well-known CKEditor:
![2025-05-12_02-01](https://github.com/user-attachments/assets/6dffd33c-6433-4aad-bc04-9e54d8869c0c)

And countless others.

# Changes

The change makes the tools panel look like this for a sufficiently wide viewport (note that list and table insertion buttons are no longer wrapped under the "tools" modal):
![2025-05-12_03-00](https://github.com/user-attachments/assets/6895e2b3-f5c2-46e1-95c4-4867e4fc829e)


And like this for a narrow one (we should improve button positioning on narrow viewports in general, but that's outside the scope of the PR):
![2025-05-12_03-00_1](https://github.com/user-attachments/assets/d1c18ae2-eaf4-4bbb-956e-d480ee89b3e9)

