### PR TITLE
Add an admin email lookup tool

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -201,4 +201,15 @@ class AdminController < ApplicationController
       render :change_back
     end
   end
+
+  def do_email_query
+    users = User.where(email: params[:email])
+    if users.any?
+      @user = users.first
+      @profiles = @user.community_users.includes(:community).where(community: current_user.admin_communities)
+    else
+      flash[:danger] = 'No user found with that email address.'
+    end
+    render :email_query
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -219,6 +219,26 @@ class User < ApplicationRecord
     global_moderator? || global_admin? || false
   end
 
+  # Which communities is this user a moderator (local or global) on?
+  # @return [Community[]] list of communities
+  def moderator_communities
+    if global_moderator?
+      Community.all
+    else
+      Community.joins(:community_users).where(community_users: { user_id: id, is_moderator: true })
+    end
+  end
+
+  # Which communities is this user an admin (local or global) of?
+  # @return [Community[]] list of communities
+  def admin_communities
+    if global_admin?
+      Community.all
+    else
+      Community.joins(:community_users).where(community_users: { user_id: id, is_admin: true })
+    end
+  end
+
   # Is the user allowed to see deleted posts?
   def can_see_deleted?
     at_least_moderator? || community_user&.privilege('flag_curate') || false

--- a/app/views/admin/email_query.html.erb
+++ b/app/views/admin/email_query.html.erb
@@ -1,0 +1,18 @@
+<h1><%= t 'admin.tools.email_query' %></h1>
+<p><%= t 'admin.email_query_blurb' %></p>
+
+<% if defined?(@user) %>
+  <p>Your query for <strong><%= params[:email] %></strong> returned profiles in these communities:</p>
+  <ul>
+    <% @profiles.each do |p| %>
+      <li><%= user_link @user, { host: p.community.host }, anchortext: p.community.name %></li>
+    <% end %>
+  </ul>
+  <p class="has-font-size-caption">These results only include communities where you are an admin.</p>
+<% else %>
+  <%= form_tag do_email_query_path, method: 'POST' do %>
+    <%= label_tag :email, 'Email', class: 'form-element' %>
+    <%= text_field_tag :email, params[:email], class: 'form-element' %>
+    <%= submit_tag 'Search', class: 'button is-filled' %>
+  <% end %>
+<% end %>

--- a/config/locales/strings/en.admin.yml
+++ b/config/locales/strings/en.admin.yml
@@ -18,6 +18,9 @@ en:
     error_search_uuid: 'Search for an error UUID'
     privileges_blurb: >
       Here you can define the reputation required to gain each available privilege. Click on a value to edit it.
+    email_query_blurb: >
+      This tool allows you to query for a user by their email address. If a user is found, you will be shown a list of
+      their profiles on communities on which you are an admin.
     tools:
       g_site_settings: 'Global Site Settings'
       g_tag_sets: 'Global Tag Sets'
@@ -31,4 +34,5 @@ en:
       licenses: 'Licenses'
       audit_log: 'Audit Log'
       post_types: 'Post Types'
+      email_query: 'User Lookup by Email'
     user_fed_stat: 'User fed to STAT.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,9 @@ Rails.application.routes.draw do
     post   'impersonate/:id',              to: 'admin#change_users', as: :impersonate
     get    'impersonate/:id',              to: 'admin#impersonate', as: :start_impersonating
 
+    get    'email-query',                  to: 'admin#email_query', as: :admin_email_query
+    post   'email-query',                  to: 'admin#do_email_query', as: :do_email_query
+
     scope 'post-types' do
       root                                 to: 'post_types#index', as: :post_types
       get    'new',                        to: 'post_types#new', as: :new_post_type

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -120,7 +120,7 @@ class AdminControllerTest < ActionController::TestCase
 
   test 'should do email query' do
     sign_in users(:admin)
-    post :do_email_query, params: { email: users(:standard).email }
+    post :do_email_query, params: { email: users(:standard_user).email }
     assert_response(:success)
     assert_not_nil assigns(:user)
     assert_not_nil assigns(:profiles)

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class AdminControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
-  PARAM_LESS_ACTIONS = [:index, :error_reports, :privileges, :audit_log].freeze
+  PARAM_LESS_ACTIONS = [:index, :error_reports, :privileges, :audit_log, :email_query].freeze
 
   test 'should get index' do
     sign_in users(:admin)
@@ -116,5 +116,13 @@ class AdminControllerTest < ActionController::TestCase
     get :audit_log
     assert_response(:success)
     assert_not_nil assigns(:logs)
+  end
+
+  test 'should do email query' do
+    sign_in users(:admin)
+    post :do_email_query, params: { email: users(:standard).email }
+    assert_response(:success)
+    assert_not_nil assigns(:user)
+    assert_not_nil assigns(:profiles)
   end
 end

--- a/test/fixtures/communities.yml
+++ b/test/fixtures/communities.yml
@@ -2,6 +2,10 @@ sample:
   host: sample.qpixel.com
   name: Sample
 
+extra:
+  host: extra.qpixel.com
+  name: Extra
+
 fake:
   host: fake.qpixel.com
   name: Comms Sabotage

--- a/test/fixtures/communities.yml
+++ b/test/fixtures/communities.yml
@@ -2,10 +2,6 @@ sample:
   host: sample.qpixel.com
   name: Sample
 
-extra:
-  host: extra.qpixel.com
-  name: Extra
-
 fake:
   host: fake.qpixel.com
   name: Comms Sabotage

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -226,4 +226,20 @@ class UserTest < ActiveSupport::TestCase
       assert_equal cu.user.has_ability_on(community.id, unrestricted.internal_id), !cu.user.deleted
     end
   end
+
+  test 'moderator_communities should correctly list mod communities' do
+    global_result = users(:global_moderator).moderator_communities
+    assert_equal Community.all.size, global_result.size
+
+    local_result = users(:moderator).moderator_communities
+    assert_equal 1, local_result.size
+  end
+
+  test 'admin_communities should correctly list admin communities' do
+    global_result = users(:global_admin).admin_communities
+    assert_equal Community.all.size, global_result.size
+
+    local_result = users(:admin).admin_communities
+    assert_equal 1, local_result.size
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -228,6 +228,8 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'moderator_communities should correctly list mod communities' do
+    Community.create(name: 'Test', host: 'test.host')
+
     global_result = users(:global_moderator).moderator_communities
     assert_equal Community.all.size, global_result.size
 
@@ -236,6 +238,8 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'admin_communities should correctly list admin communities' do
+    Community.create(name: 'Test', host: 'test.host')
+
     global_result = users(:global_admin).admin_communities
     assert_equal Community.all.size, global_result.size
 


### PR DESCRIPTION
Allows admins to look up user accounts by email address (for i.e. deletion requests).

Only shows profiles in communities on which the querying user is an admin.