### PR TITLE
fixed lack of visible error when failing to delete post drafts

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -322,7 +322,7 @@ $(() => {
         }
       }
       else {
-        console.error('Failed to delete draft.');
+        QPixel.createNotification('danger', `Failed to delete post draft. (${resp.status})`);
       }
     }
 


### PR DESCRIPTION
closes #1466 

<img width="993" height="463" alt="Screenshot from 2025-08-05 16-37-15" src="https://github.com/user-attachments/assets/297dab1c-65f9-4ce9-b857-7e0d656cd0cd" />

As with all the other AJAX error messages, this PR does not intend to improve the message itself as we need a centralized solution with standard JSON error responses - this will be done in a separate PR later.

422 "Unprocessable entity" is what we return in response to logged out users trying to delete post drafts, and we don't submit the form until the draft is successfully deleted, so that's the best we can do for now.