### PR TITLE
Explicit permissions for the ci-cd workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -12,6 +12,12 @@ env:
   RAILS_ENV: test
   RUBY_VERSION: 3.2
 
+permissions:
+  actions: write
+  contents: read
+  issues: read
+  pull-requests: read
+
 jobs:
   rubocop:
     name: Rubocop checking


### PR DESCRIPTION
Ports another minor change from the #1699 PR while it's in the works - explicit `permissions` for our main ci-cd GitHub Actions workflow.

Prevents code scanning from complaining upon changing the workflow file