### PR TITLE
Do not show restricted categories for users who can't see them in the list of targets

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -5,7 +5,7 @@ class CategoriesController < ApplicationController
   before_action :verify_view_access, except: [:index, :homepage, :new, :create, :post_types]
 
   def index
-    @categories = Category.all.order(sequence: :asc, id: :asc)
+    @categories = Category.accessible_to(current_user).all.order(sequence: :asc, id: :asc)
     respond_to do |format|
       format.html
       format.json do


### PR DESCRIPTION
closes #914 

This is the list available to a global admin user (note the "ModRestricted" category):

<img width="818" height="327" alt="Screenshot from 2025-08-05 04-22-00" src="https://github.com/user-attachments/assets/044b6fd6-b62d-46d8-a31d-a076d83bf4d4" />

And this is how the list now looks like for non-mod users (same with other restriction levels - this PR simply builds on top of previous work that introduced the `Category#accessible_to(user)` method):

<img width="818" height="288" alt="Screenshot from 2025-08-05 04-21-33" src="https://github.com/user-attachments/assets/f20dfd7e-3629-4ac4-abe5-ea547e71e9e6" />
