### PR TITLE
give curators a link to recently deleted posts

### DIFF
--- a/app/controllers/moderator_controller.rb
+++ b/app/controllers/moderator_controller.rb
@@ -1,8 +1,10 @@
 # Web controller. Provides authenticated actions for use by moderators. A lot of the stuff in here, and hence a lot of
 # the tools, are rather repetitive.
 class ModeratorController < ApplicationController
-  before_action :verify_moderator, except: [:nominate_promotion, :promotions, :remove_promotion, :recently_deleted_posts]
-  before_action :authenticate_user!, only: [:nominate_promotion, :promotions, :remove_promotion, :recently_deleted_posts]
+  before_action :verify_moderator,
+                except: [:nominate_promotion, :promotions, :remove_promotion, :recently_deleted_posts]
+  before_action :authenticate_user!,
+                only: [:nominate_promotion, :promotions, :remove_promotion, :recently_deleted_posts]
   before_action :set_post, only: [:nominate_promotion, :remove_promotion]
   before_action :unless_locked, only: [:nominate_promotion, :remove_promotion]
 

--- a/app/controllers/moderator_controller.rb
+++ b/app/controllers/moderator_controller.rb
@@ -1,8 +1,8 @@
 # Web controller. Provides authenticated actions for use by moderators. A lot of the stuff in here, and hence a lot of
 # the tools, are rather repetitive.
 class ModeratorController < ApplicationController
-  before_action :verify_moderator, except: [:nominate_promotion, :promotions, :remove_promotion]
-  before_action :authenticate_user!, only: [:nominate_promotion, :promotions, :remove_promotion]
+  before_action :verify_moderator, except: [:nominate_promotion, :promotions, :remove_promotion, :recently_deleted_posts]
+  before_action :authenticate_user!, only: [:nominate_promotion, :promotions, :remove_promotion, :recently_deleted_posts]
   before_action :set_post, only: [:nominate_promotion, :remove_promotion]
   before_action :unless_locked, only: [:nominate_promotion, :remove_promotion]
 

--- a/app/controllers/moderator_controller.rb
+++ b/app/controllers/moderator_controller.rb
@@ -1,6 +1,7 @@
 # Web controller. Provides authenticated actions for use by moderators. A lot of the stuff in here, and hence a lot of
 # the tools, are rather repetitive.
 class ModeratorController < ApplicationController
+  before_action :verify_can_see_deleted, only: [:recently_deleted_posts]
   before_action :verify_moderator,
                 except: [:nominate_promotion, :promotions, :remove_promotion, :recently_deleted_posts]
   before_action :authenticate_user!,
@@ -79,5 +80,13 @@ class ModeratorController < ApplicationController
 
   def unless_locked
     check_if_locked(@post)
+  end
+
+  def verify_can_see_deleted
+    if !user_signed_in? || !current_user.can_see_deleted?
+      render 'errors/not_found', layout: 'without_sidebar', status: :not_found
+      return false
+    end
+    true
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,6 +5,13 @@ module ApplicationHelper
   ##
   # Is the current user a moderator or admin on the current community?
   # @return [Boolean]
+  def at_least_curator?
+    user_signed_in? && ( check_your_privilege('curate') || current_user.at_least_moderator?)
+  end
+
+  ##
+  # Is the current user a moderator or admin on the current community?
+  # @return [Boolean]
   def at_least_moderator?
     user_signed_in? && current_user.at_least_moderator?
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,7 +22,7 @@ module ApplicationHelper
   def can_see_deleted?
     user_signed_in? && current_user.can_see_deleted?
   end
-  
+
   ##
   # Is the current user a standard user (not a moderator or an admin)?
   # @return [Boolean] check result

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,13 +5,6 @@ module ApplicationHelper
   ##
   # Is the current user a moderator or admin on the current community?
   # @return [Boolean]
-  def at_least_curator?
-    user_signed_in? && ( check_your_privilege('curate') || current_user.at_least_moderator?)
-  end
-
-  ##
-  # Is the current user a moderator or admin on the current community?
-  # @return [Boolean]
   def at_least_moderator?
     user_signed_in? && current_user.at_least_moderator?
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,6 +17,13 @@ module ApplicationHelper
   end
 
   ##
+  ## Does the current user have access to deleted posts?
+  # @return [Boolean]
+  def can_see_deleted?
+    user_signed_in? && current_user.can_see_deleted?
+  end
+  
+  ##
   # Is the current user a standard user (not a moderator or an admin)?
   # @return [Boolean] check result
   def standard?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -223,7 +223,7 @@ class User < ApplicationRecord
   def can_see_deleted?
     at_least_moderator? || community_user&.privilege('flag_curate') || false
   end
-  
+
   # Does this user have a profile on a given community?
   # @param community_id [Integer] id of the community to check
   # @return [Boolean] check result

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -219,6 +219,11 @@ class User < ApplicationRecord
     global_moderator? || global_admin? || false
   end
 
+  # Is the user allowed to see deleted posts?
+  def can_see_deleted?
+    at_least_moderator? || community_user&.privilege('flag_curate') || false
+  end
+  
   # Does this user have a profile on a given community?
   # @param community_id [Integer] id of the community to check
   # @return [Boolean] check result

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -76,7 +76,7 @@
       <h4 class="widget--header has-margin-0">Tools</h4>
       <div class="widget--body">
         <ul>
-	  <% if can_see_deleted? %>
+	  <% if can_see_deleted? && !at_least_moderator? %>
 	  <li><a href="/mod/deleted">Recent Deletions</a></li>
 	  <% end %>
 	  <%# this calls into application_helper, not the user model! %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -71,12 +71,16 @@
     <% end %>
   <% end %>
 
