### PR TITLE
Fix for the "0 available post types" case when clicking on the "Create Post" button

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -130,6 +130,8 @@ class CategoriesController < ApplicationController
     @post_types = @category.top_level_post_types
     if @post_types.one?
       redirect_to new_category_post_path(post_type: @post_types.first, category: @category)
+    elsif @post_types.empty? && current_user&.admin?
+      redirect_to edit_category_post_types_path(@category, no_return: '1')
     end
   end
 

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -127,7 +127,7 @@ class CategoriesController < ApplicationController
   end
 
   def post_types
-    @post_types = @category.post_types.where(is_top_level: true)
+    @post_types = @category.top_level_post_types
     if @post_types.one?
       redirect_to new_category_post_path(post_type: @post_types.first, category: @category)
     end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -22,6 +22,10 @@ class Category < ApplicationRecord
     trust_level <= 0
   end
 
+  def top_level_post_types
+    post_types.where(is_top_level: true)
+  end
+
   def new_posts_for?(user)
     key = "#{community_id}/#{user.id}/#{id}/last_visit"
     Rails.cache.fetch key, expires_in: 5.minutes do

--- a/app/views/categories/category_post_types.html.erb
+++ b/app/views/categories/category_post_types.html.erb
@@ -1,8 +1,17 @@
-<p class="has-font-size-caption">
-  <%= link_to edit_category_path(@category) do %>
-    &laquo; Back to category edit
-  <% end %>
-</p>
+<%#
+    View for managing allowed category post types
+
+    Parameters:
+      params[:no_return] : whether to suppress the return link
+%>
+
+<% unless params[:no_return] == '1' %>
+  <p class="has-font-size-caption">
+    <%= link_to edit_category_path(@category) do %>
+      &laquo; Back to category edit
+    <% end %>
+  </p>
+<% end %>
 <h1>Allowed post types for <%= @category.name %></h1>
 <p class="has-font-size-caption">
   Only post types listed here are allowed to be posted in this category. Not all will be displayed as available options

--- a/app/views/categories/post_types.html.erb
+++ b/app/views/categories/post_types.html.erb
@@ -1,6 +1,12 @@
-<h1>What kind of post?</h1>
+<% header_title = @post_types.any? ? 'What kind of post?' : 'No allowed post types'
+   header_subtitle = @post_types.any? \
+    ? 'This category has more than one type of post available. Pick a post type to get started.'
+    : 'This category does not have any post types available.' 
+%>
+
+<h1><%= header_title %></h1>
 <p class="has-font-size-larger has-color-tertiary-500">
-  This category has more than one type of post available. Pick a post type to get started.
+  <%= header_subtitle %>
 </p>
 
 <% @post_types.each do |pt| %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -282,9 +282,16 @@ $(() => {
             <% end %>
           <% end %>
           <div class="category-header--nav-separator"></div>
-          <%= link_to category_post_types_path(current_cat.id),
-                      class: 'category-header--nav-item is-button' do %>
-            <%= current_cat.button_text.present? ? current_cat.button_text : 'Create Post' %>
+          <% button_text = current_cat.button_text.present? ? current_cat.button_text : 'Create Post' %>
+          <% if current_cat&.top_level_post_types.any? %>
+            <%= link_to category_post_types_path(current_cat.id),
+                        class: "category-header--nav-item is-button" do %>
+              <%= button_text %>
+            <% end %>
+          <% else %>
+            <%= button_tag button_text, class: "button is-muted is-outlined",
+                                        disabled: true,
+                                        title: "The category doesn't have any allowed post types" %>
           <% end %>
         </div>
       </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -283,7 +283,7 @@ $(() => {
           <% end %>
           <div class="category-header--nav-separator"></div>
           <% button_text = current_cat.button_text.present? ? current_cat.button_text : 'Create Post' %>
-          <% if current_cat&.top_level_post_types.any? %>
+          <% if current_cat&.top_level_post_types.any? || admin? %>
             <%= link_to category_post_types_path(current_cat.id),
                         class: "category-header--nav-item is-button" do %>
               <%= button_text %>


### PR DESCRIPTION
DO NOT MERGE UNTIL #1513 IS IN - it's NOT targeted to `develop` at this moment

This PR addresses an issue with attempting to click on the "Create Post" button in categories without any allowed post types (usually happens with brand new categories). Currently, we incorrectly handle this case, redirecting the user to the page that asks the user to select a post type as the category has more than one (where in fact is has _none_):

<img width="760" height="485" alt="Screenshot from 2025-07-23 05-15-55" src="https://github.com/user-attachments/assets/e5070f1c-75de-4c88-b1d1-e97a90c87659" />

This PR disables the abovementioned button and adds a corresponding title text (not shown in the screenshot, a bit hard to capture) for users who cannot edit allowed category post types (anyone other than an admin ATTOW). Due to category headers having configurable colors and the styling being managed by Co-Design, I did my best to provide _some_ workable styling (without custom overrides), but couldn't do more without tearing my hair out - if anyone wants to tackle the rest, be my guest:

<img width="1155" height="101" alt="Screenshot from 2025-07-23 06-50-32" src="https://github.com/user-attachments/assets/0c8095c1-d0b4-400f-a921-cce72501db94" />

For the sake of comparison, this is how the enabled button looks like now:

<img width="1155" height="101" alt="Screenshot from 2025-07-23 06-50-44" src="https://github.com/user-attachments/assets/b6b69772-a28b-465d-b60c-300196d9e71b" />

For users who _can_ edit available category post types, we now redirect directly to the page where they can manage them:

<img width="1191" height="516" alt="Screenshot from 2025-07-23 07-02-58" src="https://github.com/user-attachments/assets/03a42c44-2273-4901-b338-dcf92892c610" />

The "0 types" case is also fixed just in case (even through it should now not be possible to land there by accident):

<img width="1191" height="516" alt="Screenshot from 2025-07-23 07-02-41" src="https://github.com/user-attachments/assets/a81349f2-d247-43ab-a8e5-b301cd6e38cd" />

---

Here's how the flow will look like:

https://github.com/user-attachments/assets/3a70352f-6081-49b3-86fd-90373954f162
