### PR TITLE
Enabling activity sort on user posts pages

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -197,7 +197,9 @@ class UsersController < ApplicationController
              end.where(user: @user).list_includes.joins(:category)
              .where('IFNULL(categories.min_view_trust_level, 0) <= ?', current_user&.trust_level || 0)
              .user_sort({ term: params[:sort], default: :score },
-                        age: :created_at, score: :score)
+                        activity: :last_activity,
+                        age: :created_at,
+                        score: :score)
              .paginate(page: params[:page], per_page: 25)
     respond_to do |format|
       format.html do

--- a/app/views/users/posts.html.erb
+++ b/app/views/users/posts.html.erb
@@ -14,10 +14,15 @@
   </span>
 
   <div class="button-list is-gutterless has-margin-2">
-    <%= link_to 'Score', request.params.merge(sort: 'score'), class: 'button is-muted is-outlined ' + (active_search?('score') ? 'is-active' : ''),
-                role: 'button', 'aria-label': 'Sort by score' %>
-    <%= link_to 'Age', request.params.merge(sort: 'age'), class: 'button is-muted is-outlined ' + (active_search?('created_at') ? 'is-active' : ''),
-                role: 'button', 'aria-label': 'Sort by age' %>
+    <%= link_to 'Activity', request.params.merge(sort: 'activity'), 
+                            class: 'button is-muted is-outlined ' + (active_search?('last_activity') ? 'is-active' : ''),
+                            role: 'button', 'aria-label': 'Sort by activity' %>
+    <%= link_to 'Age', request.params.merge(sort: 'age'), 
+                       class: 'button is-muted is-outlined ' + (active_search?('created_at') ? 'is-active' : ''),
+                       role: 'button', 'aria-label': 'Sort by age' %>
+    <%= link_to 'Score', request.params.merge(sort: 'score'), 
+                         class: 'button is-muted is-outlined ' + (active_search?('score') ? 'is-active' : ''),
+                         role: 'button', 'aria-label': 'Sort by score' %>
   </div>
 </div>
 


### PR DESCRIPTION
closes #1113 

This is how the page will look like after the change (note that I haven't changed the default, the sorting still defaults to "score"):

![2025-05-17_14-10](https://github.com/user-attachments/assets/07e010f7-fce8-4bb0-9eef-ffded70e5dea)
