### PR TITLE
Suggestions for the PR #1681

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -163,6 +163,10 @@ module ApplicationHelper
   # @param params [Hash{Symbol => #to_s}] additional URL params
   # @return [String]
   def generic_share_link(post, **params)
+    unless params.key?(:host)
+      params.store(:host, post.community.host)
+    end
+
     if second_level_post_types.include?(post.post_type_id)
       answer_post_url({
         id: post.parent_id,

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -13,6 +13,13 @@ module CommentsHelper
     end
   end
 
+  # Gets a link to a given comment's user
+  # @param comment [Comment] comment to link the user for
+  # @return [String] comment user link
+  def comment_user_link(comment)
+    user_link(comment.user, { host: comment.community.host })
+  end
+
   ##
   # Process a comment and convert ping-strings (i.e. @#1234) into links.
   # @param comment [String] The text of the comment to process.

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,4 +1,13 @@
 module PostsHelper
+  # Gets a link to a given post's user
+  # @param post [Post] post to link the user for
+  # @param active [Boolean] if +true+, will link to the user with the last activity on the post
+  # @return [String] user link
+  def post_user_link(post, active: false)
+    user = active ? post.last_activity_by || post.user : post.user
+    user_link(user, { host: post.community.host })
+  end
+
   ##
   # Get HTML for a field - should only be used in Markdown create/edit requests. Prioritises using the client-side
   # rendered HTML over rendering server-side.

--- a/app/mailers/flag_mailer.rb
+++ b/app/mailers/flag_mailer.rb
@@ -1,5 +1,5 @@
 class FlagMailer < ApplicationMailer
-  helper :application, :post_types, :users, :tags, :comments
+  helper :application, :post_types, :users, :tags, :posts, :comments
 
   def flag_escalated
     @flag = params[:flag]

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -40,7 +40,7 @@
       </div>
     <% end %>
     <div class="comment--info">
-      <%= user_link comment.user %> wrote
+      <%= comment_user_link(comment) %> wrote
       <span title="<%= comment.created_at.iso8601 %>"><%= time_ago_in_words(comment.created_at) %> ago</span>
       <% if comment.updated_at > comment.created_at %>
         · <span title="<%= comment.updated_at.iso8601 %>">edited <%= time_ago_in_words(comment.updated_at) %> ago</span>

--- a/app/views/flags/_flag.html.erb
+++ b/app/views/flags/_flag.html.erb
@@ -21,7 +21,7 @@
   <div class="widget--body">
     <p>
       <strong><%= flag.post_flag_type&.name || 'Flag reason' %></strong>: <%= flag.reason %> &mdash;
-      <%= user_link flag.user %> at <%= flag.created_at.iso8601 %>
+      <%= user_link flag.user, { host: flag.community.host } %> at <%= flag.created_at.iso8601 %>
       <% if flag.post_type == 'Post' && flag.post.updated_at > flag.created_at %>
         <%= link_to post_history_path(flag.post) do %>
           (post modified after flag)
@@ -33,7 +33,7 @@
     <div class="widget--body">
       <p>
         <strong>Escalation reason</strong>: <%= flag.escalation_comment %> &mdash;
-        <%= user_link flag.escalated_by %> <%= flag.escalated_at.iso8601 %>
+        <%= user_link flag.escalated_by, { host: flag.community.host } %> at <%= flag.escalated_at.iso8601 %>
       </p>
       <p>
 	      <strong>Attention</strong>: The reply to the flag will be shown to the flagger, not the mod escalating this

--- a/app/views/flags/_flag.html.erb
+++ b/app/views/flags/_flag.html.erb
@@ -23,7 +23,7 @@
       <strong><%= flag.post_flag_type&.name || 'Flag reason' %></strong>: <%= flag.reason %> &mdash;
       <%= user_link flag.user, { host: flag.community.host } %> at <%= flag.created_at.iso8601 %>
       <% if flag.post_type == 'Post' && flag.post.updated_at > flag.created_at %>
-        <%= link_to post_history_path(flag.post) do %>
+        <%= link_to post_history_url(flag.post, { host: flag.community.host }) do %>
           (post modified after flag)
         <% end %>
       <% end %>

--- a/app/views/posts/_list.html.erb
+++ b/app/views/posts/_list.html.erb
@@ -1,7 +1,6 @@
 <%# is_question = post.post_type_id == Question.post_type_id %>
 <%# is_article = post.post_type_id == Article.post_type_id %>
 <%# is_meta = (is_question && post.meta?) || (!is_question && post.parent&.meta?) %>
-<% active_user = post.last_activity_by || post.user %>
 <% @show_type_tag = !!defined?(show_type_tag) ? show_type_tag : false %>
 <% @show_category_tag = !!defined?(show_category_tag) ? show_category_tag : false %>
 <% @last_activity = !!defined?(last_activity) ? last_activity : true %>
@@ -47,11 +46,11 @@
         </span>&nbsp;&middot;&nbsp;
       <% end %>
       posted <span title="<%= post.created_at.iso8601 %>"><%= time_ago_in_words(post.created_at, locale: :en_abbrev) %> ago</span>
-      by <%= user_link post.user %>
+      by <%= post_user_link(post) %>
       <% if post.last_activity != post.created_at %>
         &nbsp;&middot;&nbsp; <%= post.last_activity_type %>
         <span title="<%= post.last_activity.iso8601 %>"><%= time_ago_in_words(post.last_activity, locale: :en_abbrev) %> ago</span>
-        by <%= user_link active_user %>
+        by <%= post_user_link(post, active: true) %>
       <% end %>
     </p>
     <div class="has-padding-top-2 post-list--tags">

--- a/app/views/summary_mailer/content_summary.html.erb
+++ b/app/views/summary_mailer/content_summary.html.erb
@@ -10,7 +10,7 @@
 <% if @posts.any? %>
   <% @posts.first(10).each do |p| %>
     <p>
-      <strong><%= link_to p.title, generic_share_link(p, host: p.community.host) %></strong><br/>
+      <strong><%= link_to p.title, generic_share_link(p) %></strong><br/>
       by <%= user_link p.user, { host: p.community.host } %> on <%= p.community.name %>
     </p>
   <% end %>
@@ -32,7 +32,7 @@
         <%= f.status || 'pending' %>
       </span><br/>
       by <%= user_link f.user, { host: f.community.host } %>
-      on <%= link_to f.post.title, generic_share_link(f.post, host: f.community.host) %>
+      on <%= link_to f.post.title, generic_share_link(f.post) %>
       on <%= f.community.name %><br/>
     </p>
   <% end %>
@@ -49,7 +49,7 @@
     <blockquote><%= c.content %></blockquote>
     <p class="has-margin-top-0">
       by <%= user_link c.user, { host: c.post.community.host } %>
-      on <%= link_to c.post.title, generic_share_link(c.post, host: c.post.community.host) %>
+      on <%= link_to c.post.title, generic_share_link(c.post) %>
       on <%= c.post.community.name %>
     </p>
   <% end %>

--- a/test/mailers/flag_mailer_test.rb
+++ b/test/mailers/flag_mailer_test.rb
@@ -3,6 +3,11 @@ require 'test_helper'
 class FlagMailerTest < ActionMailer::TestCase
   test 'flag_escalated' do
     assert_emails 1 do
+      flag = flags(:escalated)
+
+      # forces 'post modified after flag' to be rendered
+      flag.post.update(updated_at: DateTime.now)
+
       FlagMailer.with(flag: flags(:escalated)).flag_escalated.deliver_now
     end
   end

--- a/test/mailers/flag_mailer_test.rb
+++ b/test/mailers/flag_mailer_test.rb
@@ -1,14 +1,22 @@
 require 'test_helper'
 
 class FlagMailerTest < ActionMailer::TestCase
-  test 'flag_escalated' do
+  test 'flag_escalated should correctly send flag escalation emails' do
+    assert_emails 1 do
+      flag = flags(:escalated)
+
+      FlagMailer.with(flag: flag).flag_escalated.deliver_now
+    end
+  end
+
+  test 'flag_escalated should not fail if the flagged post has been updated before escalation' do
     assert_emails 1 do
       flag = flags(:escalated)
 
       # forces 'post modified after flag' to be rendered
       flag.post.update(updated_at: DateTime.now)
 
-      FlagMailer.with(flag: flags(:escalated)).flag_escalated.deliver_now
+      FlagMailer.with(flag: flag).flag_escalated.deliver_now
     end
   end
 end


### PR DESCRIPTION
Fixes the exact reason why the mailer sometimes causes a server error (`post_history_path` in a context that doesn't have the `_path` helpers, only `_url`). Also adds a test case ensuring we don't get a regression on this in the future. 

Finally, the suggestions fix the `generic_share_link` helper linking to the default host (for mailers, it's `meta.codidact.com`) in contexts where host is not provided implicitly or explicitly via the `host:` parameter & other links in the flag escalation email (which closes #1184)