### PR TITLE
Spam account automatic de-privileging

### DIFF
--- a/app/jobs/potential_spam_profiles_job.rb
+++ b/app/jobs/potential_spam_profiles_job.rb
@@ -6,7 +6,7 @@ class PotentialSpamProfilesJob < ApplicationJob
     user_ids = ActiveRecord::Base.connection.execute(sql).to_a.flatten
     users = User.where(id: user_ids)
 
-    ability_ids = Ability.where(internal_id: 'unrestricted').map(&:id)
+    ability_ids = Ability.unscoped.where(internal_id: 'unrestricted').map(&:id)
 
     users.each do |user|
       cu_ids = user.community_users.map(&:id)

--- a/app/jobs/potential_spam_profiles_job.rb
+++ b/app/jobs/potential_spam_profiles_job.rb
@@ -1,0 +1,17 @@
+class PotentialSpamProfilesJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    sql = File.read(Rails.root.join('db/scripts/potential_spam_profiles.sql'))
+    user_ids = ActiveRecord::Base.connection.execute(sql).to_a.flatten
+    users = User.where(id: user_ids)
+
+    ability_ids = Ability.where(internal_id: 'unrestricted').map(&:id)
+
+    users.each do |user|
+      cu_ids = user.community_users.map(&:id)
+      UserAbility.where(community_user_id: cu_ids, ability_id: ability_ids)
+                 .update_all(is_suspended: true, suspension_message: 'This ability has been automatically suspended.')
+    end
+  end
+end

--- a/db/scripts/potential_spam_profiles.sql
+++ b/db/scripts/potential_spam_profiles.sql
@@ -1,0 +1,20 @@
+select u.id
+from users u
+inner join community_users cu on u.id = cu.user_id
+inner join communities c on cu.community_id = c.id
+left join posts p on p.user_id = u.id
+left join comments cm on cm.user_id = u.id
+left join votes v on v.user_id = u.id
+left join flags f on f.user_id = u.id
+where u.profile_markdown is not null
+  and u.profile like '%href="%'
+  and u.created_at >= date_sub(current_timestamp, interval 25 hour)
+  and u.deleted = false
+  and u.email not like '%localhost'
+group by u.id
+having sum(cu.reputation) = 1
+   and count(distinct p.id) = 0
+   and count(distinct cm.id) = 0
+   and count(distinct v.id) = 0
+   and count(distinct f.id) = 0
+order by u.id

--- a/scripts/run_spam_cleanup.rb
+++ b/scripts/run_spam_cleanup.rb
@@ -1,1 +1,2 @@
 CleanUpSpammyUsersJob.perform_later
+PotentialSpamProfilesJob.perform_later

--- a/test/fixtures/community_users.yml
+++ b/test/fixtures/community_users.yml
@@ -98,3 +98,10 @@ sample_enabled_2fa:
   is_admin: false
   is_moderator: false
   reputation: 1
+
+sample_spammer:
+  user: spammer
+  community: sample
+  is_admin: false
+  is_moderator: false
+  reputation: 1

--- a/test/fixtures/user_abilities.yml
+++ b/test/fixtures/user_abilities.yml
@@ -73,6 +73,10 @@ e2_ep_susp:
   suspension_end: ~
   suspension_message: go away
 
-e_sp:
+sp_eo:
+  community_user: sample_spammer
+  ability: everyone
+
+sp_ur:
   community_user: sample_spammer
   ability: unrestricted

--- a/test/fixtures/user_abilities.yml
+++ b/test/fixtures/user_abilities.yml
@@ -72,3 +72,7 @@ e2_ep_susp:
   is_suspended: true
   suspension_end: ~
   suspension_message: go away
+
+e_sp:
+  community_user: sample_spammer
+  ability: unrestricted

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -148,3 +148,18 @@ enabled_2fa:
   enabled_2fa: true
   two_factor_token: WT65ANYXBB2SBR7III7IVWNJDS4PQF2T
   backup_2fa_code: M8lENyehyCvo9F9MbyTl1aOL
+
+spammer:
+  email: spammer@example.com
+  encrypted_password: '$2a$11$roUHXKxecjyQ72Qn7DWs3.9eRCCoRn176kX/UNb/xiue3aGqf7xEW'
+  profile: > 
+    Find the best spam on the network <a href="https://example.com">here</a>!
+    The yummiest spam you've ever tasted.
+  profile_markdown: >
+    Find the best spam on the network [here](https://example.com)!
+    The yummiest spam you've ever tasted.
+  sign_in_count: 1
+  username: BestSpamOnTheNet
+  is_global_admin: false
+  is_global_moderator: false
+  confirmed_at: 2020-01-01T00:00:00.000000Z

--- a/test/jobs/potential_spam_profiles_job_test.rb
+++ b/test/jobs/potential_spam_profiles_job_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class PotentialSpamProfilesJobTest < ActiveJob::TestCase
   # test "the truth" do

--- a/test/jobs/potential_spam_profiles_job_test.rb
+++ b/test/jobs/potential_spam_profiles_job_test.rb
@@ -1,7 +1,10 @@
 require 'test_helper'
 
 class PotentialSpamProfilesJobTest < ActiveJob::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'should run job successfully' do
+    perform_enqueued_jobs do
+      PotentialSpamProfilesJob.perform_later
+    end
+    assert_performed_jobs 1
+  end
 end

--- a/test/jobs/potential_spam_profiles_job_test.rb
+++ b/test/jobs/potential_spam_profiles_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PotentialSpamProfilesJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/jobs/potential_spam_profiles_job_test.rb
+++ b/test/jobs/potential_spam_profiles_job_test.rb
@@ -2,9 +2,15 @@ require 'test_helper'
 
 class PotentialSpamProfilesJobTest < ActiveJob::TestCase
   test 'should run job successfully' do
+    unrestricted_id = abilities(:unrestricted).internal_id
+
+    assert users(:spammer).community_user.ability?(unrestricted_id)
+
     perform_enqueued_jobs do
       PotentialSpamProfilesJob.perform_later
     end
+
     assert_performed_jobs 1
+    assert_not users(:spammer).community_user.ability?(unrestricted_id)
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -205,7 +205,8 @@ class UserTest < ActiveSupport::TestCase
     communities.each do |community|
       CommunityUser.unscoped.undeleted.where(community_id: community.id).each do |cu|
         unless cu.user.deleted
-          assert_equal cu.user.ability_on?(community.id, everyone.internal_id), true
+          assert cu.user.ability_on?(community.id, everyone.internal_id),
+                 "Expected user '#{cu.user.username}' to have the 'everyone' ability"
         end
       end
     end


### PR DESCRIPTION
See #1729.

Adds a nightly job which complements the cleanup job we already have. This uses the query from #1729 with two changes:

* Requires _all_ community profiles to have reputation = 1
* Requires 0 flags raised in addition to 0 posts, comments, and votes

All users returned by the query have their Participate Everywhere ability removed, which disables profile links.