### PR TITLE
Use correct host when rendering comment pings

### DIFF
--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -47,7 +47,7 @@ module CommentsHelper
   # @param content [String] content to convert ping-strings for
   # @param pingable [Array<Integer>, nil] A list of user IDs. Any user ID not present will be displayed as 'unpingable'.
   # @return [ActiveSupport::SafeBuffer]
-  def render_pings(content, pingable: nil)
+  def render_pings(content, pingable: nil, host: nil)
     users = pinged_users(content)
 
     content.gsub(/@#(\d+)/) do |ping|
@@ -57,8 +57,10 @@ module CommentsHelper
       else
         was_pung = pingable.present? && pingable.include?(user.id)
         classes = "ping #{'me' if user.same_as?(current_user)} #{'unpingable' unless was_pung}"
-        user_link user, class: classes, dir: 'ltr',
-                  title: was_pung ? '' : I18n.t('comments.warnings.unrelated_user_not_pinged')
+        user_link(user, { host: host },
+                  class: classes,
+                  dir: 'ltr',
+                  title: was_pung ? '' : I18n.t('comments.warnings.unrelated_user_not_pinged'))
       end
     end.html_safe
   end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -77,7 +77,8 @@
     </div>
   </div>
   <div class="comment--body" dir="ltr">
-    <%= render_pings(raw(sanitize(render_comment_helpers(render_markdown(comment.content)), scrubber: CommentScrubber.new)),
-                     pingable: pingable) %>
+    <% rendered = render_comment_helpers(render_markdown(comment.content)) %>
+    <% sanitized = sanitize(rendered, scrubber: CommentScrubber.new) %>
+    <%= render_pings(raw(sanitized), pingable: pingable, host: comment.community.host) %>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,50 +1,51 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
-<head>
-  <%= render 'layouts/head' %>
-</head>
-<body class="<%= Rails.env.development? ? 'development' : '' %>"
+  <head>
+    <%= render 'layouts/head' %>
+  </head>
+  <body class="<%= Rails.env.development? ? 'development' : '' %>"
       data-user-id="<%= user_signed_in? ? current_user.id : 'none' %>"
       data-mathjax="<%= SiteSetting['MathJaxEnabled'] %>">
-  <%= render 'layouts/header' %>
+    <%= render 'layouts/header' %>
 
-  <main class="container">
-    <div class="grid">
-      <div class="grid--cell is-8-lg is-12">
-        <div class="has-padding-4">
-          <% {notice: :info, alert: :danger, danger: :danger, success: :success, info: :info, warning: :warning}.each do |mt, cc| %>
-            <% if flash[mt].present? %>
-              <div class="notice is-<%= cc.to_s %>">
-                <%= flash[mt] %>
-              </div>
+    <main class="container">
+      <div class="grid">
+        <div class="grid--cell is-8-lg is-12">
+          <div class="has-padding-4">
+            <% {notice: :info, alert: :danger, danger: :danger, success: :success, info: :info, warning: :warning}.each do |mt, cc| %>
+              <% if flash[mt].present? %>
+                <div class="notice is-<%= cc.to_s %>">
+                  <%= flash[mt] %>
+                </div>
+              <% end %>
             <% end %>
-          <% end %>
 
-
-          <% if @first_visit_notice %>
-            <% notice = SiteSetting['FirstVisitGuidance'] %>
-            <% if notice.present? %>
-              <div class="notice js-first-visit-notice" id="fvn">
-                <button type="button" class="button is-close-button" data-dismiss="#fvn" aria-label="Close" id="fvn-dismiss">
-                  <span aria-hidden="true">&times;</span>
-                </button>
-                <%= raw(sanitize(notice, scrubber: scrubber)) %>
-              </div>
+            <% if @first_visit_notice %>
+              <% notice = SiteSetting['FirstVisitGuidance'] %>
+              <% if notice.present? %>
+                <div class="notice js-first-visit-notice" id="fvn">
+                  <button type="button" class="button is-close-button" data-dismiss="#fvn" aria-label="Close" id="fvn-dismiss">
+                    <span aria-hidden="true">&times;</span>
+                  </button>
+                  <%= raw(sanitize(notice, scrubber: scrubber)) %>
+                </div>
+              <% end %>
             <% end %>
-          <% end %>
 
-          <%= yield %>
+            <%= yield %>
+          </div>
         </div>
+
+        <%= render 'layouts/sidebar' %>
       </div>
+    </main>
 
-      <%= render 'layouts/sidebar' %>
-    </div>
-  </main>
+    <%= render 'layouts/footer' %>
 
-  <%= render 'layouts/footer' %>
+    <%= render 'layouts/matomo' %>
 
-  <%= render 'layouts/matomo' %>
-
-  <script src="https://7zb04r9ckbwg.statuspage.io/embed/script.js"></script>
-</body>
+    <% if Rails.env.production? %>
+      <script src="https://7zb04r9ckbwg.statuspage.io/embed/script.js"></script>
+    <% end %>
+  </body>
 </html>

--- a/test/helpers/comments_helper_test.rb
+++ b/test/helpers/comments_helper_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class CommentsHelperTest < ActionView::TestCase
+  include ApplicationHelper
+  include UsersHelper
   include Devise::Test::ControllerHelpers
 
   test '[help center] and [help] substitution' do
@@ -107,5 +109,21 @@ class CommentsHelperTest < ActionView::TestCase
       assert_equal false, rate_limited
       assert_nil limit_message
     end
+  end
+
+  test 'render_pings should correctly render comment pings' do
+    std = users(:standard_user)
+    mod = users(:moderator)
+
+    sign_in std
+
+    host = RequestContext.community.host
+
+    rendered = render_pings("this is not correct, @##{std.id}. @##{mod.id}'s answer is better. @#123, thoughs?",
+                            host: host)
+
+    assert Regexp.new("http:\\/\\/#{Regexp.escape(host)}\\/users\\/#{std.id}").match?(rendered)
+    assert Regexp.new("http:\\/\\/#{Regexp.escape(host)}\\/users\\/#{mod.id}").match?(rendered)
+    assert(/@#123/.match?(rendered))
   end
 end


### PR DESCRIPTION
closes #1708

Where previously for any scheduled email (or anywhere where `RequestContext` is not populated or is reset for that matter) we had pings use the default host (usually `meta.codidact.com`), which is incorrect, now the correct host is used:

<img width="1380" height="499" alt="2025-07-28_06-01" src="https://github.com/user-attachments/assets/046b0437-be3e-4059-9bc1-7c12199d5c29" />


Also (unrelated, unfortunately, but setting up a new PR _just_ for that is too much hassle) stops loading our production status page in dev & test environments (see lines 47-50, the rest has been properly autoformatted [apart from line length])