### PR TITLE
Update Devise config

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -11,7 +11,6 @@ Devise.setup do |config|
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
   # config.secret_key = 'a01993900cb61b8d32ff3a777b37164cc49d880aaa8e03c3f9a2990612fa1b4c588d934556e60ea4f51dd334d23caa8ca9ba6a84d651cb412a3d155096b74556'
-  config.secret_key = 'd379fc6a0bc73bc2faf863d6846f1bd676af3adb46b594f8b3287c52b54cd303556961e03716e370c0031692ec9fc698aee177676f939f3825befbf4b5ef8e9a'
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
@@ -110,7 +109,7 @@ Devise.setup do |config|
   # config.pepper = '87767bd8e2fa1b42fdf61c33717d80f306570b0c0eb964f090023e7e23f3f196ea847ea7a1c7dd16efff145511e9aa0a80094024708dbe3406b1a184f43ee18a'
 
   # Send a notification email when the user's password is changed
-  # config.send_password_change_notification = false
+  config.send_password_change_notification = true
 
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
@@ -126,7 +125,7 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  # config.confirm_within = 3.days
+  config.confirm_within = 3.hours
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
@@ -169,27 +168,27 @@ Devise.setup do |config|
   # Defines which strategy will be used to lock an account.
   # :failed_attempts = Locks an account after a number of failed attempts to sign in.
   # :none            = No lock strategy. You should handle locking by yourself.
-  # config.lock_strategy = :failed_attempts
+  config.lock_strategy = :failed_attempts
 
   # Defines which key will be used when locking and unlocking an account
-  # config.unlock_keys = [:email]
+  config.unlock_keys = [:email]
 
   # Defines which strategy will be used to unlock an account.
   # :email = Sends an unlock link to the user email
   # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
   # :both  = Enables both strategies
   # :none  = No unlock strategy. You should handle unlocking by yourself.
-  # config.unlock_strategy = :both
+  config.unlock_strategy = :email
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.
-  # config.maximum_attempts = 20
+  config.maximum_attempts = 10
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
   # config.unlock_in = 1.hour
 
   # Warn on the last attempt before the account is locked.
-  # config.last_attempt_warning = true
+  config.last_attempt_warning = true
 
   # ==> Configuration for :recoverable
   #
@@ -199,7 +198,7 @@ Devise.setup do |config|
   # Time interval you can reset your password with a reset password key.
   # Don't put a too small interval or your users won't have the time to
   # change their passwords.
-  config.reset_password_within = 6.hours
+  config.reset_password_within = 3.hours
 
   # When set to false, does not sign a user in automatically after their password is
   # reset. Defaults to true, so a user is signed in automatically after a reset.

--- a/test/mailers/previews/devise_mailer_preview.rb
+++ b/test/mailers/previews/devise_mailer_preview.rb
@@ -2,4 +2,8 @@ class DeviseMailerPreview < ActionMailer::Preview
   def confirmation_instructions
     Devise::Mailer.confirmation_instructions(User.first, 'faketoken')
   end
+
+  def password_change
+    Devise::Mailer.password_change(User.first)
+  end
 end


### PR DESCRIPTION
* Remove Devise-specific secret key (falls back to application secret key base)
* Send notification emails on password change
* Set account confirmation & password reset windows to 3 hours
* Add lock/unlock strategies based on failed attempts (10) - accounts can also be manually locked if necessary