### PR TITLE
Fix for modals not reacting to the Esc key & for file input field not gaining focus

### DIFF
--- a/app/assets/javascripts/modals.js
+++ b/app/assets/javascripts/modals.js
@@ -1,7 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
-  document.addEventListener('keypress', (ev) => {
-    if (ev.code === 'Escape') {
-      document.querySelectorAll('.modal').forEach((el) => el.classList.remove('is-active'));
+  document.addEventListener('keyup', (ev) => {
+    if (ev.code === 'Escape' && !ev.metaKey && !ev.ctrlKey) {
+      document.querySelectorAll('.modal').forEach((el) => {
+        el.classList.remove('is-active');
+      });
     }
   });
 });

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -48,6 +48,23 @@ $(() => {
     $uploadForm.trigger('submit')
   });
 
+  new MutationObserver((records) => {
+    for (const record of records) {
+      if (record.target instanceof HTMLElement &&
+          record.target.id === 'markdown-image-upload' &&
+          record.target.classList.contains('is-active')) {
+        const fileInput = record.target.querySelector('input[type="file"]');
+        
+        if (fileInput instanceof HTMLInputElement) {
+          fileInput.focus();
+        }
+      }
+    }
+  }).observe(document, {
+    attributeFilter: ['class'],
+    subtree: true,
+  });
+
   $uploadForm.on('submit', async (evt) => {
     evt.preventDefault();
 

--- a/app/views/posts/_image_upload.html.erb
+++ b/app/views/posts/_image_upload.html.erb
@@ -1,19 +1,19 @@
 <div class="modal is-with-backdrop" id="markdown-image-upload">
   <div class="modal--container">
     <div class="modal--header">
-      <button class="button is-close-button modal--header-button" data-modal="#markdown-image-upload">&times;</button>
+      <button class="button is-close-button modal--header-button"
+              data-modal="#markdown-image-upload">&times;</button>
       Image upload
     </div>
     <div class="modal--body">
       <%= form_tag upload_path, multipart: true, class: 'form-inline upload-form js-upload-form' do %>
         <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
         <div class="form-group">
-          <%= label_tag :file, 'Insert an image', class: "form-element" %>
+          <%= label_tag :file, 'Insert an image', class: 'form-element' %>
           <div class="form-caption js-max-size">Max file size <%= SiteSetting['MaxUploadSize'] %>.</div>
-          <%= file_field_tag :file, class: "form-element" %>
+          <%= file_field_tag :file, class: 'form-element' %>
         </div>
       <% end %>
     </div>
   </div>
 </div>
-


### PR DESCRIPTION
closes #1366

2 fixes:
- modals now react to the <kbd>Esc</kbd> key being presses as expected (they should close);
- file input field is now focused when the image upload modal is opened;

https://github.com/user-attachments/assets/bd9d61eb-52e6-4a78-8868-9ce485ff0a9b


