### PR TITLE
Improve system test tag selection

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -74,8 +74,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     end
 
     # Wait for tag search to finish
-    assert_text("Searching…")
-    assert_no_text("Searching…")
+    assert_text('Searching…')
+    assert_no_text('Searching…')
 
     # Get the first and last options listed
     first_option = find('#select2-post_tags_cache-results li:first-child')


### PR DESCRIPTION
In wondering how to make the tests more reliable, I noticed that the `post_form_select_tag` method in `test/application_system_test_case.rb` excludes "Searching..." from the drop down box, which means the search may still be ongoing, so the number of tags that have been added to the drop down box may not be consistent between runs. I've instead made the method wait for the search to finish before proceeding, so it will always be working with the full list of results.

I've also simplified the nested `if` block in the same method, since it was repeating the same output in 2 different branches.

I have no reason to think that the ongoing search was causing any problems. I'm just making it more robust while I think of it. Similarly for the duplication in the `if` block - it was working correctly already, I'm just always wary of having the same output in 2 different places, with the risk of 1 being amended in future without the other.