### PR TITLE
Do not clear cache key network/post_types/rep_changes as it's not used

### DIFF
--- a/app/controllers/post_types_controller.rb
+++ b/app/controllers/post_types_controller.rb
@@ -21,7 +21,7 @@ class PostTypesController < ApplicationController
   end
 
   def create
-    @type = PostType.new post_type_params
+    @type = PostType.new(post_type_params)
     if @type.save
       clear_cache!
       redirect_to post_types_path
@@ -55,8 +55,6 @@ class PostTypesController < ApplicationController
   end
 
   def clear_cache!
-    # FIXME: this is likely not clearing cache for rep changes
-    Rails.cache.delete 'network/post_types/rep_changes'
     PostType.clear_ids_cache
     current_community = RequestContext.community
     Community.all.each do |c|

--- a/test/controllers/post_types_controller_test.rb
+++ b/test/controllers/post_types_controller_test.rb
@@ -89,12 +89,19 @@ class PostTypesControllerTest < ActionController::TestCase
 
   test 'can update post type' do
     sign_in users(:global_admin)
-    data = { name: 'Test Type', description: 'words', icon_name: 'heart',
-      has_answers: true, has_license: true, has_category: true,
-      answer_type_id: Answer.post_type_id, has_reactions: false,
-      has_only_specific_reactions: true }
-    patch :update, params: { post_type: data,
-                             id: post_types(:question).id }
+
+    data = { name: 'Test Type',
+             description: 'words',
+             icon_name: 'heart',
+             has_answers: true,
+             has_license: true,
+             has_category: true,
+             answer_type_id: Answer.post_type_id,
+             has_reactions: false,
+             has_only_specific_reactions: true }
+
+    try_update_post_type(post_types(:question), **data)
+
     assert_response(:found)
     assert_redirected_to post_types_path
 
@@ -106,17 +113,27 @@ class PostTypesControllerTest < ActionController::TestCase
   end
 
   test 'update requires auth' do
-    patch :update, params: { post_type: { name: 'Test Type', description: 'words', icon_name: 'heart',
-                                          has_answers: 'true', has_license: 'true', has_category: 'true' },
-                             id: post_types(:question).id }
+    try_update_post_type(post_types(:question))
     assert_redirected_to_sign_in
   end
 
   test 'update requires global admin' do
     sign_in users(:admin)
-    patch :update, params: { post_type: { name: 'Test Type', description: 'words', icon_name: 'heart',
-                                          has_answers: 'true', has_license: 'true', has_category: 'true' },
-                             id: post_types(:question).id }
+    try_update_post_type(post_types(:question))
     assert_response(:not_found)
+  end
+
+  private
+
+  # @param post_type [PostType] post type to update
+  # @param opts
+  def try_update_post_type(post_type, **opts)
+    patch :update, params: { post_type: { name: 'Test Type',
+                                          description: 'words',
+                                          icon_name: 'heart',
+                                          has_answers: 'true',
+                                          has_license: 'true',
+                                          has_category: 'true' }.merge(opts),
+                             id: post_type.id }
   end
 end


### PR DESCRIPTION
closes #1572

After further investigation, I can confirm that the `network/post_types/rep_changes` is not used at all, so there's no need to clear it. The key is a leftover from migration to CategoryPostType from 4 years ago: 9290ac03916c01790e2cb9704b2947d7e3d315b8