### PR TITLE
Add body previews to posts of the Article type

### DIFF
--- a/app/views/posts/_article_list.html.erb
+++ b/app/views/posts/_article_list.html.erb
@@ -21,6 +21,11 @@
       <% end %>
       <%= link_to post.title, generic_share_link(post), 'data-ckb-item-link' => '' %>
     </div>
+    <% if (SiteSetting['PostBodyListTruncateLength'] || 0) > 0 %>
+      <p class="post-list--content">
+        <%= sanitize(strip_tags(post.body).truncate(SiteSetting['PostBodyListTruncateLength'] || 200), scrubber: scrubber) %>
+      </p>
+    <% end %>
      <p class="has-color-tertiary-600 has-float-right post-list--meta">
       posted <span title="<%= post.created_at.iso8601 %>"><%= time_ago_in_words(post.created_at, locale: :en_abbrev) %> ago</span>
       by <%= user_link post.user %>


### PR DESCRIPTION
Closes #1003 

`posts/_article_list` partial was simply lacking the section that renders the previews:

<img width="790" height="327" alt="Screenshot from 2025-08-05 04-47-22" src="https://github.com/user-attachments/assets/3867ac33-1c29-4eed-9162-8f6115a8fe11" />
