### PR TITLE
Link to duplicate posts

### DIFF
--- a/app/assets/stylesheets/widgets.scss
+++ b/app/assets/stylesheets/widgets.scss
@@ -1,0 +1,14 @@
+.widget--body {
+  transition: all 0.2s ease;
+}
+
+.widget--body.hiding {
+  scale: 0;
+  height: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.widget--body.hidden {
+  display: none;
+}

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -23,7 +23,8 @@ class Post < ApplicationRecord
   has_many :flags, as: :post, dependent: :destroy
   has_many :children, class_name: 'Post', foreign_key: 'parent_id', dependent: :destroy
   has_many :suggested_edits, dependent: :destroy
-  has_many :reactions
+  has_many :reactions, dependent: :destroy
+  has_many :inbound_duplicates, class_name: 'Post', foreign_key: 'duplicate_post_id', dependent: :nullify
 
   counter_culture :parent, column_name: proc { |model| model.deleted? ? nil : 'answer_count' }
   counter_culture [:user, :community_user], column_name: proc { |model| model.deleted? ? nil : 'post_count' }
@@ -53,6 +54,7 @@ class Post < ApplicationRecord
                           includes(:user, :tags, :post_type, :category, :last_activity_by,
                                    user: :avatar_attachment)
                         }
+  scope :has_duplicates, -> { joins(:inbound_duplicates) } # uses INNER JOIN by default so no where required
 
   before_validation :update_tag_associations, if: -> { post_type&.has_tags }
   after_create :create_initial_revision

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -14,35 +14,64 @@
 
 
   <% unless @community.is_fake %>
-    <% if Rails.env.development? || @hot_questions.to_a.size > 0 || @pinned_links.to_a.size > 0 %>
-      <div class="widget has-margin-4 is-tertiary">
-        <% if Rails.env.development? || @pinned_links.to_a.size > 0 %>
-          <div class="widget--header">Featured</div>
-          <% @pinned_links.each do |pl| %>
-            <div class="widget--body">
-              <% pl_link = pl.post.nil? ? pl.link : generic_share_link(pl.post) %>
-              <% pl_label = pl.post.nil? ? pl.label : (pl.post.parent.nil? ? pl.post.title : pl.post.parent.title) %>
-              <%= link_to pl_link, class: 'h-fw-bold' do %>
-                <%= pl_label %>
-              <% end %>
-              <% unless pl.shown_before.nil? %>
-                <div>
-                  &mdash;
-                  <% if !pl.shown_after.nil? %>
-                    <% if pl.shown_after < DateTime.now %>
-                      ends in  <%= time_ago_in_words(pl.shown_before) %>
+    <%# Featured widget %>
+    <% if Rails.env.development? || @pinned_links.to_a.size > 0 %>
+      <% cache @pinned_links do %>
+        <div class="widget has-margin-4 is-teal">
+          <% if Rails.env.development? || @pinned_links.to_a.size > 0 %>
+            <div class="widget--header">Featured</div>
+            <% @pinned_links.each do |pl| %>
+              <div class="widget--body">
+                <% pl_link = pl.post.nil? ? pl.link : generic_share_link(pl.post) %>
+                <% pl_label = pl.post.nil? ? pl.label : (pl.post.parent.nil? ? pl.post.title : pl.post.parent.title) %>
+                <%= link_to pl_link, class: 'h-fw-bold' do %>
+                  <%= pl_label %>
+                <% end %>
+                <% unless pl.shown_before.nil? %>
+                  <div>
+                    &mdash;
+                    <% if !pl.shown_after.nil? %>
+                      <% if pl.shown_after < DateTime.now %>
+                        ends in  <%= time_ago_in_words(pl.shown_before) %>
+                      <% else %>
+                        starts in <%= time_ago_in_words(pl.shown_after) %>
+                      <% end %>
                     <% else %>
-                      starts in <%= time_ago_in_words(pl.shown_after) %>
+                      in <%= time_ago_in_words(pl.shown_before) %>
                     <% end %>
-                  <% else %>
-                    in <%= time_ago_in_words(pl.shown_before) %>
-                  <% end %>
-                </div>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
+    <% end %>
+
+    <%# Related Posts widget %>
+    <% if defined?(@post) && @post.inbound_duplicates.any? %>
+      <% cache [@post, @post.inbound_duplicates] do %>
+        <div class="widget has-margin-4 is-green">
+          <div class="widget--header">Related Posts</div>
+          <% @post.inbound_duplicates.each do |dp| %>
+            <div class="widget--body">
+              <% unless dp.category.nil? %>
+                <%= dp.category.name %>
+                &mdash;
+              <% end %>
+              <%= link_to generic_share_link(dp) do %>
+                <%= dp.title %>
               <% end %>
             </div>
           <% end %>
-        <% end %>
-        <% if Rails.env.development? || @hot_questions.to_a.size > 0 %>
+        </div>
+      <% end %>
+    <% end %>
+
+    <%# Hot Posts widget %>
+    <% if Rails.env.development? || @hot_questions.to_a.size > 0 %>
+      <% cache @hot_questions do %>
+        <div class="widget has-margin-4 is-tertiary">
           <div class="widget--header">Hot Posts</div>
           <% @hot_questions.each do |hq| %>
             <div class="widget--body">
@@ -55,8 +84,8 @@
               <% end %>
             </div>
           <% end %>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
     <% end %>
   <% end %>
 


### PR DESCRIPTION
Closes #1348.

Adds a related posts widget to the sidebar, between the now-split "featured" and "hot posts" widgets.

Also makes related and hot posts widgets collapsible, controlled by user preference.