### PR TITLE
Revision reference fix for rejected suggested edits

### DIFF
--- a/app/controllers/suggested_edit_controller.rb
+++ b/app/controllers/suggested_edit_controller.rb
@@ -42,11 +42,7 @@ class SuggestedEditController < ApplicationController
              before_tags: @post.tags.to_a,
              after_tags: @edit.tags }
 
-    before = { before_body: @post.body,
-               before_body_markdown: @post.body_markdown,
-               before_tags_cache: @post.tags_cache.dup,
-               before_tags: @post.tags.to_a,
-               before_title: @post.title }
+    before = before_attributes(@post)
 
     @post.transaction do
       post_update_status = @post.update(applied_details)
@@ -99,10 +95,15 @@ class SuggestedEditController < ApplicationController
       return
     end
 
-    now = DateTime.now
+    before = before_attributes(@post)
 
-    if @edit.update(active: false, accepted: false, rejected_comment: params[:rejection_comment], decided_at: now,
-                    decided_by: current_user, updated_at: now)
+    if @edit.update(before.merge(active: false,
+                                 accepted: false,
+                                 rejected_comment: params[:rejection_comment],
+                                 decided_at: DateTime.now,
+                                 decided_by: current_user,
+                                 updated_at: DateTime.now))
+
       flash[:success] = 'Edit rejected successfully.'
       AbilityQueue.add(@edit.user, "Suggested Edit Rejected ##{@edit.id}")
       render json: {
@@ -110,10 +111,8 @@ class SuggestedEditController < ApplicationController
         redirect_url: helpers.generic_share_link(@post)
       }
     else
-      render json: {
-               status: 'error',
-               message: 'Cannot reject this suggested edit... Strange.'
-             },
+      render json: { status: 'error',
+                     message: 'Cannot reject this suggested edit... Strange.' },
              status: :internal_server_error
     end
   end
@@ -135,5 +134,13 @@ class SuggestedEditController < ApplicationController
       last_edited_at: DateTime.now,
       last_edited_by: @edit.user
     }.compact
+  end
+
+  def before_attributes(post)
+    { before_body: post.body,
+      before_body_markdown: post.body_markdown,
+      before_tags_cache: post.tags_cache.dup,
+      before_tags: post.tags.to_a,
+      before_title: post.title }
   end
 end

--- a/app/models/concerns/edits_validations.rb
+++ b/app/models/concerns/edits_validations.rb
@@ -14,7 +14,7 @@ module EditsValidations
     max_edit_comment_length = SiteSetting['MaxEditCommentLength'] || 255
     max_length = [max_edit_comment_length, 255].min
     if comment.length > max_length
-      msg = I18n.t('edits.max_edit_comment_length', { count: max_length }).gsub(':length', max_length.to_s)
+      msg = I18n.t('edits.max_edit_comment_length', count: max_length).gsub(':length', max_length.to_s)
       errors.add(:base, msg)
     end
   end

--- a/app/tasks/maintenance/fix_rejected_edit_states_task.rb
+++ b/app/tasks/maintenance/fix_rejected_edit_states_task.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class FixRejectedEditStatesTask < MaintenanceTasks::Task
+    include ApplicationHelper
+
+    def collection
+      SuggestedEdit.rejected
+    end
+
+    def last_revision_before_decided(edit)
+      PostHistory.of_type('post_edited')
+                 .where(post: edit.post)
+                 .where(created_at: edit.post.created_at..edit.decided_at)
+                 .order(created_at: :desc)
+                 .first
+    end
+
+    def initial_revision_before_decided(edit)
+      PostHistory.of_type('initial_revision')
+                 .where(post: edit.post)
+                 .where(created_at: edit.post.created_at..edit.decided_at)
+                 .order(created_at: :desc)
+                 .first
+    end
+
+    def valid_before_attributes?(edit)
+      [
+        :before_body,
+        :before_body_markdown,
+        :before_tags_cache,
+        :before_title
+      ].all? do |attr|
+        edit.send(attr).present?
+      end
+    end
+
+    def process(edit)
+      return if valid_before_attributes?(edit)
+
+      last_revision = last_revision_before_decided(edit).presence || initial_revision_before_decided(edit)
+
+      return unless last_revision.present?
+
+      begin
+        status = edit.update({ before_body: render_markdown(last_revision.after_state),
+                               before_body_markdown: last_revision.after_state,
+                               before_tags: last_revision.after_tags.dup,
+                               before_tags_cache: last_revision.after_tags.map(&:name),
+                               before_title: last_revision.after_title })
+
+        unless status
+          Rails.logger.warn("Failed to fix edit ##{edit.id}")
+        end
+      rescue StandardError => e
+        Rails.logger.warn(e)
+      end
+    end
+  end
+end

