### PR TITLE
fixed user avatar alt text overflow

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,5 +1,16 @@
 @import 'variables';
 
+img {
+  &.header--item-image {
+    &.user-avatar {
+      align-items: center;
+      display: flex;
+      font-size: 0.75em;
+      overflow: hidden;
+    }
+  }
+}
+
 .user-list {
   display: grid;
   gap: 1em;

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -84,7 +84,9 @@ $(() => {
         </a>
         <%= link_to user_path(current_user), class: 'header--item is-complex is-visible-on-mobile',
                                              title: 'Manage profile' do %>
-          <img alt="user avatar" src="<%= avatar_url(current_user, 40) %>" class="header--item-image avatar-40">&nbsp;&nbsp;
+          <img alt="user avatar"
+               src="<%= avatar_url(current_user, 40) %>"
+               class="header--item-image user-avatar avatar-40">&nbsp;&nbsp;
           <span class="<%= SiteSetting['SiteHeaderIsDark'] ? 'has-color-white' : 'has-color-tertiary-600' %>"><%= current_user.reputation %></span>
         <% end %>
       <% end %>


### PR DESCRIPTION
closes #1046 

A bit smaller font size to fit & `overflow: hide` just in case:

<img width="391" height="56" alt="Screenshot from 2025-08-05 01-03-01" src="https://github.com/user-attachments/assets/524ceefc-d78b-4927-8782-e2f360584e87" />
