### PR TITLE
0valt/1732/close reasons

### DIFF
--- a/app/controllers/close_reasons_controller.rb
+++ b/app/controllers/close_reasons_controller.rb
@@ -30,7 +30,7 @@ class CloseReasonsController < ApplicationController
         redirect_to close_reasons_path
       end
     else
-      render :edit
+      render :edit, status: :bad_request
     end
   end
 
@@ -58,7 +58,7 @@ class CloseReasonsController < ApplicationController
         redirect_to close_reasons_path
       end
     else
-      render :new
+      render :new, status: :bad_request
     end
   end
 

--- a/app/controllers/close_reasons_controller.rb
+++ b/app/controllers/close_reasons_controller.rb
@@ -15,15 +15,21 @@ class CloseReasonsController < ApplicationController
 
   def update
     before = @close_reason.attributes.map { |k, v| "#{k}: #{v}" }.join(' ')
-    @close_reason.update close_reason_params
-    after = @close_reason.attributes.map { |k, v| "#{k}: #{v}" }.join(' ')
-    AuditLog.moderator_audit(event_type: 'close_reason_update', related: @close_reason, user: current_user,
-                             comment: "from <<CloseReason #{before}>>\nto <<CloseReason #{after}>>")
+    if @close_reason.update(close_reason_params)
+      after = @close_reason.attributes.map { |k, v| "#{k}: #{v}" }.join(' ')
 
-    if @close_reason.community.nil?
-      redirect_to close_reasons_path(global: 1)
+      AuditLog.moderator_audit(event_type: 'close_reason_update',
+                               related: @close_reason,
+                               user: current_user,
+                               comment: "from <<CloseReason #{before}>>\nto <<CloseReason #{after}>>")
+
+      if @close_reason.community.nil?
+        redirect_to close_reasons_path(global: 1)
+      else
+        redirect_to close_reasons_path
+      end
     else
-      redirect_to close_reasons_path
+      render :edit
     end
   end
 

--- a/app/controllers/close_reasons_controller.rb
+++ b/app/controllers/close_reasons_controller.rb
@@ -39,14 +39,12 @@ class CloseReasonsController < ApplicationController
   end
 
   def create
-    @close_reason = CloseReason.new(name: params[:close_reason][:name],
-                                    description: params[:close_reason][:description],
-                                    requires_other_post: params[:close_reason][:requires_other_post],
-                                    active: params[:close_reason][:active],
-                                    community: params[:global] == '1' ? nil : @community)
+    community_params = { community: params[:global] == '1' ? nil : @community }
+    @close_reason = CloseReason.new(close_reason_params.merge(community_params))
 
     if @close_reason.save
       attr = @close_reason.attributes_print
+
       AuditLog.moderator_audit(event_type: 'close_reason_create',
                                related: @close_reason,
                                user: current_user,

--- a/app/models/close_reason.rb
+++ b/app/models/close_reason.rb
@@ -3,5 +3,7 @@ class CloseReason < ApplicationRecord
 
   scope :active, -> { where(active: true) }
 
-  validates :name, presence: true, uniqueness: { scope: [:community_id], case_sensitive: false }
+  validates :name, length: { maximum: 255 },
+                   presence: true,
+                   uniqueness: { scope: [:community_id], case_sensitive: false }
 end

--- a/app/models/close_reason.rb
+++ b/app/models/close_reason.rb
@@ -3,5 +3,5 @@ class CloseReason < ApplicationRecord
 
   scope :active, -> { where(active: true) }
 
-  validates :name, uniqueness: { scope: [:community_id], case_sensitive: false }
+  validates :name, presence: true, uniqueness: { scope: [:community_id], case_sensitive: false }
 end

--- a/app/models/close_reason.rb
+++ b/app/models/close_reason.rb
@@ -6,4 +6,8 @@ class CloseReason < ApplicationRecord
   validates :name, length: { maximum: 255 },
                    presence: true,
                    uniqueness: { scope: [:community_id], case_sensitive: false }
+
+  def global?
+    community.nil?
+  end
 end

--- a/test/controllers/close_reasons_controller_test.rb
+++ b/test/controllers/close_reasons_controller_test.rb
@@ -33,7 +33,7 @@ class CloseReasonsControllerTest < ActionController::TestCase
     assert_not_nil assigns(:close_reason)
   end
 
-  test 'should create close reason' do
+  test 'should correctly create close reasons' do
     sign_in users(:global_admin)
 
     [false, true].each do |global|
@@ -42,6 +42,12 @@ class CloseReasonsControllerTest < ActionController::TestCase
       assert_redirected_to close_reasons_path(global: global ? '1' : nil)
       assert_not_nil assigns(:close_reason)&.id
     end
+  end
+
+  test 'should not create invalid close reasons' do
+    sign_in users(:global_admin)
+    try_create_close_reason(name: '')
+    assert_response(:bad_request)
   end
 
   test 'should get edit' do
@@ -59,13 +65,19 @@ class CloseReasonsControllerTest < ActionController::TestCase
 
   test 'should update close reason' do
     sign_in users(:global_admin)
-    patch :update, params: { id: close_reasons(:duplicate).id, close_reason: { name: 'test', description: 'test',
-                                                                               requires_other_post: true,
-                                                                               active: false } }
+
+    try_update_close_reason(close_reasons(:duplicate), active: false)
+
     assert_response(:found)
     assert_redirected_to close_reasons_path
     assert_not_nil assigns(:close_reason)
     assert_equal false, assigns(:close_reason).active
+  end
+
+  test 'should not update close reasons to invalid states' do
+    sign_in users(:global_admin)
+    try_update_close_reason(close_reasons(:duplicate), name: '')
+    assert_response(:bad_request)
   end
 
   private
@@ -78,5 +90,10 @@ class CloseReasonsControllerTest < ActionController::TestCase
                                             requires_other_post: true,
                                             active: true }.merge(opts),
                             global: global ? '1' : '0' }
