### PR TITLE
Docker setup fix: make NPM executable work out of the box

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,17 +22,19 @@ RUN bundle install
 
 # cherry pick only what we really need to run Node.js
 COPY --from=node /usr/local/bin/node /usr/local/bin
-COPY --from=node /usr/local/bin/nodejs /usr/local/bin
-COPY --from=node /usr/local/bin/npm /usr/local/bin
-COPY --from=node /usr/local/bin/npx /usr/local/bin
-COPY --from=node /usr/local/bin/yarn /usr/local/bin
-COPY --from=node /usr/local/bin/yarnpkg /usr/local/bin
 COPY --from=node /usr/local/include/node /usr/local/include
 COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --from=node /usr/local/share/doc/node /usr/local/share/doc
 COPY --from=node /usr/local/share/man/man1/node.1 /usr/local/share/man/man1
 COPY --from=node /usr/local/share/systemtap/tapset/node.stp /usr/local/share/systemtap/tapset
 COPY --from=node /opt/yarn-v1.22.4 /opt/yarn-v1.22.4
+
+# create symlinks needed to run Node.js & NPM
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+RUN ln -s /opt/yarn-v1.22.4/bin/yarn /usr/local/bin/yarn
+RUN ln -s /opt/yarn-v1.22.4/bin/yarnpkg /usr/local/bin/yarnpkg
+RUN ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 FROM build
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -23,17 +23,19 @@ RUN bundle install
 
 # cherry pick only what we really need to run Node.js
 COPY --from=node /usr/local/bin/node /usr/local/bin
-COPY --from=node /usr/local/bin/nodejs /usr/local/bin
-COPY --from=node /usr/local/bin/npm /usr/local/bin
-COPY --from=node /usr/local/bin/npx /usr/local/bin
-COPY --from=node /usr/local/bin/yarn /usr/local/bin
-COPY --from=node /usr/local/bin/yarnpkg /usr/local/bin
 COPY --from=node /usr/local/include/node /usr/local/include
 COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --from=node /usr/local/share/doc/node /usr/local/share/doc
 COPY --from=node /usr/local/share/man/man1/node.1 /usr/local/share/man/man1
 COPY --from=node /usr/local/share/systemtap/tapset/node.stp /usr/local/share/systemtap/tapset
 COPY --from=node /opt/yarn-v1.22.4 /opt/yarn-v1.22.4
+
+# create symlinks needed to run Node.js & NPM
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+RUN ln -s /opt/yarn-v1.22.4/bin/yarn /usr/local/bin/yarn
+RUN ln -s /opt/yarn-v1.22.4/bin/yarnpkg /usr/local/bin/yarnpkg
+RUN ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 FROM build
 


### PR DESCRIPTION
This PR fixes a mistake I made when configuring how dependencies of the global `npm` package are copied over from the base Node.js image. Also further slims down the image by switching to symlinks for the Node.js related libraries (and in case of `npm`, it's a necessary change to be able to just run all commands from the container).
