### PR TITLE
Fix lack of custom font-family in post previews on Judaism

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -38,7 +38,9 @@
 <% if SiteSetting['SyntaxHighlightingEnabled'] %>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/default.min.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/highlight.min.js"></script>
-  <script defer>hljs.highlightAll();</script>
+  <script defer>
+    hljs.highlightAll();
+  </script>
 <% end %>
 
 <% if SiteSetting['MathJaxEnabled'] %>

--- a/public/assets/community/judaism.css
+++ b/public/assets/community/judaism.css
@@ -1,5 +1,9 @@
 @import url('https://fonts.googleapis.com/css2?family=Frank+Ruhl+Libre&display=swap');
 
-.post--body > *:not(div), .post-list--title, .post--title, .post-preview {
+.post--body > *:not(div),
+.post-list--title,
+.post-list--content,
+.post--title,
+.post-preview {
     font-family: 'Frank Ruhl Libre', serif;
 }

--- a/public/assets/community/judaism.css
+++ b/public/assets/community/judaism.css
@@ -1,5 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Frank+Ruhl+Libre&display=swap');
 
-.post--body > *:not(div), .post-list--title, .post--title {
+.post--body > *:not(div), .post-list--title, .post--title, .post-preview {
     font-family: 'Frank Ruhl Libre', serif;
 }


### PR DESCRIPTION
closes #631

<img width="784" height="407" alt="Screenshot from 2025-08-05 15-27-45" src="https://github.com/user-attachments/assets/b7027011-9543-45b1-8d3b-047d37464713" />

Also applies the same fix for post body previews in post lists:

<img width="746" height="173" alt="Screenshot from 2025-08-05 15-33-14" src="https://github.com/user-attachments/assets/297428d3-5484-4f97-9534-de0b220b3542" />
