### PR TITLE
fixed lack of audit log pagination

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -65,6 +65,9 @@ class AdminController < ApplicationController
   end
 
   def audit_log
+    @page = helpers.safe_page(params)
+    @per_page = helpers.safe_per_page(params)
+
     @logs = if current_user.is_global_admin
               AuditLog.unscoped.where.not(log_type: ['user_annotation', 'user_history'])
             else
@@ -72,7 +75,8 @@ class AdminController < ApplicationController
             end.user_sort({ term: params[:sort], default: :created_at },
                           age: :created_at, type: :log_type, event: :event_type,
                           related: Arel.sql('related_type DESC, related_id DESC'), user: :user_id)
-            .paginate(page: params[:page], per_page: 100)
+            .paginate(page: @page, per_page: @per_page)
+
     render layout: 'without_sidebar'
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -342,4 +342,21 @@ module ApplicationHelper
   rescue
     [nil, nil]
   end
+
+  ##
+  # Extracts boundary-safe page num from parameters
+  # @param params [ActionController::Parameters] parameters to parse
+  # @return [Integer] boundary-safe page num
+  def safe_page(params)
+    params[:page].nil? ? 1 : params[:page].to_i
+  end
+
+  ##
+  # Extracts boundary-safe page limit from parameters
+  # @param params [ActionController::Parameters] parameters to parse
+  # @param min [Integer, nil] minimum limit per page
+  # @return [Integer] boundary-safe page limit
+  def safe_per_page(params, min = 20)
+    params[:per_page].nil? || params[:per_page].to_i < min ? min : params[:per_page].to_i
+  end
 end

--- a/app/views/admin/audit_log.html.erb
+++ b/app/views/admin/audit_log.html.erb
@@ -18,3 +18,7 @@
 </div>
 
 <%= render 'log_table' %>
+
+<div class="has-padding-top-4">
+  <%= will_paginate @logs, renderer: BootstrapPagination::Rails %>
+</div>


### PR DESCRIPTION
closes #1640 

This PR adds a couple of generally useful helpers for getting boundary-safe page number / limit values + fixes the lack of rendered pagination in the audit logs view: 

![image](https://github.com/user-attachments/assets/6f54f2f2-7243-4e2b-8024-bc53b41966e9)

Note that given that we now properly paginate logs, I've opted to reduce the default number of items per page to 20. The number can be controlled via `per_page` parameter as per usual (20 is the minimum and is the default value). This will get useful later when we add a control for how many items to show per page.