### PR TITLE
Reduce email chunks

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -65,7 +65,7 @@ class AdminController < ApplicationController
 
     Thread.new do
       emails = User.where.not(confirmed_at: nil).where('email NOT LIKE ?', '%localhost').select(:email).map(&:email)
-      emails.each_slice(50) do |slice|
+      emails.each_slice(49) do |slice|
         AdminMailer.with(body_markdown: params[:body_markdown],
                          subject: params[:subject],
                          emails: slice, community: community)


### PR DESCRIPTION
The AWS limit of 50 recipients was triggering because we were sending TO one address, BCC 50 others - 51 recipients.

Reduced chunk size to 49, which should solve the problem.

Closes #1724.