### PR TITLE
NamespacedEnvCache fix + pinned links caching fix

### DIFF
--- a/app/models/pinned_link.rb
+++ b/app/models/pinned_link.rb
@@ -1,4 +1,10 @@
 class PinnedLink < ApplicationRecord
   include MaybeCommunityRelated
   belongs_to :post
+
+  # Is the link time-constrained?
+  # @return [Boolean] check result
+  def timed?
+    shown_before.present? || shown_after.present?
+  end
 end

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -12,11 +12,11 @@
     <% end %>
   <% end %>
 
-
   <% unless @community.is_fake %>
     <%# Featured widget %>
     <% if Rails.env.development? || @pinned_links.to_a.size > 0 %>
-      <% cache @pinned_links do %>
+      <% has_timed = @pinned_links.any?(&:timed?) %>
+      <% cache_unless has_timed, @pinned_links do %>
         <div class="widget has-margin-4 is-teal">
           <% if Rails.env.development? || @pinned_links.to_a.size > 0 %>
             <div class="widget--header">Featured</div>
@@ -122,8 +122,8 @@
           <% if can_see_deleted_posts? && !at_least_moderator? %>
             <li><a href="/mod/deleted">Recent Deletions</a></li>
           <% end %>
-	        <%# this calls into application_helper, not the user model! %>
-	        <% if at_least_moderator? %>
+          <%# this calls into application_helper, not the user model! %>
+          <% if at_least_moderator? %>
             <li><%= link_to 'Moderator Tools', moderator_path %></li>
           <% end %>
           <% if admin? %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,10 +14,12 @@ Rails.application.configure do
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  config.action_controller.perform_caching = ActiveRecord::Type::Boolean.new.cast(ENV['PERFORM_CACHING']) || false
 
   # Enable server timing
   config.server_timing = true
+
+  config.log_level = ENV['LOG_LEVEL'] || :info
 
   # Set the cache store to the redis that was configured in the database.yml
   processed = ERB.new(File.read(Rails.root.join('config', 'database.yml'))).result(binding)

--- a/lib/namespaced_env_cache.rb
+++ b/lib/namespaced_env_cache.rb
@@ -82,6 +82,7 @@ module QPixel
     private
 
     def construct_ns_key(key, include_community: true)
+      key = expanded_key(key)
       c_id = RequestContext.community_id if include_community
       "#{Rails.env}://#{[c_id, key].compact.join('/')}"
     end


### PR DESCRIPTION
As per investigation [in chat](https://discord.com/channels/634104110131445811/668890340199235613/1399396382908878929)

This PR fixes a long-standing bug with NamespacedEnvCache's `construct_ns_key` not accounting for the fact that keys can also be instances of `Array` or `Hash` (`ActiveSupport::Cache::Store` normalizes such keys under the hood in `expanded_key`).

Fixing the abovementioned issue exposed the bug in our widget for pinned (featured) links: since it's now `cache`d, `time_ago_in_words` is cached alongside the content, resulting in incorrect relative times for all timed pinned links (that is those that have `shown_before` or `shown_after` set), which this PR also fixes.

Finally, it makes `config.action_controller.perform_caching` and `config.log_level` for the development mode overridable via environment variables (`PERFORM_CACHING` and `LOG_LEVEL` respectively) - caching is sometimes needed (and due to the `perform_caching` being explicitly set to `false`, launching the server with the `-C` flag has no effect), and even the `:info` level can be too much. No changes were made to the defaults