### PR TITLE
audit tag renames

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -121,13 +121,15 @@ class TagsController < ApplicationController
     status = false
 
     @tag.transaction do
+      old_tag_name = @tag.name
+
       status = @tag.update(name: params[:name])
 
       if status
         AuditLog.moderator_audit(event_type: 'tag_rename',
                                  related: @tag,
                                  user: current_user,
-                                 comment: "#{@tag.name} renamed to #{params[:name]}")
+                                 comment: "#{old_tag_name} renamed to #{params[:name]}")
       else
         raise ActiveRecord::Rollback
       end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -128,6 +128,8 @@ class TagsController < ApplicationController
                                  related: @tag,
                                  user: current_user,
                                  comment: "#{@tag.name} renamed to #{params[:name]}")
+      else
+        raise ActiveRecord::Rollback
       end
     end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -119,7 +119,8 @@ class TagsController < ApplicationController
 
   def rename
     Post.transaction do
-      AuditLog.moderator_audit event_type: 'tag_rename', related: @tag, user: current_user, comment: "#{@tag.name} renamed to #{params[:name]}"
+      AuditLog.moderator_audit event_type: 'tag_rename', related: @tag, user: current_user,
+                               comment: "#{@tag.name} renamed to #{params[:name]}"
       status = @tag.update(name: params[:name])
       render json: { success: status, tag: @tag }
     end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -121,9 +121,14 @@ class TagsController < ApplicationController
     status = false
 
     Post.transaction do
-      AuditLog.moderator_audit event_type: 'tag_rename', related: @tag, user: current_user,
-                               comment: "#{@tag.name} renamed to #{params[:name]}"
       status = @tag.update(name: params[:name])
+
+      if status
+        AuditLog.moderator_audit(event_type: 'tag_rename',
+                                 related: @tag,
+                                 user: current_user,
+                                 comment: "#{@tag.name} renamed to #{params[:name]}")
+      end
     end
 
     render json: { success: status, tag: @tag }

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -120,7 +120,7 @@ class TagsController < ApplicationController
   def rename
     status = false
 
-    Post.transaction do
+    @tag.transaction do
       status = @tag.update(name: params[:name])
 
       if status

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -118,12 +118,15 @@ class TagsController < ApplicationController
   end
 
   def rename
+    status = false
+
     Post.transaction do
       AuditLog.moderator_audit event_type: 'tag_rename', related: @tag, user: current_user,
                                comment: "#{@tag.name} renamed to #{params[:name]}"
       status = @tag.update(name: params[:name])
-      render json: { success: status, tag: @tag }
     end
+
+    render json: { success: status, tag: @tag }
   end
 
   def select_merge; end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -118,8 +118,11 @@ class TagsController < ApplicationController
   end
 
   def rename
-    status = @tag.update(name: params[:name])
-    render json: { success: status, tag: @tag }
+    Post.transaction do
+      AuditLog.moderator_audit event_type: 'tag_rename', related: @tag, user: current_user, comment: "#{@tag.name} renamed to #{params[:name]}"
+      status = @tag.update(name: params[:name])
+      render json: { success: status, tag: @tag }
+    end
   end
 
   def select_merge; end

--- a/test/controllers/tags_controller_test.rb
+++ b/test/controllers/tags_controller_test.rb
@@ -176,7 +176,7 @@ class TagsControllerTest < ActionController::TestCase
   end
 
   test 'should correctly rename a tag' do
-    sign_in users(:admin)
+    sign_in users(:moderator)
 
     tag = tags(:base)
 
@@ -202,7 +202,7 @@ class TagsControllerTest < ActionController::TestCase
   end
 
   test 'should prevent renaming a tag to an invalid name' do
-    sign_in users(:admin)
+    sign_in users(:moderator)
 
     tag = tags(:base)
 

--- a/test/controllers/tags_controller_test.rb
+++ b/test/controllers/tags_controller_test.rb
@@ -5,7 +5,7 @@ class TagsControllerTest < ActionController::TestCase
 
   test 'index with json format should return JSON list of tags' do
     get :index, params: { format: 'json' }
-    assert_response 200
+    assert_response :success
     assert_nothing_raised do
       JSON.parse(response.body)
     end
@@ -14,7 +14,7 @@ class TagsControllerTest < ActionController::TestCase
 
   test 'index with search params should return tags including search term' do
     get :index, params: { format: 'json', term: 'dis' }
-    assert_response 200
+    assert_response :success
     assert_nothing_raised do
       JSON.parse(response.body)
     end
@@ -26,7 +26,7 @@ class TagsControllerTest < ActionController::TestCase
 
   test 'index with search params should return tags whose synonyms include search term' do
     get :index, params: { format: 'json', term: 'syn' }
-    assert_response 200
+    assert_response :success
     assert_nothing_raised do
       JSON.parse(response.body)
     end
@@ -38,40 +38,40 @@ class TagsControllerTest < ActionController::TestCase
 
   test 'should get category tags list' do
     get :category, params: { id: categories(:main).id }
