### PR TITLE
Fix lack of title search for posts

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,12 +2,12 @@ class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
   def self.fuzzy_search(term, **cols)
-    sanitized = sanitize_for_search term, **cols
+    sanitized = sanitize_for_search(term, **cols)
     select(Arel.sql("`#{table_name}`.*, #{sanitized} AS search_score"))
   end
 
   def self.match_search(term, **cols)
-    sanitized = sanitize_for_search term, **cols
+    sanitized = sanitize_for_search(term, **cols)
     select(Arel.sql("`#{table_name}`.*, #{sanitized} AS search_score")).where(sanitized)
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -75,7 +75,7 @@ class Post < ApplicationRecord
   # @param term [String] the search term
   # @return [ActiveRecord::Relation<Post>]
   def self.search(term)
-    match_search term, posts: :body_markdown
+    match_search term, posts: [:body_markdown, :title]
   end
 
   def self.by_slug(slug, user)

--- a/db/migrate/20250801124236_add_post_titles_to_posts_fts.rb
+++ b/db/migrate/20250801124236_add_post_titles_to_posts_fts.rb
@@ -1,0 +1,7 @@
+# initial post FTS did not include titles
+class AddPostTitlesToPostsFts < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :posts, :body_markdown
+    add_index :posts, [:body_markdown, :title], type: :fulltext
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_28_030361) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_01_124236) do
   create_table "abilities", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "community_id"
     t.string "name"
@@ -505,7 +505,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_28_030361) do
     t.datetime "locked_at", precision: nil
     t.datetime "locked_until", precision: nil
     t.index ["att_source"], name: "index_posts_on_att_source"
-    t.index ["body_markdown"], name: "index_posts_on_body_markdown", type: :fulltext
+    t.index ["body_markdown", "title"], name: "index_posts_on_body_markdown_and_title", type: :fulltext
     t.index ["category_id"], name: "index_posts_on_category_id"
     t.index ["close_reason_id"], name: "index_posts_on_close_reason_id"
     t.index ["community_id"], name: "index_posts_on_community_id"


### PR DESCRIPTION
closes #387

And no, we can't just add a separate index for the `title` column, the way we use search we need the composite index