### PR TITLE
Fix for deleted user card wrapping

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -100,6 +100,10 @@
 .user-card {
   display: flex;
 
+  &.deleted-content {
+    padding: 0.5rem;
+  }
+
   .user-card--avatar {
     align-self: flex-start;
     padding: 0 0.5rem;
@@ -113,11 +117,6 @@
       padding: 8px;
       display: inline-block;
     }
-  }
-
-  &.deleted-content .user-card--content {
-    display: flex;
-    align-items: center;
   }
 
   .user-card--content {


### PR DESCRIPTION
closes #1589 

User card after the change:

![Screenshot from 2025-05-13 12-17-09](https://github.com/user-attachments/assets/7f4e080f-12db-4395-894b-bce81125b920)


Compared to an undeleted user card:

![Screenshot from 2025-05-13 12-13-44](https://github.com/user-attachments/assets/157b7118-007d-43da-a2aa-a6b662de8312)
