### PR TITLE
Thread title validation

### DIFF
--- a/app/assets/javascripts/character_count.js
+++ b/app/assets/javascripts/character_count.js
@@ -67,7 +67,7 @@ $(() => {
 
     const fullCount = $tgt.val().trim().length;
     const count = omitMarkdown ?
-                    QPixel.MD.stripMarkdown($tgt.val().trim(), { removeQuotes: true }).length :
+                    QPixel.MD.stripMarkdown($tgt.val().trim(), { removeLeadingQuote: true }).length :
                     fullCount;
 
     $info.toggleClass('hide', fullCount === count)

--- a/app/assets/javascripts/character_count.js
+++ b/app/assets/javascripts/character_count.js
@@ -65,9 +65,9 @@ $(() => {
     const $info = $counter.find('.js-character-count__info');
     const omitMarkdown = $tgt.data('markdown') === 'strip';
 
-    const fullCount = $tgt.val().length;
+    const fullCount = $tgt.val().trim().length;
     const count = omitMarkdown ?
-                    QPixel.MD.stripMarkdown($tgt.val(), { removeQuotes: true }).length :
+                    QPixel.MD.stripMarkdown($tgt.val().trim(), { removeQuotes: true }).length :
                     fullCount;
 
     $info.toggleClass('hide', fullCount === count)

--- a/app/assets/javascripts/character_count.js
+++ b/app/assets/javascripts/character_count.js
@@ -62,8 +62,18 @@ $(() => {
     const $button = $form.find('input[type="submit"],.js-suggested-edit-approve');
     const $count = $counter.find('.js-character-count__count');
     const $icon = $counter.find('.js-character-count__icon');
+    const $info = $counter.find('.js-character-count__info');
+    const omitMarkdown = $tgt.data('markdown') === 'strip';
 
-    const count = $tgt.val().length;
+    const fullCount = $tgt.val().length;
+    const count = omitMarkdown ?
+                    QPixel.MD.stripMarkdown($tgt.val(), { removeQuotes: true }).length :
+                    fullCount;
+
+    $info.toggleClass('hide', fullCount === count)
+         .attr('title', 'Markdown will be stripped away and does not count towards the limit');
+    $icon.toggleClass('hide', fullCount !== count);
+
     const max = parseInt($counter.attr('data-max'), 10);
     const min = parseInt($counter.attr('data-min'), 10);
     const threshold = parseFloat($counter.attr('data-threshold'));

--- a/app/assets/javascripts/qpixel_markdown.js
+++ b/app/assets/javascripts/qpixel_markdown.js
@@ -1,0 +1,16 @@
+window.QPixel = window.QPixel || {};
+
+QPixel.MD = {
+  stripMarkdown: (content, options = {}) => {
+    const stripped = content
+      .replace(/(?:^#+ +|^-{3,}|^\[[^\]]+\]: ?.+$|^!\[[^\]]+\](?:\([^)]+\)|\[[^\]]+\])$|<[^>]+>)/g, '')
+      .replace(/[*_~]+/g, '')
+      .replace(/!?\[([^\]]+)\](?:\([^)]+\)|\[[^\]]+\])/g, '$1');
+    
+    if (options.removeQuotes) {
+      return stripped.replace(/^>.+?$/g, '');
+    }
+
+    return stripped;
+  },
+};

--- a/app/assets/javascripts/qpixel_markdown.js
+++ b/app/assets/javascripts/qpixel_markdown.js
@@ -7,7 +7,7 @@ QPixel.MD = {
       .replace(/[*_~]+/g, '')
       .replace(/!?\[([^\]]+)\](?:\([^)]+\)|\[[^\]]+\])/g, '$1');
     
-    if (options.removeQuotes) {
+    if (options.removeLeadingQuote ?? false) {
       return stripped.replace(/^>.+?$/g, '');
     }
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -208,7 +208,13 @@ class CommentsController < ApplicationController
       return
     end
 
-    @comment_thread.update title: params[:title]
+    title = helpers.strip_markdown(params[:title], strip_leading_quote: true)
+    status = @comment_thread.update(title: title)
+
+    unless status
+      flash[:danger] = I18n.t('comments.errors.rename_thread_generic')
+    end
+
     redirect_to comment_thread_path(@comment_thread.id)
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -26,7 +26,7 @@ class CommentsController < ApplicationController
 
     body = params[:body]
 
-    @comment_thread = CommentThread.new(title: title, post: @post)
+    @comment_thread = CommentThread.new(title: helpers.strip_markdown(title, strip_leading_quote: true), post: @post)
     @comment = Comment.new(post: @post, content: body, user: current_user, comment_thread: @comment_thread)
 
     pings = check_for_pings(@comment_thread, body)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -127,8 +127,9 @@ module ApplicationHelper
   # This isn't a perfect way to strip out Markdown, so it should only be used for non-critical things like
   # page descriptions - things that will later be supplemented by the full formatted content.
   # @param markdown [String] The Markdown string to strip.
+  # @param strip_leading_quote [Boolean] whether to remove the leading blockquote if present
   # @return [String] The plain-text equivalent.
-  def strip_markdown(markdown)
+  def strip_markdown(markdown, strip_leading_quote: false)
     # Remove block-level formatting: headers, hr, references, images, HTML tags
     markdown = markdown.gsub(/(?:^#+ +|^-{3,}|^\[[^\]]+\]: ?.+$|^!\[[^\]]+\](?:\([^)]+\)|\[[^\]]+\])$|<[^>]+>)/, '')
 
@@ -136,7 +137,10 @@ module ApplicationHelper
     markdown = markdown.gsub(/[*_~]+/, '')
 
     # Remove links and inline images but replace them with their text/alt text.
-    markdown.gsub(/!?\[([^\]]+)\](?:\([^)]+\)|\[[^\]]+\])/, '\1')
+    markdown = markdown.gsub(/!?\[([^\]]+)\](?:\([^)]+\)|\[[^\]]+\])/, '\1')
+
+    # Optionally remove the leading blockquote
+    strip_leading_quote ? markdown.gsub(/^>.+?$/, '') : markdown
   end
 
   ##

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -4,8 +4,7 @@ module CommentsHelper
   # @param body [String] coment thread body
   # @return [String] generated title
   def generate_thread_title(body)
