### PR TITLE
Start comment @-mention autocomplete as soon as at least 1 username char is entered

### DIFF
--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -267,10 +267,12 @@ $(() => {
       $tgt.focus();
     };
 
-    // If the word the caret is currently in starts with an @, and has at least 3 characters after that, assume it's
-    // an attempt to ping another user with a username, and kick off suggestions -- unless it starts with @#, in which
-    // case it's likely an already-selected ping.
-    if (currentWord.startsWith('@') && !currentWord.startsWith('@#') && currentWord.length >= 4) {
+    // at least 1 character has to be present to trigger autocomplete (2 is because pings start with @)
+    const hasReachedAutocompleteThreshold = currentWord.length >= 2;
+
+    // If the word the caret is currently in starts with an @, and is reached the autocomplete threshold, assume it's
+    // a ping attempt and kick off suggestions (unless it starts with @#, meaning it's likely an already-selected ping)
+    if (currentWord.startsWith('@') && !currentWord.startsWith('@#') && hasReachedAutocompleteThreshold) {
       const threadId = $tgt.data('thread');
       const postId = $tgt.data('post');
 


### PR DESCRIPTION
closes #1673 

With this change, we'll now start offering @-mention autocomplete as soon as at least one username character is inputted by the user after "@".

https://github.com/user-attachments/assets/6114d22d-734f-4229-9f42-3acebeb2145f