+  end
+
+  def try_update_close_reason(reason, **opts)
+    patch :update, params: { id: reason.id,
+                             close_reason: opts }
   end
 end

--- a/test/controllers/close_reasons_controller_test.rb
+++ b/test/controllers/close_reasons_controller_test.rb
@@ -38,6 +38,7 @@ class CloseReasonsControllerTest < ActionController::TestCase
 
     [false, true].each do |global|
       try_create_close_reason(global: global, name: global ? 'all communities' : 'per-community')
+
       assert_response(:found)
       assert_redirected_to close_reasons_path(global: global ? '1' : nil)
       assert_not_nil assigns(:close_reason)&.id
@@ -63,15 +64,21 @@ class CloseReasonsControllerTest < ActionController::TestCase
     assert_response(:not_found)
   end
 
-  test 'should update close reason' do
+  test 'should correctly update close reasons' do
     sign_in users(:global_admin)
 
-    try_update_close_reason(close_reasons(:duplicate), active: false)
+    close_reasons.each do |reason|
+      try_update_close_reason(reason, active: false, name: "#{reason.name} updated")
 
-    assert_response(:found)
-    assert_redirected_to close_reasons_path
-    assert_not_nil assigns(:close_reason)
-    assert_equal false, assigns(:close_reason).active
+      assert_response(:found)
+      assert_redirected_to close_reasons_path(global: reason.global? ? '1' : nil)
+
+      @close_reason = assigns(:close_reason)
+
+      assert_not_nil @close_reason
+      assert_equal false, @close_reason.active
+      assert_equal "#{reason.name} updated", @close_reason.name
+    end
   end
 
   test 'should not update close reasons to invalid states' do

--- a/test/controllers/close_reasons_controller_test.rb
+++ b/test/controllers/close_reasons_controller_test.rb
@@ -35,12 +35,13 @@ class CloseReasonsControllerTest < ActionController::TestCase
 
   test 'should create close reason' do
     sign_in users(:global_admin)
-    post :create, params: { close_reason: { name: 'test', description: 'test', requires_other_post: true,
-                                            active: true } }
-    assert_response(:found)
-    assert_redirected_to close_reasons_path
-    assert_not_nil assigns(:close_reason)
-    assert_not_nil assigns(:close_reason).id
+
+    [false, true].each do |global|
+      try_create_close_reason(global: global, name: global ? 'all communities' : 'per-community')
+      assert_response(:found)
+      assert_redirected_to close_reasons_path(global: global ? '1' : nil)
+      assert_not_nil assigns(:close_reason)&.id
+    end
   end
 
   test 'should get edit' do
@@ -65,5 +66,17 @@ class CloseReasonsControllerTest < ActionController::TestCase
     assert_redirected_to close_reasons_path
     assert_not_nil assigns(:close_reason)
     assert_equal false, assigns(:close_reason).active
+  end
+
+  private
+
+  def try_create_close_reason(**opts)
+    global = opts.delete(:global) || false
+
+    post :create, params: { close_reason: { name: 'test',
+                                            description: 'test',
+                                            requires_other_post: true,
+                                            active: true }.merge(opts),
+                            global: global ? '1' : '0' }
   end
 end


### PR DESCRIPTION
closes #1732 

This PR ensures close reason names are validated for both minimum & maximum length (the latter is just so as crafty users aren't "rewarded" with a server error).

It also fixes lack of visible validation errors when trying to _update_ (we've fixed the create action earlier) an invalid close reason:

<img width="785" height="276" alt="Screenshot from 2025-08-04 12-11-55" src="https://github.com/user-attachments/assets/b5e509c9-5bf3-40a8-82fe-1ac9c7bedc0f" />