-    body = strip_markdown(body)
-    body = body.gsub(/^>.+?$/, '') # also remove leading blockquotes
+    body = strip_markdown(body, strip_leading_quote: true)
 
     if body.length > 100
       "#{body[0..100]}..."

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -184,6 +184,12 @@ module CommentsHelper
 
     [true, message]
   end
+
+  # Get the maximum comment thread title length for the current community, with a maximum of 255.
+  # @return [Integer]
+  def maximum_thread_title_length
+    [SiteSetting['MaxThreadTitleLength'] || 255, 255].min
+  end
 end
 
 # HTML sanitizer for use with comments.

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -12,7 +12,7 @@ class CommentThread < ApplicationRecord
   scope :archived, -> { where(archived: true) }
 
   validate :maximum_title_length
-  validates :title, presence: true
+  validates :title, presence: { message: I18n.t('comments.errors.title_presence') }
 
   after_create :create_follower
 

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -24,10 +24,16 @@ class CommentThread < ApplicationRecord
     locked? || archived? || deleted?
   end
 
+  # Is a given user a follower of the thread?
+  # @param user [User] user to check
+  # @return [Boolean] check result
   def followed_by?(user)
     ThreadFollower.where(comment_thread: self, user: user).any?
   end
 
+  # Does a given user have access to the thread?
+  # @param user [User] user to check access for
+  # @return [Boolean] check result
   def can_access?(user)
     (!deleted? || user&.privilege?('flag_curate') || user&.post_privilege?('flag_curate', post)) &&
       post.can_access?(user)

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -11,6 +11,9 @@ class CommentThread < ApplicationRecord
   scope :publicly_available, -> { where(deleted: false).where('reply_count > 0') }
   scope :archived, -> { where(archived: true) }
 
+  validate :maximum_title_length
+  validates :title, presence: true
+
   after_create :create_follower
 
   def self.post_followed?(post, user)
@@ -51,6 +54,13 @@ class CommentThread < ApplicationRecord
     END_SQL
 
     ActiveRecord::Base.connection.execute(query).to_a.flatten
+  end
+
+  def maximum_title_length
+    max_len = SiteSetting['MaxThreadTitleLength'] || 255
+    if title.length > [max_len, 255].min
+      errors.add(:title, "can't be more than #{max_len} characters")
+    end
   end
 
   private

--- a/app/views/comments/_new_thread_modal.html.erb
+++ b/app/views/comments/_new_thread_modal.html.erb
@@ -1,6 +1,6 @@
 <%#
-    Start new comment thread dialog.
-%>
+   "Start new comment thread dialog.
+"%>
 
 <%
   # TODO: make configurable
@@ -43,10 +43,14 @@
                          class: 'form-element js-thread-title-field',
                          data: { post: post.id,
                                  thread: '-1',
-                                 character_count: ".js-character-count-thread-title" } %>
+                                 character_count: '.js-character-count-thread-title',
+                                 markdown: 'strip' } %>
       <%= render 'shared/char_count', type: 'thread-title' %>
 
-      <%= submit_tag 'Create thread', class: 'button is-filled', id: "create_thread_button_#{post.id}", disabled: true %>
+      <%= submit_tag 'Create thread',
+                     class: 'button is-filled',
+                     id: "create_thread_button_#{post.id}",
+                     disabled: true %>
     <% end %>
   </div>
 </div>

