### PR TITLE
Enable username autocomplete in thread titles

### DIFF
--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -236,7 +236,7 @@ $(() => {
    * @type {Record<`${number}-${number}`, Record<string, number>>}
    */
   const pingable = {};
-  $(document).on('keyup', '.js-comment-field, .js-thread-title', pingable_popup);
+  $(document).on('keyup', '.js-comment-field, .js-thread-title-field', pingable_popup);
 
   /**
    * @type {QPixelPingablePopupCallback}

--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -236,7 +236,7 @@ $(() => {
    * @type {Record<`${number}-${number}`, Record<string, number>>}
    */
   const pingable = {};
-  $(document).on('keyup', '.js-comment-field', pingable_popup);
+  $(document).on('keyup', '.js-comment-field, .js-thread-title', pingable_popup);
 
   /**
    * @type {QPixelPingablePopupCallback}

--- a/app/views/comments/_new_thread_modal.html.erb
+++ b/app/views/comments/_new_thread_modal.html.erb
@@ -39,7 +39,11 @@
         You can give your comment thread a title. If you leave this blank, the beginning of the initial comment will
         be shown.
       </span>
-      <%= text_field_tag :title, '', class: 'form-element', data: { character_count: ".js-character-count-thread-title" } %>
+      <%= text_field_tag :title, '',
+                         class: 'form-element js-thread-title',
+                         data: { post: post.id,
+                                 thread: '-1',
+                                 character_count: ".js-character-count-thread-title" } %>
       <%= render 'shared/char_count', type: 'thread-title' %>
 
       <%= submit_tag 'Create thread', class: 'button is-filled', id: "create_thread_button_#{post.id}", disabled: true %>

--- a/app/views/comments/_new_thread_modal.html.erb
+++ b/app/views/comments/_new_thread_modal.html.erb
@@ -40,7 +40,7 @@
         be shown.
       </span>
       <%= text_field_tag :title, '',
-                         class: 'form-element js-thread-title',
+                         class: 'form-element js-thread-title-field',
                          data: { post: post.id,
                                  thread: '-1',
                                  character_count: ".js-character-count-thread-title" } %>

--- a/app/views/comments/_rename_thread_modal.html.erb
+++ b/app/views/comments/_rename_thread_modal.html.erb
@@ -16,7 +16,10 @@
     </div>
     <div class="modal--body">
       <%= label_tag :title, 'Title', class: 'form-element' %>
-      <%= text_field_tag :title, thread.title, class: 'form-element' %>
+      <%= text_field_tag :title,
+                         thread.title,
+                         class: 'form-element js-thread-title-field',
+                         data: { post: thread.post.id, thread: thread.id } %>
     </div>
     <div class="modal--footer">
       <%= submit_tag 'Update thread', class: 'button is-muted is-filled' %>


### PR DESCRIPTION
Noticed when making the update post: even though we now properly render pings in thread titles, we don't offer any autocomplete - this PR addresses this shortcoming:

https://github.com/user-attachments/assets/c5e58983-bbb9-4e4d-b745-0b73affcec07

Autocomplete will also become available when renaming threads:

<img width="642" height="318" alt="image" src="https://github.com/user-attachments/assets/c94d9d39-39ec-481d-b185-2631eb9f23b8" />


