### PR TITLE
Remove matrices from the ci-cd pipeline's Rubocop job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,15 +10,12 @@ on:
 
 env:
   RAILS_ENV: test
+  RUBY_VERSION: 3.2
 
 jobs:
   rubocop:
     name: Rubocop checking
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        ruby_version: [3.1, 3.2]
 
     steps:
       - name: Checkout repo
@@ -30,7 +27,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby_version }}
+          ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
       - run: bundle exec rubocop
 
@@ -106,7 +103,7 @@ jobs:
           path: tmp/screenshots
           if-no-files-found: ignore
       - uses: codecov/codecov-action@v5
-        if: ${{ matrix.ruby_version == 3.2 && matrix.test_type == 'test' && github.actor != 'dependabot[bot]' }}
+        if: ${{ matrix.ruby_version == env.RUBY_VERSION && matrix.test_type == 'test' && github.actor != 'dependabot[bot]' }}
         with:
           directory: coverage
           fail_ci_if_error: true


### PR DESCRIPTION
This minor PR applies removal of the Rubocop job matrix from the #1709 PR as it's going to take longer than initially expected to merge in. Having one less check to run on every PR is of benefit to us right now.