-    assert_response 200
+    assert_response :success
     assert_not_nil assigns(:tags)
     assert_not_nil assigns(:category)
 
     sign_in users(:standard_user)
     get :category, params: { id: categories(:main).id }
-    assert_response 200
+    assert_response :success
     assert_not_nil assigns(:tags)
     assert_not_nil assigns(:category)
   end
 
   test 'should get children list' do
     get :children, params: { id: categories(:main).id, tag_id: tags(:topic).id }
-    assert_response 200
+    assert_response :success
     assert_not_nil assigns(:tags)
     assert_not_nil assigns(:category)
 
     sign_in users(:standard_user)
     get :children, params: { id: categories(:main).id, tag_id: tags(:topic).id }
-    assert_response 200
+    assert_response :success
     assert_not_nil assigns(:tags)
     assert_not_nil assigns(:category)
   end
 
   test 'should get tag page and RSS' do
     get :show, params: { id: categories(:main).id, tag_id: tags(:topic).id }
-    assert_response 200
+    assert_response :success
     assert_not_nil assigns(:tag)
     assert_not_nil assigns(:category)
     assert_not_nil assigns(:posts)
 
     sign_in users(:standard_user)
     get :show, params: { id: categories(:main).id, tag_id: tags(:topic).id }
-    assert_response 200
+    assert_response :success
     assert_not_nil assigns(:tag)
     assert_not_nil assigns(:category)
     assert_not_nil assigns(:posts)
@@ -79,14 +79,14 @@ class TagsControllerTest < ActionController::TestCase
 
   test 'should get tag RSS feed' do
     get :show, params: { id: categories(:main).id, tag_id: tags(:topic).id, format: :rss }
-    assert_response 200
+    assert_response :success
     assert_not_nil assigns(:tag)
     assert_not_nil assigns(:category)
     assert_not_nil assigns(:posts)
 
     sign_in users(:standard_user)
     get :show, params: { id: categories(:main).id, tag_id: tags(:topic).id, format: :rss }
-    assert_response 200
+    assert_response :success
     assert_not_nil assigns(:tag)
     assert_not_nil assigns(:category)
     assert_not_nil assigns(:posts)
@@ -94,20 +94,20 @@ class TagsControllerTest < ActionController::TestCase
 
   test 'should deny edit to anonymous user' do
     get :edit, params: { id: categories(:main).id, tag_id: tags(:topic).id }
-    assert_response 302
+    assert_response :found
     assert_redirected_to new_user_session_path
   end
 
   test 'should deny edit to unprivileged user' do
     sign_in users(:standard_user)
     get :edit, params: { id: categories(:main).id, tag_id: tags(:topic).id }
-    assert_response 403
+    assert_response :forbidden
   end
 
   test 'should get edit' do
     sign_in users(:deleter)
     get :edit, params: { id: categories(:main).id, tag_id: tags(:topic).id }
-    assert_response 200
+    assert_response :success
     assert_not_nil assigns(:tag)
     assert_not_nil assigns(:category)
   end
@@ -115,7 +115,7 @@ class TagsControllerTest < ActionController::TestCase
   test 'should deny update to anonymous user' do
     patch :update, params: { id: categories(:main).id, tag_id: tags(:topic).id,
                              tag: { parent_id: tags(:discussion).id, excerpt: 'things' } }
-    assert_response 302
+    assert_response :found
     assert_redirected_to new_user_session_path
   end
 
@@ -123,14 +123,14 @@ class TagsControllerTest < ActionController::TestCase
     sign_in users(:standard_user)
     patch :update, params: { id: categories(:main).id, tag_id: tags(:topic).id,
                              tag: { parent_id: tags(:discussion).id, excerpt: 'things' } }
-    assert_response 403
+    assert_response :forbidden
   end
 
   test 'should update tag' do
     sign_in users(:deleter)
     patch :update, params: { id: categories(:main).id, tag_id: tags(:topic).id,
                              tag: { parent_id: tags(:discussion).id, excerpt: 'things' } }
-    assert_response 302
+    assert_response :found
     assert_redirected_to tag_path(id: categories(:main).id, tag_id: tags(:topic).id)
     assert_not_nil assigns(:tag)
     assert_equal tags(:discussion).id, assigns(:tag).parent_id
@@ -141,7 +141,7 @@ class TagsControllerTest < ActionController::TestCase
     sign_in users(:deleter)
     patch :update, params: { id: categories(:main).id, tag_id: tags(:topic).id,
                              tag: { tag_synonyms_attributes: { '1': { name: 'conversation' } } } }
-    assert_response 302
+    assert_response :found
     assert_redirected_to tag_path(id: categories(:main).id, tag_id: tags(:topic).id)
     assert_not_nil assigns(:tag)
     assert_equal 'conversation', assigns(:tag).tag_synonyms.first&.name
