### PR TITLE
Minor fix for the users page search button alignment

### DIFF
--- a/app/assets/stylesheets/audit_logs.scss
+++ b/app/assets/stylesheets/audit_logs.scss
@@ -1,10 +1,12 @@
 @import 'variables';
 
 .audit-log-filters {
-  .select2-container {
+  .form-group-horizontal .actions, .select2-container {
     height: 37px;
     margin: 4px 0px;
+  }
 
+  .select2-container {
     .selection {
       .select2-selection {
         border-color: $muted-graphic;
@@ -15,6 +17,15 @@
       .select2-selection__arrow {
         top: 50%;
         translate: 0 -50%;
+      }
+    }
+  }
+
+  .form-group-horizontal {
+    .actions {
+      .button {
+        height: 100%;
+        margin: 0;
       }
     }
   }

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -20,10 +20,10 @@ select.form-element {
   }
 
   & > .form-group {
-    margin: 0 0 1em 0;
+    margin: 0.5em 0;
 
     @media screen and (min-width: $screen-md) {
-      margin: 0 1em 0 0;
+      margin: 0 0.5em;
       flex: 1;
     }
   }
@@ -31,12 +31,6 @@ select.form-element {
   & > .actions {
     display: flex;
     align-items: flex-end;
-    margin-bottom: 4px; // to match bottom margin on .form-element
-
-    button, input[type="submit"] {
-      margin: unset;
-      padding: 9.5px 12px; // because for some reason it has to be 9.5px to match .form-elements' height
-    }
   }
 }
 


### PR DESCRIPTION
Fixes the following misalignment accidentally caused by an override specific to audit log filtering:

<img width="800" height="170" alt="2025-07-31_17-49" src="https://github.com/user-attachments/assets/066e9000-efba-4fbb-9658-a14f96b360f7" />

With the fix applied (exactly how it currently looks in prod):

<img width="781" height="160" alt="2025-07-31_17-56" src="https://github.com/user-attachments/assets/a87dbc5f-f9b6-45c0-bfea-df7c58de6af1" />

The audit log filter button override is still preserved:

<img width="1151" height="140" alt="2025-07-31_17-57" src="https://github.com/user-attachments/assets/5314261e-b057-4f3a-9c83-1c89160f1807" />