--- a/app/views/comments/_new_thread_modal.html.erb
+++ b/app/views/comments/_new_thread_modal.html.erb
@@ -45,7 +45,10 @@
                                  thread: '-1',
                                  character_count: '.js-character-count-thread-title',
                                  markdown: 'strip' } %>
-      <%= render 'shared/char_count', type: 'thread-title' %>
+      <%= render 'shared/char_count',
+                 type: 'thread-title',
+                 min: 1,
+                 max: maximum_thread_title_length %>
 
       <%= submit_tag 'Create thread',
                      class: 'button is-filled',

--- a/app/views/comments/_rename_thread_modal.html.erb
+++ b/app/views/comments/_rename_thread_modal.html.erb
@@ -1,9 +1,9 @@
 <%#
-  Helper for rendering comment thread rename action modal
+   "Helper for rendering comment thread rename action modal
 
   Variables:
     thread : Comment thread to create the modal for
-%>
+"%>
 
 <div class="modal is-with-backdrop is-small js--rename-thread-<%= thread.id %>">
   <%= form_tag rename_comment_thread_path(thread.id), class: 'modal--container' do %>
@@ -12,18 +12,27 @@
               class="button is-close-button modal--header-button"
               data-modal=".js--rename-thread-<%= thread.id %>">&times;
       </button>
-      Rename...
+      Rename thread
     </div>
     <div class="modal--body">
       <%= label_tag :title, 'Title', class: 'form-element' %>
       <%= text_field_tag :title,
                          thread.title,
                          class: 'form-element js-thread-title-field',
-                         data: { post: thread.post.id, thread: thread.id } %>
+                         data: { post: thread.post.id,
+                                 thread: thread.id,
+                                 character_count: ".js-character-count-thread-title-#{thread.id}",
+                                 markdown: 'strip' } %>
+      <%= render 'shared/char_count',
+                 type: "thread-title-#{thread.id}",
+                 cur: thread.title.length,
+                 max: maximum_thread_title_length %>
     </div>
     <div class="modal--footer">
       <%= submit_tag 'Update thread', class: 'button is-muted is-filled' %>
-      <button type="button" class="button is-muted" data-modal=".js--rename-thread-<%= thread.id %>">Cancel</button>
+      <button type="button"
+              class="button is-muted"
+              data-modal=".js--rename-thread-<%= thread.id %>">Cancel</button>
     </div>
   <% end %>
 </div>

--- a/app/views/comments/_rename_thread_modal.html.erb
+++ b/app/views/comments/_rename_thread_modal.html.erb
@@ -26,6 +26,7 @@
       <%= render 'shared/char_count',
                  type: "thread-title-#{thread.id}",
                  cur: thread.title.length,
+                 min: 1,
                  max: maximum_thread_title_length %>
     </div>
     <div class="modal--footer">

--- a/app/views/shared/_char_count.html.erb
+++ b/app/views/shared/_char_count.html.erb
@@ -21,6 +21,7 @@
   data-max="<%= max %>"
   data-min="<%= min %>"
   data-threshold="<%= threshold %>">
+    <i class="fas fa-info-circle hide js-character-count__info"></i>
     <i class="fas fa-ellipsis-h js-character-count__icon"></i>
     <span class="js-character-count__count">
       <%= cur %> / <%= cur < min ? min : max %>

--- a/config/locales/strings/en.comments.yml
+++ b/config/locales/strings/en.comments.yml
@@ -29,6 +29,8 @@ en:
         Something went wrong when trying to delete the comment.
       undelete_comment_server_error: >
         Something went wrong when trying to undelete the comment.
+      rename_thread_generic: >
+        Failed to rename the thread.
     labels:
       create_new_thread: >
         Start new comment thread

--- a/config/locales/strings/en.comments.yml
+++ b/config/locales/strings/en.comments.yml
@@ -31,6 +31,8 @@ en:
         Something went wrong when trying to undelete the comment.
       rename_thread_generic: >
         Failed to rename the thread.
+      title_presence: >
+        can't be empty after Markdown is removed.
     labels:
       create_new_thread: >
         Start new comment thread

--- a/db/seeds/site_settings.yml
+++ b/db/seeds/site_settings.yml
@@ -158,6 +158,13 @@
     The maximum characters a single tag name may contain. Default is 35 for compatibility with Stack Exchange; going lower
     may introduce validation issues with content imported from SE.
 
+- name: MaxThreadTitleLength
+  value: 250
+  value_type: integer
+  category: SiteDetails
+  description: >
+    The maximum characters a comment thread title may contain. Defaults to 255.
+
 - name: MaxTitleLength
   value: 150
   value_type: integer