--- a/test/controllers/suggested_edit_controller_test.rb
+++ b/test/controllers/suggested_edit_controller_test.rb
@@ -109,36 +109,36 @@ class SuggestedEditControllerTest < ActionController::TestCase
   test 'approving edit should change status and apply it' do
     sign_in users(:editor)
 
-    suggested_edit = suggested_edits(:accepted_suggested_edit)
-    suggested_edit.update(active: true, accepted: false)
-
-    post :approve, params: { id: suggested_edit.id }
-    suggested_edit.reload
+    post :approve, params: { id: suggested_edits(:pending_suggested_edit).id }
 
     assert_response(:success)
-    assert_not_nil assigns(:edit)
 
-    assert_equal suggested_edit.active, false
-    assert_equal suggested_edit.accepted, true
-    assert_equal suggested_edit.body_markdown, suggested_edit.post.body_markdown
-    assert_equal suggested_edit.tags_cache, suggested_edit.post.tags_cache
-    assert_equal suggested_edit.title, suggested_edit.post.title
+    @edit = assigns(:edit)
+
+    assert_not_nil @edit
+    assert_equal @edit.active, false
+    assert_equal @edit.accepted, true
+    assert_equal @edit.body_markdown, @edit.post.body_markdown
+    assert_equal @edit.tags_cache, @edit.post.tags_cache
+    assert_equal @edit.title, @edit.post.title
   end
 
   test 'rejecting edit should change status' do
     sign_in users(:editor)
 
-    suggested_edit = suggested_edits(:rejected_suggested_edit)
-    suggested_edit.update(active: true, accepted: false)
-
-    post :reject, params: { id: suggested_edit.id, rejection_comment: 'WHY NOT?' }
-    suggested_edit.reload
+    post :reject, params: { id: suggested_edits(:pending_suggested_edit).id,
+                            rejection_comment: 'WHY NOT?' }
 
     assert_response(:success)
-    assert_not_nil assigns(:edit)
 
-    assert_equal suggested_edit.active, false
-    assert_equal suggested_edit.accepted, false
-    assert_equal suggested_edit.rejected_comment, 'WHY NOT?'
+    @edit = assigns(:edit)
+
+    assert_not_nil @edit
+    assert_equal @edit.active, false
+    assert_equal @edit.accepted, false
+    assert_equal @edit.before_body_markdown, @edit.post.body_markdown
+    assert_equal @edit.before_tags_cache, @edit.post.tags_cache
+    assert_equal @edit.before_title, @edit.post.title
+    assert_equal @edit.rejected_comment, 'WHY NOT?'
   end
 end

--- a/test/fixtures/post_histories.yml
+++ b/test/fixtures/post_histories.yml
@@ -14,3 +14,11 @@ question_one_hidden_revision:
   comment: 'A hidden revision made by an admin user'
   community: sample
   hidden: true
+
+question_two_initial_revision:
+  post_history_type: initial_revision
+  user: editor
+  post: question_two
+  community: sample
+  after_state: This is the body of test question two. Note that we did not include any markdown or HTML in here.
+  after_title: Q2 - This is test question number two

--- a/test/models/concerns/edits_validations_test.rb
+++ b/test/models/concerns/edits_validations_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class EditsValidationsTest < ActiveSupport::TestCase
+  def setup
+    @klass = Class.new do
+      include ActiveModel::Validations
+      include EditsValidations
+
+      def self.name
+        'EditsValidationsTest' # otherwise, ActiveModel::Name will error out
+      end
+
+      def initialize(comment)
+        super()
+        @comment = comment
+      end
+
+      attr_accessor :comment
+    end
+  end
+
+  test 'max_edit_comment_length should correctly validate comment length' do
+    max_length = 5
+
+    SiteSetting['MaxEditCommentLength'] = max_length
+
+    ['a' * max_length, 'b' * (max_length + 1)].each do |comment|
+      instance = @klass.new(comment)
+
+      is_valid = instance.valid?
+
+      if comment.length <= max_length
+        assert is_valid
+        assert instance.errors.none?
+      else
+        assert_not is_valid
+        assert instance.errors[:base].any?
+      end
+    end
+  end
+end

--- a/test/tasks/maintenance/fix_rejected_edit_states_task_test.rb
+++ b/test/tasks/maintenance/fix_rejected_edit_states_task_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+module Maintenance
+  class FixRejectedEditStatesTaskTest < ActiveSupport::TestCase
+    test 'perform should correctly fix rejected edit states' do
+      edit = suggested_edits(:rejected_suggested_edit)
+
+      Maintenance::FixRejectedEditStatesTask.process(edit)
+      edit.reload
+
+      assert_not_nil edit.before_body
+      assert_not_nil edit.before_body_markdown
+      assert_not_nil edit.before_title
+    end
+  end
+end


### PR DESCRIPTION
closes #1371

I also added a maintenance task that should fix up the existing rejected suggested edits - we can run at any time we want after deployment (I've tested on the cases that I have available, but it's not enough to safely run in prod - let's run it on dev servers first when the time comes).