### PR TITLE
Fixes for featured (pinned) links

### DIFF
--- a/app/controllers/pinned_links_controller.rb
+++ b/app/controllers/pinned_links_controller.rb
@@ -27,9 +27,9 @@ class PinnedLinksController < ApplicationController
   end
 
   def create
-    @link = PinnedLink.create(pinned_link_params)
+    @link = PinnedLink.new(pinned_link_params)
 
-    if @link.valid?
+    if @link.save
       attr = @link.attributes_print
 
       AuditLog.moderator_audit(event_type: 'pinned_link_create',

--- a/app/controllers/pinned_links_controller.rb
+++ b/app/controllers/pinned_links_controller.rb
@@ -27,14 +27,22 @@ class PinnedLinksController < ApplicationController
   end
 
   def create
-    @link = PinnedLink.create pinned_link_params
+    @link = PinnedLink.create(pinned_link_params)
 
-    attr = @link.attributes_print
-    AuditLog.moderator_audit(event_type: 'pinned_link_create', related: @link, user: current_user,
-                             comment: "<<PinnedLink #{attr}>>")
+    if @link.valid?
+      attr = @link.attributes_print
 
-    flash[:success] = 'Your pinned link has been created. Due to caching, it may take some time until it is shown.'
-    redirect_to pinned_links_path
+      AuditLog.moderator_audit(event_type: 'pinned_link_create',
+                               related: @link,
+                               user: current_user,
+                               comment: "<<PinnedLink #{attr}>>")
+
+      flash[:success] =
+        'Your pinned link has been created. Due to caching, it may take some time until it is shown.'
+      redirect_to pinned_links_path
+    else
+      render 'pinned_links/new'
+    end
   end
 
   def edit; end

--- a/app/controllers/pinned_links_controller.rb
+++ b/app/controllers/pinned_links_controller.rb
@@ -49,13 +49,20 @@ class PinnedLinksController < ApplicationController
 
   def update
     before = @link.attributes_print
-    @link.update pinned_link_params
-    after = @link.attributes_print
-    AuditLog.moderator_audit(event_type: 'pinned_link_update', related: @link, user: current_user,
-                             comment: "from <<PinnedLink #{before}>>\nto <<PinnedLink #{after}>>")
 
-    flash[:success] = 'The pinned link has been updated. Due to caching, it may take some time until it is shown.'
-    redirect_to pinned_links_path
+    if @link.update(pinned_link_params)
+      after = @link.attributes_print
+
+      AuditLog.moderator_audit(event_type: 'pinned_link_update',
+                               related: @link,
+                               user: current_user,
+                               comment: "from <<PinnedLink #{before}>>\nto <<PinnedLink #{after}>>")
+
+      flash[:success] = 'The pinned link has been updated. Due to caching, it may take some time until it is shown.'
+      redirect_to pinned_links_path
+    else
+      render 'pinned_links/edit', status: :bad_request
+    end
   end
 
   private

--- a/app/controllers/pinned_links_controller.rb
+++ b/app/controllers/pinned_links_controller.rb
@@ -41,7 +41,7 @@ class PinnedLinksController < ApplicationController
         'Your pinned link has been created. Due to caching, it may take some time until it is shown.'
       redirect_to pinned_links_path
     else
-      render 'pinned_links/new'
+      render 'pinned_links/new', status: :bad_request
     end
   end
 

--- a/app/models/pinned_link.rb
+++ b/app/models/pinned_link.rb
@@ -2,9 +2,17 @@ class PinnedLink < ApplicationRecord
   include MaybeCommunityRelated
   belongs_to :post, optional: true
 
+  validate :check_post_or_url
+
   # Is the link time-constrained?
   # @return [Boolean] check result
   def timed?
     shown_before.present? || shown_after.present?
+  end
+
+  def check_post_or_url
+    unless post_id.present? || link.present?
+      errors.add(:base, 'either a post or a URL must be set')
+    end
   end
 end

--- a/app/models/pinned_link.rb
+++ b/app/models/pinned_link.rb
@@ -1,6 +1,6 @@
 class PinnedLink < ApplicationRecord
   include MaybeCommunityRelated
-  belongs_to :post
+  belongs_to :post, optional: true
 
   # Is the link time-constrained?
   # @return [Boolean] check result

--- a/test/controllers/pinned_links_controller_test.rb
+++ b/test/controllers/pinned_links_controller_test.rb
@@ -61,6 +61,13 @@ class PinnedLinksControllerTest < ActionController::TestCase
     assert_equal 'updated label', assigns(:link).label
   end
 
+  test 'update should correctly handle invlid pinned links' do
+    sign_in users(:moderator)
+    try_update_pinned_link(pinned_links(:active_with_label), link: nil)
+    assert_response(:bad_request)
+    assert assigns(:link)&.errors&.any?
+  end
+
   private
 
   def try_create_pinned_link(**opts)

--- a/test/controllers/pinned_links_controller_test.rb
+++ b/test/controllers/pinned_links_controller_test.rb
@@ -3,31 +3,79 @@ require 'test_helper'
 class PinnedLinksControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
-  test 'edit should require moderator' do
-    sign_in users(:standard_user)
-    get :edit, params: { id: pinned_links(:active_with_label).id }
-    assert_response(:not_found)
+  test 'only mods or higher should be able to create pinned links' do
+    post = posts(:question_one)
+
+    users.each do |user|
+      sign_in user
+      try_create_pinned_link(post: post)
+      assert_response(user.at_least_moderator? ? :found : :not_found)
+    end
   end
 
-  test 'edit should work for moderators' do
+  test 'only mods or higher should be able to edit pinned links' do
+    link = pinned_links(:active_with_label)
+
+    users.each do |user|
+      sign_in user
+      try_edit_pinned_link(link)
+      assert_response(user.at_least_moderator? ? :success : :not_found)
+    end
+  end
+
+  test 'only mods or higher should be able to update pinned links' do
+    link = pinned_links(:active_with_label)
+
+    users.each do |user|
+      sign_in user
+      try_update_pinned_link(link, label: 'updated label')
+      assert_response(user.at_least_moderator? ? :found : :not_found)
+    end
+  end
+
+  test 'create should correctly create pinned links' do
     sign_in users(:moderator)
-    get :edit, params: { id: pinned_links(:active_with_label).id }
-    assert_response(:success)
+
+    try_create_pinned_link(post: posts(:question_one))
+
+    assert_response(:found)
+    assert_redirected_to pinned_links_path
     assert_not_nil assigns(:link)
   end
 
-  test 'update should require moderator' do
-    sign_in users(:standard_user)
-    post :update, params: { id: pinned_links(:active_with_label).id, pinned_link: { label: 'updated label' } }
-    assert_response(:not_found)
-  end
-
-  test 'update should work for moderators' do
+  test 'update should correctly update pinned links' do
     sign_in users(:moderator)
-    post :update, params: { id: pinned_links(:active_with_label).id, pinned_link: { label: 'updated label' } }
+
+    try_update_pinned_link(pinned_links(:active_with_label), label: 'updated label')
+
     assert_response(:found)
     assert_redirected_to pinned_links_path
     assert_not_nil assigns(:link)
     assert_equal 'updated label', assigns(:link).label
+  end
+
+  private
+
+  def try_create_pinned_link(**opts)
+    community_id = opts.delete(:community)&.id
+    post_id = opts.delete(:post)&.id
+
+    post :create, params: {
+      pinned_link: {
+        community_id: community_id,
+        post_id: post_id
+      }.merge(opts)
+    }
+  end
+
+  def try_edit_pinned_link(link)
+    get :edit, params: { id: link.id }
+  end
+
+  def try_update_pinned_link(link, **opts)
+    post :update, params: {
+      id: link.id,
+      pinned_link: opts
+    }
   end
 end

--- a/test/controllers/pinned_links_controller_test.rb
+++ b/test/controllers/pinned_links_controller_test.rb
@@ -43,6 +43,13 @@ class PinnedLinksControllerTest < ActionController::TestCase
     assert_not_nil assigns(:link)
   end
 
+  test 'create should correctly handle invalid pinned links' do
+    sign_in users(:moderator)
+    try_create_pinned_link
+    assert_response(:bad_request)
+    assert assigns(:link)&.errors&.any?
+  end
+
   test 'update should correctly update pinned links' do
     sign_in users(:moderator)
 


### PR DESCRIPTION
closes #1726

This PR fixes two tightly-coupled bugs that we have with pinned links:

- it's now possible to create pinned links without post id (as expected);
- creation of pinned links no longer silently fails for invalid links;
- updating pinned links no longer silently fails when trying to save invalid updates;
- we now validate that either a post or a URL is set;
---

This is how attempting to create an inavlid pinned link looks like now:

<img width="796" height="211" alt="Screenshot from 2025-08-02 20-16-42" src="https://github.com/user-attachments/assets/b4d3c01c-4f42-401f-89f7-e02a9f8f9ae9" />
