### PR TITLE
show who reviewed an edit in the 'decided' list

### DIFF
--- a/app/views/suggested_edit/category_index.html.erb
+++ b/app/views/suggested_edit/category_index.html.erb
@@ -67,6 +67,9 @@
           ><%= edit.active ? 'Pending' : (edit.approved? ? 'Approved' : 'Rejected' ) %></strong> suggested edit
           by <%= user_link edit.user %>,
           <span title="<%= edit.created_at.iso8601 %>"><%= time_ago_in_words(edit.created_at) %> ago</span>
+	  <% unless edit.active %>
+	  (reviewed by <%= user_link edit.decided_by %>)
+	  <% end %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
Small change suggested in chat recently: in the list of handled suggested edits, show who handled it.  The information is shown on the individual item if you click through, but this makes it a little easier to find a specific review.

![screenshot: adds "handled by (name)" after the editor name and time](https://github.com/user-attachments/assets/6d17164a-2620-4aeb-8a7c-53a455b00648)