@@ -151,7 +151,7 @@ class TagsControllerTest < ActionController::TestCase
     sign_in users(:deleter)
     patch :update, params: { id: categories(:main).id, tag_id: tags(:base).id,
                              tag: { tag_synonyms_attributes: { '1': { id: tag_synonyms(:base_synonym).id, _destroy: 'true' } } } }
-    assert_response 302
+    assert_response :found
     assert_redirected_to tag_path(id: categories(:main).id, tag_id: tags(:base).id)
     assert_not_nil assigns(:tag)
     assert_equal true, (assigns(:tag).tag_synonyms.none? { |ts| ts.name == 'synonym' })
@@ -161,7 +161,7 @@ class TagsControllerTest < ActionController::TestCase
     sign_in users(:deleter)
     patch :update, params: { id: categories(:main).id, tag_id: tags(:topic).id,
                              tag: { parent_id: tags(:topic).id, excerpt: 'things' } }
-    assert_response 400
+    assert_response :bad_request
     assert_not_nil assigns(:tag)
     assert_equal ['A tag cannot be its own parent.'], assigns(:tag).errors.full_messages
   end
@@ -170,12 +170,12 @@ class TagsControllerTest < ActionController::TestCase
     sign_in users(:deleter)
     patch :update, params: { id: categories(:main).id, tag_id: tags(:topic).id,
                              tag: { parent_id: tags(:child).id, excerpt: 'things' } }
-    assert_response 400
+    assert_response :bad_request
     assert_not_nil assigns(:tag)
     assert_equal ["The #{tags(:child).name} tag is already a child of this tag."], assigns(:tag).errors.full_messages
   end
 
-  test 'should correctly rename the tag' do
+  test 'should correctly rename a tag' do
     sign_in users(:admin)
 
     tag = tags(:base)
@@ -190,7 +190,7 @@ class TagsControllerTest < ActionController::TestCase
       tag: tag
     }
 
-    assert_response 200
+    assert_response :success
     assert_nothing_raised do
       JSON.parse(response.body)
     end
@@ -199,5 +199,32 @@ class TagsControllerTest < ActionController::TestCase
 
     assert_equal true, res_body['success']
     assert_equal new_tag_name, res_body['tag']['name']
+  end
+
+  test 'should prevent renaming a tag to an invalid name' do
+    sign_in users(:admin)
+
+    tag = tags(:base)
+
+    old_tag_name = tag.name
+
+    post :rename, params: {
+      format: :json,
+      id: categories(:main).id,
+      name: '',
+      tag_id: tag.id,
+      tag: tag
+    }
+
+    assert_response :success
+    assert_nothing_raised do
+      JSON.parse(response.body)
+    end
+
+    res_body = JSON.parse(response.body)
+
+    assert_equal false, res_body['success']
+    tag.reload
+    assert_equal tag.name, old_tag_name
   end
 end

--- a/test/controllers/tags_controller_test.rb
+++ b/test/controllers/tags_controller_test.rb
@@ -202,6 +202,7 @@ class TagsControllerTest < ActionController::TestCase
 
     log_entry = AuditLog.last
     assert_equal 'tag_rename', log_entry['event_type']
+    assert_equal @tag.id, log_entry['related_id']
   end
 
   test 'should prevent renaming a tag to an invalid name' do

--- a/test/controllers/tags_controller_test.rb
+++ b/test/controllers/tags_controller_test.rb
@@ -174,4 +174,30 @@ class TagsControllerTest < ActionController::TestCase
     assert_not_nil assigns(:tag)
     assert_equal ["The #{tags(:child).name} tag is already a child of this tag."], assigns(:tag).errors.full_messages
   end
+
+  test 'should correctly rename the tag' do
+    sign_in users(:admin)
+
+    tag = tags(:base)
+
+    new_tag_name = 'renamed'
+
+    post :rename, params: {
+      format: :json,
+      id: categories(:main).id,
+      name: new_tag_name,
+      tag_id: tag.id,
+      tag: tag
+    }
+
+    assert_response 200
+    assert_nothing_raised do
+      JSON.parse(response.body)
+    end
+
+    res_body = JSON.parse(response.body)
+
+    assert_equal true, res_body['success']
+    assert_equal new_tag_name, res_body['tag']['name']
+  end
 end

--- a/test/controllers/tags_controller_test.rb
+++ b/test/controllers/tags_controller_test.rb
@@ -199,6 +199,9 @@ class TagsControllerTest < ActionController::TestCase
 
     assert_equal true, res_body['success']
     assert_equal new_tag_name, res_body['tag']['name']
+
+    log_entry = AuditLog.last
+    assert_equal 'tag_rename', log_entry['event_type']
   end
 
   test 'should prevent renaming a tag to an invalid name' do


### PR DESCRIPTION
Adds tag renames to the audit log -- merges are already there, and renames, like merges, don't leave visible history other than the log.  Fixes https://github.com/codidact/qpixel/issues/1638.

![screenshot of log entry](https://github.com/user-attachments/assets/bfb2e321-ac50-4858-8b20-7250be8b7f74)
