### PR TITLE
make confirmation email clearer to (try to) reduce false spam flags

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,6 +1,6 @@
-<p>Welcome to Codidact, <%= @resource.username %>! We're glad you're here.</p>
+<p>Welcome to Codidact, <%= @resource.username %>! We're glad you're here.  (If this wasn't you, please ignore this email.)</p>
 
-<p>Please confirm your registration by clicking below (or copy and paste the URL into your browser).</p>
+<p>Please confirm your registration by clicking below (or copy and paste the URL into your browser).  You cannot sign in to your account until you do this.</p>
 
 <p>
   <%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token, host: RequestContext.community.host),

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -18,11 +18,11 @@ en:
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:
-        subject: "Confirmation instructions"
+        subject: "New Codidact account confirmation instructions"
       reset_password_instructions:
-        subject: "Reset password instructions"
+        subject: "Codidact reset password instructions"
       unlock_instructions:
-        subject: "Unlock instructions"
+        subject: "Codidact unlock instructions"
       password_change:
         subject: "Password Changed"
     omniauth_callbacks:


### PR DESCRIPTION
Added "Codidact" to email subject lines (because a lot of spam is generic like "confirmation instructions"), and expanded the confirmation message to include "ignore if this wasn't you" guidance in hopes of reducing incorrect spam reports.

I didn't review other message bodies (only subject lines) because new accounts are by far the most likely source of unexpected email to innocent bystanders.