### PR TITLE
One last suggestion for PR #1681

### DIFF
--- a/app/views/posts/_list.html.erb
+++ b/app/views/posts/_list.html.erb
@@ -59,16 +59,15 @@
         <%= post_type_badge(post.post_type) %>
       <% end %>
       <% if post.post_type.has_tags %>
-        <% required_ids = post.category&.required_tag_ids %>
-        <% moderator_ids = post.category&.moderator_tag_ids %>
-        <% topic_ids = post.category&.topic_tag_ids %>
-        <% category_sort_tags(post.tags, required_ids, topic_ids, moderator_ids).each do |tag| %>
-          <% required = required_ids&.include?(tag.id) ? 'is-filled' : '' %>
-          <% topic = topic_ids&.include?(tag.id) ? 'is-outlined' : '' %>
-          <% moderator = moderator_ids.include?(tag.id) ? 'is-red is-outlined' : '' %>
-          <%= link_to tag.name, tag_url(id: post.category_id, tag_id: tag.id),
-                           class: "badge is-tag #{required} #{topic} #{moderator}",
-                           title: tag.excerpt.present? ? tag.excerpt : "(no description yet)" %>
+        <% required_tag_ids = post.category&.required_tag_ids %>
+        <% moderator_tag_ids = post.category&.moderator_tag_ids %>
+        <% topic_tag_ids = post.category&.topic_tag_ids %>
+        <% category_sort_tags(post.tags, required_tag_ids, topic_tag_ids, moderator_tag_ids).each do |tag| %>
+          <%= render 'posts/tag_badge', post: post,
+                                        tag: tag,
+                                        moderator_tag_ids: moderator_tag_ids,
+                                        required_tag_ids: required_tag_ids,
+                                        topic_tag_ids: topic_tag_ids %>
         <% end %>
       <% end %>
       <% display_label = user_preference('display_import_labels', community: true) == 'true' %>

--- a/app/views/posts/_tag_badge.html.erb
+++ b/app/views/posts/_tag_badge.html.erb
@@ -1,0 +1,19 @@
+<%#
+    Renders a linked badge for a given post & tag
+
+    Variables:
+      post             : Post the tag is on
+      tag              : Tag to render the badge for
+    ? required_tag_ids : list of tag IDs required for the post's category
+    ? topic_tag_ids    : list of tag IDs topical for the post's category
+    ? moderator_tag_ids      : list of mod-only tags IDs for the post's category
+%>
+
+<% required = required_tag_ids&.include?(tag.id) ? 'is-filled' : '' %>
+<% topic = topic_tag_ids&.include?(tag.id) ? 'is-outlined' : '' %>
+<% mod_only = moderator_tag_ids&.include?(tag.id) ? 'is-red is-outlined' : '' %>
+
+<%= link_to tag.name,
+            tag_url(id: post.category_id, tag_id: tag.id, host: post.community.host),
+            class: "badge is-tag #{required} #{topic} #{mod_only}",
+            title: tag.excerpt.present? ? tag.excerpt : "(no description yet)" %>


### PR DESCRIPTION
Fixes post tag badges linking to default host in flag escalation emails (and possibly other places). 
Also adds a reusable partial for post tags.