### PR TITLE
Add pinned_links cache clear

### DIFF
--- a/scripts/clear_cache.rb
+++ b/scripts/clear_cache.rb
@@ -1,1 +1,4 @@
 Rails.cache.delete_matched 'network/*'
+RequestContext.redis.keys('*pinned_links').each do |key|
+  RequestContext.redis.del(key)
+end


### PR DESCRIPTION
Closes #1725.

The `clear_cache.rb` is run as part of our normal deploy script, so this will clear cached pinned links entries on every deploy.