### PR TITLE
Show pings in thread titles & strip markdown

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -21,11 +21,7 @@ class CommentsController < ApplicationController
   def create_thread
     title = params[:title]
     unless title.present?
-      title = if params[:body].length > 100
-                "#{params[:body][0..100]}..."
-              else
-                params[:body]
-              end
+      title = helpers.generate_thread_title(params[:body])
     end
 
     body = params[:body]

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -34,18 +34,11 @@ module CommentsHelper
     user_link(comment.user, { host: comment.community.host })
   end
 
-  # Extracts user ID from a given ping string (i.e. @#1234)
-  # @param ping [String] ping to extract from
-  # @return [Integer] extracted ID
-  def uid_from_ping(ping)
-    ping[2..-1].to_i
-  end
-
   # Gets a list of pinged user IDs from a given content
   # @param content [String] content to get pinged user IDs from
   # @return [Array<String>] list of pinged user IDs
   def pinged_user_ids(content)
-    content.scan(/@#\d+/).map { |ping| uid_from_ping(ping) }
+    content.scan(/@#(\d+)/).map { |g| g[0].to_i }
   end
 
   # Gets a list of pinged users for a given content
@@ -64,8 +57,8 @@ module CommentsHelper
   def render_pings(content, pingable: nil)
     users = pinged_users(content)
 
-    content.gsub(/@#\d+/) do |ping|
-      user = users[uid_from_ping(ping)]
+    content.gsub(/@#(\d+)/) do |ping|
+      user = users[Regexp.last_match(1).to_i]
       if user.nil?
         ping
       else
@@ -83,9 +76,9 @@ module CommentsHelper
   def render_pings_text(content)
     users = pinged_users(content)
 
-    content.gsub(/@#\d+/) do |ping|
-      user = users[uid_from_ping(ping)]
-      "@#{user.nil? ? ping : rtl_safe_username(user)}"
+    content.gsub(/@#(\d+)/) do |ping|
+      user = users[Regexp.last_match(1).to_i]
+      user.nil? ? ping : "@#{rtl_safe_username(user)}"
     end
   end
 

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -47,6 +47,16 @@ module CommentsHelper
     end.html_safe
   end
 
+  # Converts all ping strings (i.e. @#1234) in content into usernames for use in text-only contexts
+  # @param content [String] content to convert ping strings for
+  # @return [String] processed content
+  def render_pings_text(content)
+    content.gsub(/@#\d+/) do |id|
+      user = User.where(id: id[2..-1].to_i).first
+      "@#{user.nil? ? id : rtl_safe_username(user)}"
+    end
+  end
+
   ##
   # Process comment text and convert helper links (like [help] and [flags]) into real links.
   # @param comment_text [String] The text of the comment to process.

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -34,18 +34,11 @@ module CommentsHelper
     user_link(comment.user, { host: comment.community.host })
   end
 
-  # Gets a list of pinged user IDs from a given content
-  # @param content [String] content to get pinged user IDs from
-  # @return [Array<String>] list of pinged user IDs
-  def pinged_user_ids(content)
-    content.scan(/@#(\d+)/).map { |g| g[0].to_i }
-  end
-
   # Gets a list of pinged users for a given content
   # @param content [String] content to get pinged users from
   # @return [Hash{String => User}] list of pinged users
   def pinged_users(content)
-    user_ids = pinged_user_ids(content)
+    user_ids = content.scan(/@#(\d+)/).map { |g| g[0].to_i }
     User.where(id: user_ids).to_a.to_h { |u| [u.id, u] }
   end
 

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -54,7 +54,7 @@ module CommentsHelper
         ping
       else
         was_pung = pingable.present? && pingable.include?(user.id)
-        classes = "ping #{user.id == current_user&.id ? 'me' : ''} #{was_pung ? '' : 'unpingable'}"
+        classes = "ping #{user.same_as?(current_user) ? 'me' : ''} #{was_pung ? '' : 'unpingable'}"
         user_link user, class: classes, dir: 'ltr',
                   title: was_pung ? '' : 'This user was not notified because they have not participated in this thread.'
       end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,5 +1,19 @@
 # Helpers related to comments.
 module CommentsHelper
+  # Generates a comment thread title from its body
+  # @param body [String] coment thread body
+  # @return [String] generated title
+  def generate_thread_title(body)
+    body = strip_markdown(body)
+    body = body.gsub(/^>.+?$/, '') # also remove leading blockquotes
+
+    if body.length > 100
+      "#{body[0..100]}..."
+    else
+      body
+    end
+  end
+
   ##
   # Get a link to the specified comment, accounting for deleted comments.
   # @param comment [Comment]

--- a/app/models/concerns/identity.rb
+++ b/app/models/concerns/identity.rb
@@ -3,7 +3,7 @@ module Identity
 
   included do
     # Is this record the same as a given other record?
-    # @param other [ApplicationRecord] record to compare with
+    # @param other [Class, nil] record to compare with
     # @return [Boolean] check result
     def same_as?(other)
       instance_of?(other.class) && id == other.id

--- a/app/views/comment_threads/_collapsed.html.erb
+++ b/app/views/comment_threads/_collapsed.html.erb
@@ -21,6 +21,6 @@
   <% elsif thread.locked? %>
     <i class="fas fa-lock fa-fw" title="Locked thread" aria-label="Locked thread"></i>
   <% end %>
-  <%= link_to thread.title, comment_thread_path(thread), class: 'js--comment-link', data: { thread: thread.id }, role: 'button' %>
+  <%= link_to render_pings_text(thread.title), comment_thread_path(thread), class: 'js--comment-link', data: { thread: thread.id }, role: 'button' %>
   (<%= pluralize(thread.reply_count, 'comment') %>)
 </div>

--- a/app/views/comment_threads/_expanded.html.erb
+++ b/app/views/comment_threads/_expanded.html.erb
@@ -51,7 +51,7 @@
       <% elsif thread.locked? %>
         <i class="fas fa-lock fa-fw" title="Locked. This thread has been locked and cannot be modified."></i>
       <% end %>
-      <span class="js-thread-title"><%= thread.title %></span>
+      <span class="js-thread-title"><%= render_pings_text(thread.title) %></span>
     </div>
     <% skipped_deleted = 0 %>
     <% comments = thread.comments %>

--- a/test/models/concerns/identity_test.rb
+++ b/test/models/concerns/identity_test.rb
@@ -36,4 +36,14 @@ class IdentityTest < ActiveSupport::TestCase
 
     assert_not first.same_as?(second)
   end
+
+  test 'same_as? should not fail if the compared model is nil' do
+    first = @klass1.new(42)
+
+    assert_nothing_raised do
+      first.same_as?(nil)
+    end
+
+    assert_not first.same_as?(nil)
+  end
 end


### PR DESCRIPTION
closes #1262

---

This is how thread titles with pings look like now:

<img width="652" height="136" alt="Screenshot from 2025-07-16 03-33-37" src="https://github.com/user-attachments/assets/279133c3-75be-493d-9b0e-a8f7026bfced" />

And this is how they will look like after the change (not married to the exact formatting):

<img width="652" height="136" alt="Screenshot from 2025-07-16 03-33-17" src="https://github.com/user-attachments/assets/531821f8-abcd-49ca-bca8-34e2e6d9138d" />

The render reuses the `rtl_safe_username` user helper to show the actual name, so it's safe in terms of deleted usernames.

---

In addition to making comment thread titles render pings, this PR also makes sure markdown is stripped out from auto-generated titles (when the user doesn't provide one of their own):

<img width="665" height="718" alt="2025-07-16_03-04" src="https://github.com/user-attachments/assets/a4feffb2-3f2f-4c95-b872-6d878c3c26bb" />

The `generate_thread_title` helper reuses our `strip_markdown` helper but additionally strips out leading quotes (open to moving the change into the `strip_markdown` helper, but it'll have to be carefully reviewed if so)