--- a/db/seeds/site_settings.yml
+++ b/db/seeds/site_settings.yml
@@ -159,7 +159,7 @@
     may introduce validation issues with content imported from SE.
 
 - name: MaxThreadTitleLength
-  value: 250
+  value: 255
   value_type: integer
   category: SiteDetails
   description: >

--- a/global.d.ts
+++ b/global.d.ts
@@ -37,6 +37,15 @@ interface QPixelDOM {
   setVisible?: (elements: HTMLElement | HTMLElement[], visible: boolean) => void;
 }
 
+interface QPixelMD {
+  /**
+   * See [strip_markdown](./app/helpers/application_helper.rb) application helper
+   */
+  stripMarkdown(content: string, options?: {
+    removeQuotes?: boolean
+  }): string;
+}
+
 type QPixelKeyboardState =
   | "home"
   | "goto"
@@ -358,6 +367,9 @@ interface QPixel {
 
   // qpixel_dom
   DOM?: QPixelDOM;
+  // qpixel Markdown
+  MD?: QPixelMD;
+  // qpixel popups
   Popup?: typeof QPixelPopup;
   // Stripe integration, TODO: types
   stripe?: any;

--- a/global.d.ts
+++ b/global.d.ts
@@ -37,13 +37,19 @@ interface QPixelDOM {
   setVisible?: (elements: HTMLElement | HTMLElement[], visible: boolean) => void;
 }
 
+interface StripMarkdownOptions {
+  /**
+   * Whether to strip away the leading quote ("> content"), if any
+   * @default false
+   */
+  removeLeadingQuote?: boolean
+}
+
 interface QPixelMD {
   /**
-   * See [strip_markdown](./app/helpers/application_helper.rb) application helper
+   * See [strip_markdown](app/helpers/application_helper.rb) application helper
    */
-  stripMarkdown(content: string, options?: {
-    removeQuotes?: boolean
-  }): string;
+  stripMarkdown(content: string, options?: StripMarkdownOptions): string;
 }
 
 type QPixelKeyboardState =

--- a/test/controllers/comments/rename_test.rb
+++ b/test/controllers/comments/rename_test.rb
@@ -23,13 +23,26 @@ class CommentsControllerTest < ActionController::TestCase
       before_title = comment_threads(name).title
 
       try_rename_thread(comment_threads(name))
-
       @thread = assigns(:comment_thread)
 
       assert_response(:found)
       assert_not_nil @thread
       assert_redirected_to comment_thread_path(@thread)
       assert_equal before_title, @thread.title
+    end
+  end
+
+  test 'should correctly handle invalid thread titles' do
+    sign_in users(:admin)
+
+    ['', 'a' * 512].each do |title|
+      try_rename_thread(comment_threads(:normal), title: title)
+      @thread = assigns(:comment_thread)
+
+      assert_response(:found)
+      assert_not_nil @thread
+      assert_not @thread.valid?
+      assert_not_nil flash[:danger]
     end
   end
 end

--- a/test/models/comment_thread_test.rb
+++ b/test/models/comment_thread_test.rb
@@ -1,7 +1,18 @@
 require 'test_helper'
 
 class CommentThreadTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'should correctly validate titles' do
+    valid_title = 'should pass all validations'
+
+    ['', 'a' * 512, valid_title].each do |title|
+      thread = CommentThread.new(post: posts(:question_one), title: title)
+      is_valid = thread.valid?
+
+      assert_equal valid_title == title, is_valid
+
+      unless is_valid
+        assert thread.errors[:title].any?
+      end
+    end
+  end
 end


### PR DESCRIPTION
closes #1731
closes #1378

This PR:

- introduces validation for comment thread titles (minimum 1 char for now, maximum is configurable via a new `MaxThreadTitleLength` site setting, defaults to 255. Should not be set higher than that - we don't support it in the DB [on that note, we should introduce validation for such settings - it's technically possible to allow higher values]);
- adds missing character counter to the rename thread modal:
    <img width="421" height="277" alt="2025-08-12_18-56" src="https://github.com/user-attachments/assets/fce81de1-5bf6-42b8-ab88-514b99dad4f7" />
- makes character counters aware of markdown stripping if enabled (the field should set `markdown` data-attribute to `strip`) - to prevent confusing users, when that happens, the counter displays an info icon with a title explaining the situation:
    <img width="425" height="297" alt="2025-08-12_18-58" src="https://github.com/user-attachments/assets/98fc8dab-42f0-42e2-979d-8390b4fdeb30" />
- also switched character counters to ignore leading & trailing white spaces as we don't count those towards the limit in the first place (note that we also had this problem with posts and pretty much any other text fields);
- also ensures that at least a generic error message is shown when failing to rename threads (providing a proper list of errors is outside of the scope of this PR and should be done when addressing #714 );