-  <% if at_least_moderator? %>
+  <% if check_your_privilege('flag_curate')  %>
     <div class="widget has-margin-4">
-      <h4 class="widget--header has-margin-0">Moderator Tools</h4>
+      <h4 class="widget--header has-margin-0">Tools</h4>
       <div class="widget--body">
         <ul>
+	  <li><a href="/mod/deleted">Recent Deletions</a></li>
+	  <%# this calls into application_helper, not the user model! %>
+	  <% if at_least_moderator? %>
           <li><%= link_to 'Moderator Tools', moderator_path %></li>
+          <% end %>
           <% if admin? %>
             <li><%= link_to 'Admin Tools', admin_path %></li>
           <% end %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -71,12 +71,14 @@
     <% end %>
   <% end %>
 
-  <% if check_your_privilege('flag_curate')  %>
+  <% if can_see_deleted? || at_least_moderator? %>
     <div class="widget has-margin-4">
       <h4 class="widget--header has-margin-0">Tools</h4>
       <div class="widget--body">
         <ul>
+	  <% if can_see_deleted? %>
 	  <li><a href="/mod/deleted">Recent Deletions</a></li>
+	  <% end %>
 	  <%# this calls into application_helper, not the user model! %>
 	  <% if at_least_moderator? %>
           <li><%= link_to 'Moderator Tools', moderator_path %></li>

--- a/app/views/moderator/recently_deleted_posts.html.erb
+++ b/app/views/moderator/recently_deleted_posts.html.erb
@@ -1,6 +1,9 @@
 <% content_for :title, "Recently Deleted Posts" %>
-<%= link_to moderator_path, class: 'has-font-size-small' do %>
-  &laquo; Return to moderator tools
+
+<% if current_user.at_least_moderator? %>
+  <%= link_to moderator_path, class: 'has-font-size-small' do %>
+    &laquo; Return to moderator tools
+  <% end %>
 <% end %>
 
 <h1>Recently Deleted Posts</h1>

--- a/app/views/moderator/recently_deleted_posts.html.erb
+++ b/app/views/moderator/recently_deleted_posts.html.erb
@@ -9,7 +9,11 @@
 <h1>Recently Deleted Posts</h1>
 
 <% if current_user.privilege?('flag_curate') %>
+
+<% unless current_user.at_least_moderator? %>
 <p>Because you have the Curate ability, you can see deleted posts regardless of who deleted them. If you feel a post has been deleted in error, you can restore it. If a post was deleted by its author and you decide to restore it, consider leaving a comment explaining why (to reduce confusion).</p>
+<% end %>
+
 <div class="item-list">
   <% @posts.each do |post| %>
     <%= render 'posts/type_agnostic', post: post %>

--- a/app/views/moderator/recently_deleted_posts.html.erb
+++ b/app/views/moderator/recently_deleted_posts.html.erb
@@ -9,6 +9,7 @@
 <h1>Recently Deleted Posts</h1>
 
 <% if current_user.privilege?('flag_curate') %>
+<p>Because you have the Curate ability, you can see deleted posts regardless of who deleted them. If you feel a post has been deleted in error, you can restore it. If a post was deleted by its author and you decide to restore it, consider leaving a comment explaining why (to reduce confusion).</p>
 <div class="item-list">
   <% @posts.each do |post| %>
     <%= render 'posts/type_agnostic', post: post %>
@@ -20,7 +21,3 @@
 <% else %> 
 <p>You need the Curate ability in order to see deleted posts.</p>
 <% end %>
-
-
-
-

--- a/app/views/moderator/recently_deleted_posts.html.erb
+++ b/app/views/moderator/recently_deleted_posts.html.erb
@@ -7,6 +7,8 @@
 <% end %>
 
 <h1>Recently Deleted Posts</h1>
+
+<% if current_user.privilege?('flag_curate') %>
 <div class="item-list">
   <% @posts.each do |post| %>
     <%= render 'posts/type_agnostic', post: post %>
@@ -14,3 +16,11 @@
 </div>
 
 <%= will_paginate @posts, renderer: BootstrapPagination::Rails %>
+
+<% else %> 
+<p>You need the Curate ability in order to see deleted posts.</p>
+<% end %>
+
+
+
+

--- a/app/views/moderator/recently_deleted_posts.html.erb
+++ b/app/views/moderator/recently_deleted_posts.html.erb
@@ -8,8 +8,6 @@
 
 <h1>Recently Deleted Posts</h1>
 
-<% if current_user.privilege?('flag_curate') %>
-
 <% unless current_user.at_least_moderator? %>
 <p>Because you have the Curate ability, you can see deleted posts regardless of who deleted them. If you feel a post has been deleted in error, you can restore it. If a post was deleted by its author and you decide to restore it, consider leaving a comment explaining why (to reduce confusion).</p>
 <% end %>
@@ -22,6 +20,3 @@
 
 <%= will_paginate @posts, renderer: BootstrapPagination::Rails %>
 
-<% else %> 
-<p>You need the Curate ability in order to see deleted posts.</p>
-<% end %>


### PR DESCRIPTION
Fixes https://github.com/codidact/qpixel/issues/1533.  Users with the Curate ability now see the "recent deletions" link in the sidebar widget.  We don't show the link to moderators, who already have access to this list in mod tools, to reduce clutter for them.  This pattern will also make sense when we show curators the flags they can handle; adding that link for mods would be confusing when the full list of flags is already provided in the topbar, and I'd like to be consistent.
