### PR TITLE
Restrict users from directly editing posts in categories they are restricted from participating

### DIFF
--- a/app/assets/javascripts/suggested_edit.js
+++ b/app/assets/javascripts/suggested_edit.js
@@ -1,3 +1,11 @@
+/**
+ * @typedef {{
+ *  message?: string
+ *  redirect_url?: string
+ *  status: 'success' | 'error'
+ * }} SuggestedEditActionResult
+ */
+
 $(() => {
   $('[data-suggested-edit-approve]').on('click', async (ev) => {
     ev.preventDefault();
@@ -31,12 +39,13 @@ $(() => {
 
     const resp = await QPixel.fetchJSON(`/posts/suggested-edit/${editId}/reject`, { rejection_comment: comment });
 
+    /** @type {SuggestedEditActionResult} */
     const data = await resp.json();
 
     if (data.status !== 'success') {
       QPixel.createNotification('danger', '<strong>Failed:</strong> ' + data.message);
     }
-    else {
+    else if (data.redirect_url) {
       location.href = data.redirect_url;
     }
   });

--- a/app/assets/javascripts/suggested_edit.js
+++ b/app/assets/javascripts/suggested_edit.js
@@ -15,12 +15,13 @@ $(() => {
 
     const resp = await QPixel.fetchJSON(`/posts/suggested-edit/${editId}/approve`, { comment });
 
+    /** @type {SuggestedEditActionResult} */
     const data = await resp.json();
 
     if (data.status !== 'success') {
       QPixel.createNotification('danger', '<strong>Failed:</strong> ' + data.message);
     }
-    else {
+    else if (data.redirect_url) {
       location.href = data.redirect_url;
     }
   });

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -67,7 +67,7 @@ class PostsController < ApplicationController
       return
     end
 
-    if @category.present? && @category.min_trust_level.present? && @category.min_trust_level > current_user.trust_level
+    if @category.present? && !current_user.can_post_in?(@category)
       @post.errors.add(:base, helpers.i18ns('posts.category_low_trust_level', name: @category.name))
       render :new, status: :forbidden
       return

--- a/app/controllers/suggested_edit_controller.rb
+++ b/app/controllers/suggested_edit_controller.rb
@@ -25,8 +25,9 @@ class SuggestedEditController < ApplicationController
     @post = @edit.post
 
     unless current_user&.can_approve?(@edit)
-      render(json: { status: 'error', message: helpers.ability_err_msg(:edit_posts, 'review suggested edits') },
-             status: :bad_request)
+      render(json: { status: 'error',
+                     message: helpers.ability_err_msg(:edit_posts, 'review suggested edits') },
+             status: :forbidden)
       return
     end
 
@@ -85,15 +86,18 @@ class SuggestedEditController < ApplicationController
 
   def reject
     unless @edit.active?
-      render json: { status: 'error', message: 'This edit has already been reviewed.' }, status: :conflict
+      render json: { status: 'error',
+                     message: 'This edit has already been reviewed.' },
+             status: :conflict
       return
     end
 
     @post = @edit.post
 
     unless current_user&.can_reject?(@edit)
-      render(json: { status: 'error', message: helpers.ability_err_msg(:edit_posts, 'review suggested edits') },
-             status: :bad_request)
+      render json: { status: 'error',
+                     message: helpers.ability_err_msg(:edit_posts, 'review suggested edits') },
+             status: :forbidden
       return
     end
 
@@ -103,10 +107,16 @@ class SuggestedEditController < ApplicationController
                     decided_by: current_user, updated_at: now)
       flash[:success] = 'Edit rejected successfully.'
       AbilityQueue.add(@edit.user, "Suggested Edit Rejected ##{@edit.id}")
-      render json: { status: 'success', redirect_url: helpers.generic_share_link(@post) }
+      render json: {
+        status: 'success',
+        redirect_url: helpers.generic_share_link(@post)
+      }
     else
-      render json: { status: 'error', message: 'Cannot reject this suggested edit... Strange.' },
-             status: :bad_request
+      render json: {
+               status: 'error',
+               message: 'Cannot reject this suggested edit... Strange.'
+             },
+             status: :internal_server_error
     end
   end
 

--- a/app/controllers/suggested_edit_controller.rb
+++ b/app/controllers/suggested_edit_controller.rb
@@ -92,7 +92,7 @@ class SuggestedEditController < ApplicationController
     @post = @edit.post
 
     unless current_user&.can_reject?(@edit)
-      render(json: { status: 'error', redirect_url: helpers.ability_err_msg(:edit_posts, 'review suggested edits') },
+      render(json: { status: 'error', message: helpers.ability_err_msg(:edit_posts, 'review suggested edits') },
              status: :bad_request)
       return
     end
@@ -105,7 +105,7 @@ class SuggestedEditController < ApplicationController
       AbilityQueue.add(@edit.user, "Suggested Edit Rejected ##{@edit.id}")
       render json: { status: 'success', redirect_url: helpers.generic_share_link(@post) }
     else
-      render json: { status: 'error', redirect_url: 'Cannot reject this suggested edit... Strange.' },
+      render json: { status: 'error', message: 'Cannot reject this suggested edit... Strange.' },
              status: :bad_request
     end
   end

--- a/app/controllers/suggested_edit_controller.rb
+++ b/app/controllers/suggested_edit_controller.rb
@@ -23,10 +23,10 @@ class SuggestedEditController < ApplicationController
     end
 
     @post = @edit.post
-    unless check_your_privilege('edit_posts', @post, false)
+
+    unless current_user&.can_approve?(@edit)
       render(json: { status: 'error', message: helpers.ability_err_msg(:edit_posts, 'review suggested edits') },
              status: :bad_request)
-
       return
     end
 
@@ -91,10 +91,9 @@ class SuggestedEditController < ApplicationController
 
     @post = @edit.post
 
-    unless check_your_privilege('edit_posts', @post, false)
+    unless current_user&.can_reject?(@edit)
       render(json: { status: 'error', redirect_url: helpers.ability_err_msg(:edit_posts, 'review suggested edits') },
              status: :bad_request)
-
       return
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -466,6 +466,9 @@ class UsersController < ApplicationController
       new_value = !@user.send(attrib)
       @user.update(attrib => new_value)
     end
+
+    @user.community_user.recalc_trust_level
+
     AuditLog.admin_audit(event_type: 'role_toggle', related: @user, user: current_user,
                          comment: "#{attrib} to #{new_value}")
     AbilityQueue.add(@user, 'Role Change')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -82,6 +82,13 @@ class User < ApplicationRecord
     end
   end
 
+  # Can the user post in the current category?
+  # @param category [Category] category to check
+  # @return [Boolean] check result
+  def can_post_in?(category)
+    category.min_trust_level.blank? || category.min_trust_level <= trust_level
+  end
+
   # Can the user push a given post type to network
   # @param post_type [PostType] type of the post to be pushed
   # @return [Boolean] check result

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,7 +73,6 @@ class User < ApplicationRecord
   # This class makes heavy use of predicate names, and their use is prevalent throughout the codebase
   # because of the importance of these methods.
   # rubocop:disable Naming/PredicateName
-
   def has_post_privilege?(name, post)
     if post.user == self
       true
@@ -103,7 +102,7 @@ class User < ApplicationRecord
   def can_update(post, post_type)
     return false unless can_post_in?(post.category)
 
-    privilege?('edit_posts') || at_least_moderator? || self == post.user || \
+    has_post_privilege?('edit_posts', post) || at_least_moderator? || \
       (post_type.is_freely_editable && privilege?('unrestricted'))
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,10 +83,10 @@ class User < ApplicationRecord
   end
 
   # Can the user post in the current category?
-  # @param category [Category] category to check
+  # @param category [Category, nil] category to check
   # @return [Boolean] check result
   def can_post_in?(category)
-    category.min_trust_level.blank? || category.min_trust_level <= trust_level
+    category.blank? || category.min_trust_level.blank? || category.min_trust_level <= trust_level
   end
 
   # Can the user push a given post type to network

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -101,6 +101,8 @@ class User < ApplicationRecord
   # @param post_type [PostType] type of the post (some are freely editable)
   # @return [Boolean] check result
   def can_update(post, post_type)
+    return false unless can_post_in?(post.category)
+
     privilege?('edit_posts') || at_least_moderator? || self == post.user || \
       (post_type.is_freely_editable && privilege?('unrestricted'))
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,6 +81,20 @@ class User < ApplicationRecord
     end
   end
 
+  # Can the user approve a given suggested edit?
+  # @param edit [SuggestedEdit] edit to check
+  # @return [Boolean] check result
+  def can_approve?(edit)
+    edit.post.present? && can_update(edit.post, edit.post.post_type)
+  end
+
+  # Can the user reject a given suggested edit?
+  # @param edit [SuggestedEdit] edit to check
+  # @return [Boolean] check result
+  def can_reject?(edit)
+    edit.post.present? && can_update(edit.post, edit.post.post_type)
+  end
+
   # Can the user post in the current category?
   # @param category [Category, nil] category to check
   # @return [Boolean] check result

--- a/app/views/posts/_edit_link.html.erb
+++ b/app/views/posts/_edit_link.html.erb
@@ -1,0 +1,11 @@
+<%#
+  Helper for rendering post edit link buttons
+
+  Variables:
+    post : Post to create the link for
+%>
+
+<%= link_to edit_post_path(post), class: 'tools--item', 'aria-label': 'Edit this post' do %>
+  <i class="fa fa-pencil-alt"></i>
+  Edit
+<% end %>

--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -243,15 +243,15 @@
             <% if (post_type.is_public_editable && !post.locked?) || current_user&.at_least_moderator? || post.user == current_user %>
               <% if current_user&.can_update(post, post_type) %>
                 <% if post.pending_suggested_edit? %>
-                  <%= render 'review_edit_link', post: post %>
+                  <%= render 'posts/review_edit_link', post: post %>
                 <% else %>
-                  <%= render 'edit_link', post: post %>
+                  <%= render 'posts/edit_link', post: post %>
                 <% end %>
               <% elsif current_user.present? %>
                 <% if post.pending_suggested_edit? %>
                   <span class="tools--item">suggested edit pending...</span>
                 <% elsif post_type.is_freely_editable %>
-                  <%= render 'edit_link', post: post %>
+                  <%= render 'posts/edit_link', post: post %>
                 <% else %>
                   <%= link_to edit_post_path(post), class: 'tools--item', 'aria-label': 'Suggest edit to this post' do %>
                     <i class="fa fa-pencil-alt"></i>

--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -248,19 +248,13 @@
                     Review suggested edit
                   <% end %>
                 <% else %>
-                  <%= link_to edit_post_path(post), class: 'tools--item', 'aria-label': 'Edit this post' do %>
-                    <i class="fa fa-pencil-alt"></i>
-                    Edit
-                  <% end %>
+                  <%= render 'edit_link', post: post %>
                 <% end %>
               <% elsif current_user.present? %>
                 <% if post.pending_suggested_edit? %>
                   <span class="tools--item">suggested edit pending...</span>
                 <% elsif post_type.is_freely_editable %>
-                  <%= link_to edit_post_path(post), class: 'tools--item', 'aria-label': 'Edit this post' do %>
-                    <i class="fa fa-pencil-alt"></i>
-                    Edit
-                  <% end %>
+                  <%= render 'edit_link', post: post %>
                 <% else %>
                   <%= link_to edit_post_path(post), class: 'tools--item', 'aria-label': 'Suggest edit to this post' do %>
                     <i class="fa fa-pencil-alt"></i>

--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -253,7 +253,7 @@
                     Edit
                   <% end %>
                 <% end %>
-              <% elsif !current_user.nil? %>
+              <% elsif current_user.present? %>
                 <% if post.pending_suggested_edit? %>
                   <span class="tools--item">suggested edit pending...</span>
                 <% elsif post_type.is_freely_editable %>

--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -243,10 +243,7 @@
             <% if (post_type.is_public_editable && !post.locked?) || current_user&.at_least_moderator? || post.user == current_user %>
               <% if check_your_post_privilege(post, 'edit_posts') %>
                 <% if post.pending_suggested_edit? %>
-                  <%= link_to suggested_edit_url(post.pending_suggested_edit.id), class: 'tools--item is-danger is-filled' do %>
-                    <i class="fa fa-spell-check"></i>
-                    Review suggested edit
-                  <% end %>
+                  <%= render 'review_edit_link', post: post %>
                 <% else %>
                   <%= render 'edit_link', post: post %>
                 <% end %>

--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -256,11 +256,11 @@
               <% elsif !current_user.nil? %>
                 <% if post.pending_suggested_edit? %>
                   <span class="tools--item">suggested edit pending...</span>
-		<% elsif post_type.is_freely_editable %>
+                <% elsif post_type.is_freely_editable %>
                   <%= link_to edit_post_path(post), class: 'tools--item', 'aria-label': 'Edit this post' do %>
                     <i class="fa fa-pencil-alt"></i>
                     Edit
-		  <% end %>
+                  <% end %>
                 <% else %>
                   <%= link_to edit_post_path(post), class: 'tools--item', 'aria-label': 'Suggest edit to this post' do %>
                     <i class="fa fa-pencil-alt"></i>

--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -157,7 +157,7 @@
 	</div>
 	<% end %>
       <% if post_type.is_public_editable && post.pending_suggested_edit? %>
-        <% if check_your_post_privilege(post, 'edit_posts') %>
+        <% if current_user&.can_update(post, post_type) %>
           <div class="notice h-p-2">
             <p class="h-m-0">
               <i class="fa fa-pencil-alt h-m-l-2 h-c-red-600"></i>
@@ -241,7 +241,7 @@
               History
             <% end %>
             <% if (post_type.is_public_editable && !post.locked?) || current_user&.at_least_moderator? || post.user == current_user %>
-              <% if check_your_post_privilege(post, 'edit_posts') %>
+              <% if current_user&.can_update(post, post_type) %>
                 <% if post.pending_suggested_edit? %>
                   <%= render 'review_edit_link', post: post %>
                 <% else %>

--- a/app/views/posts/_review_edit_link.html.erb
+++ b/app/views/posts/_review_edit_link.html.erb
@@ -1,0 +1,11 @@
+<%#
+  Helper for rendering suggested edit review link buttons
+
+  Variables:
+    post : Post to create the link for
+%>
+
+<%= link_to suggested_edit_url(post.pending_suggested_edit.id), class: 'tools--item is-danger is-filled' do %>
+  <i class="fa fa-spell-check"></i>
+  Review suggested edit
+<% end %>

--- a/test/controllers/suggested_edit_controller_test.rb
+++ b/test/controllers/suggested_edit_controller_test.rb
@@ -45,7 +45,7 @@ class SuggestedEditControllerTest < ActionController::TestCase
     suggested_edit.update(active: true, accepted: false)
 
     post :approve, params: { id: suggested_edit.id }
-    assert_response(400)
+    assert_response(:forbidden)
   end
 
   test 'signed-out shouldn\'t be able to reject' do
@@ -53,7 +53,7 @@ class SuggestedEditControllerTest < ActionController::TestCase
     suggested_edit.update(active: true, accepted: false)
 
     post :reject, params: { id: suggested_edit.id, rejection_comment: 'WHY NOT?' }
-    assert_response(400)
+    assert_response(:forbidden)
   end
 
   test 'users without the ability to edit posts shouldn\'t be able to approve' do
@@ -62,7 +62,7 @@ class SuggestedEditControllerTest < ActionController::TestCase
     edit = suggested_edits(:pending_high_trust)
 
     post :approve, params: { id: edit.id, format: 'json' }
-    assert_response(:bad_request)
+    assert_response(:forbidden)
 
     assert_nothing_raised do
       JSON.parse(response.body)
@@ -79,7 +79,7 @@ class SuggestedEditControllerTest < ActionController::TestCase
     edit = suggested_edits(:pending_high_trust)
 
     post :reject, params: { id: edit.id, format: 'json' }
-    assert_response(:bad_request)
+    assert_response(:forbidden)
 
     assert_nothing_raised do
       JSON.parse(response.body)
@@ -97,7 +97,7 @@ class SuggestedEditControllerTest < ActionController::TestCase
     suggested_edit.update(active: false, accepted: false)
 
     post :approve, params: { id: suggested_edit.id }
-    assert_response(409)
+    assert_response(:conflict)
   end
 
   test 'already decided edit shouldn\'t be able to be rejected' do
@@ -107,7 +107,7 @@ class SuggestedEditControllerTest < ActionController::TestCase
     suggested_edit.update(active: false, accepted: true)
 
     post :reject, params: { id: suggested_edit.id, rejection_comment: 'WHY NOT?' }
-    assert_response(409)
+    assert_response(:conflict)
   end
 
   test 'approving edit should change status and apply it' do

--- a/test/controllers/suggested_edit_controller_test.rb
+++ b/test/controllers/suggested_edit_controller_test.rb
@@ -56,6 +56,40 @@ class SuggestedEditControllerTest < ActionController::TestCase
     assert_response(400)
   end
 
+  test 'users without the ability to edit posts shouldn\'t be able to approve' do
+    sign_in users(:moderator)
+
+    edit = suggested_edits(:pending_high_trust)
+
+    post :approve, params: { id: edit.id, format: 'json' }
+    assert_response(:bad_request)
+
+    assert_nothing_raised do
+      JSON.parse(response.body)
+    end
+
+    res_body = JSON.parse(response.body)
+    assert_equal 'error', res_body['status']
+    assert_not_empty res_body['message']
+  end
+
+  test 'users without the ability to edit posts shouldn\'t be able to reject' do
+    sign_in users(:moderator)
+
+    edit = suggested_edits(:pending_high_trust)
+
+    post :reject, params: { id: edit.id, format: 'json' }
+    assert_response(:bad_request)
+
+    assert_nothing_raised do
+      JSON.parse(response.body)
+    end
+
+    res_body = JSON.parse(response.body)
+    assert_equal 'error', res_body['status']
+    assert_not_empty res_body['message']
+  end
+
   test 'already decided edit shouldn\'t be able to be approved' do
     sign_in users(:editor)
 

--- a/test/fixtures/suggested_edits.yml
+++ b/test/fixtures/suggested_edits.yml
@@ -61,3 +61,14 @@ rejected_suggested_edit:
   decided_at: 2000-01-01T00:00:00.000000Z
   decided_by: editor
   rejected_comment: NO WAY
+
+pending_high_trust:
+  post: high_trust
+  user: moderator
+  community: sample
+  body: This suggested edit requires high trust to be approved or rejected
+  title: Very important suggestion
+  body_markdown: <p>This suggested edit requires high trust to be approved or rejected</p>
+  comment: High trust only
+  active: true
+  accepted: false


### PR DESCRIPTION
closes #1605

With this change, even users with the ability to edit the post will only be able to submit suggested edits unless they meet category requirements (if it's present) [both screenshots show a post with a pending suggested edit made by the user lacking access]:

![image](https://github.com/user-attachments/assets/ab2b246a-960f-41a0-868b-80e1523d56da)

And this is how the same post looks like for a user with appropriate access:

![image](https://github.com/user-attachments/assets/3da75a0b-c532-4a1a-bbe1-ee7436b49794)

This PR also adds a couple of partials to make it easier to work with our rather complex view logic when it comes to editing.

Additionally, the PR fixes broken error notice when attempting to reject a suggested edit without access ("Failure: undefined" due to what is likely just a typo).

Finally, it ensures user trust level is recalculated when manually granting / revoking user roles (currently, **it is not updated**).

On a tangent: we should review whether we still need the `check_your_post_privilege` helper (it's legacy and significantly differs from server-side checks at this point)
