### PR TITLE
Minor CI cleanup

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   RAILS_ENV: test
+  DEPBOT_NAME: dependabot[bot]
 
 jobs:
   rubocop:
@@ -106,7 +107,7 @@ jobs:
           path: tmp/screenshots
           if-no-files-found: ignore
       - uses: codecov/codecov-action@v5
-        if: ${{ matrix.ruby_version == 3.2 && matrix.test_type == 'test' }}
+        if: ${{ matrix.ruby_version == 3.2 && matrix.test_type == 'test' && github.actor != DEPBOT_NAME }}
         with:
           directory: coverage
           fail_ci_if_error: true
@@ -116,7 +117,7 @@ jobs:
   deploy:
     name: Dev server deployment
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' && github.actor != DEPBOT_NAME }}
     needs:
       - rubocop
       - typescript

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,25 @@ on:
     - cron: '0 21 * * *'
 
 jobs:
+  # TEMPORARY RESTORE - REMOVE WITH CONFIG
+  CodeQL-Build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+    - run: git checkout HEAD^2
+      if: ${{ github.event_name == 'pull_request' }}
+          - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: javascript
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
+
   analyze:
     name: Analyze JS and Ruby
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is a minor PR that:

- excludes Dependabot from attempting to upload coverage results to CodeCov;
- temporarily restores the `CodeQL-Build` job in an attempt to make it possible to finally remove [the configuration](https://github.com/codidact/qpixel/security/code-scanning/tools/CodeQL/status/configurations/actions-FZTWS5DIOVRC653POJVWM3DPO5ZS6Y3PMRSXC3BNMFXGC3DZONUXGLTZNVWA/2e60fa7fd6b83d235494082a129c752431eb63fd56f271ae86af8c4afe52d2f8)