### PR TITLE
don't allow self-deletion for an account that (still) uses 2fa

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -37,6 +37,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
     elsif @user.moderator?
       @user.errors.add(:base, I18n.t('users.errors.no_mod_self_delete'))
       render :delete
+    elsif @user.enabled_2fa
+      @user.errors.add(:base, I18n.t('users.errors.no_2fa_self_delete'))
+      render :delete
     elsif params[:username] != @user.username
       @user.errors.add(:base, I18n.t('users.errors.self_delete_wrong_username'))
       render :delete

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -66,7 +66,14 @@
   <p class="has-color-red has-font-size-caption">
     Moderators and admins cannot be self-deleted. Contact support if you wish to delete your account.
   </p>
-<% else %>
+<% elsif current_user.enabled_2fa %>
+  <%= link_to 'javascript:void(8)', class: 'button is-outlined is-danger', disabled: true do %>  
+    Delete my account &raquo;
+  <% end %>
+  <p class="has-color-red has-font-size-caption">
+    Your account uses two-factor authentication (2FA). In order to delete your account, you must first disable 2FA.
+  </p>
+  <% else %>
   <%= link_to delete_account_path, class: 'button is-outlined is-danger' do %>
     Delete my account &raquo;
   <% end %>

--- a/config/locales/strings/en.users.yml
+++ b/config/locales/strings/en.users.yml
@@ -5,5 +5,7 @@ en:
         Admin accounts cannot be self-deleted. Contact support.
       no_mod_self_delete: >
         Moderator accounts cannot be self-deleted. Contact support.
+      no_2fa_self_delete: >
+        Accounts using 2FA cannot be self-deleted. Disable 2FA first.
       self_delete_wrong_username: >
         The username you entered was incorrect.


### PR DESCRIPTION
Small followup to https://github.com/codidact/qpixel/pull/1668.  While testing something else I noticed that we should probably make it harder for a 2FA user to self-delete.  Rather than trying to check the second factor (complicated), I propose that we not allow self-deletion in this case.  If you use 2FA and want to delete your account, first disable 2FA (which will require a code) and then proceed.

We ought to do something similar for the SSO case, but I don't know how to set up an SSO environment to develop/test in.  I propose spinning that off as a separate issue for the future and making sure we document this gap in the release notes.
