### PR TITLE
Fix for the mod warning page broken dropdowns

### DIFF
--- a/app/views/mod_warning/new.html.erb
+++ b/app/views/mod_warning/new.html.erb
@@ -2,6 +2,8 @@
   <%= render 'posts/markdown_script' %>
 <% end %>
 
+<%= render 'posts/image_upload' %>
+
 <h1>Warn or suspend <%= user_link @user %></h1>
 
 <div class="notice is-warning">


### PR DESCRIPTION
closes #1363

The issue was simple: we provide a Markdown tool for uploading an image but do not render the required partial.