### PR TITLE
fixed lack of visible error when trying to rename a tag to an invalid…

### DIFF
--- a/app/assets/javascripts/tags.js
+++ b/app/assets/javascripts/tags.js
@@ -202,7 +202,7 @@ $(() => {
         location.reload();
       }
       else {
-        console.error('Failed to rename tag, somehow');
+        QPixel.createNotification('danger', `Failed to rename the tag. (${resp.status})`);
       }
     }
   });

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -141,7 +141,7 @@ class TagsController < ApplicationController
       end
     end
 
-    render json: { success: status, tag: @tag }
+    render json: { success: status, tag: @tag }, status: :bad_request
   end
 
   def select_merge; end


### PR DESCRIPTION
closes #545

Failing to rename a tag for some reason will now show a proper error notification:

<img width="853" height="322" alt="Screenshot from 2025-08-05 05-15-42" src="https://github.com/user-attachments/assets/4081a6aa-d805-4ebe-9714-1969eed0f4a4" />

We should improve the error message itself, but it's how we do error handling with many other AJAX-based actions (see, for example, nominating a post for promotion), so I'd rather address that in a centralized manner.



