### PR TITLE
Fix for the category default filter select using default UA styling

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -15,6 +15,18 @@ class Category < ApplicationRecord
 
   validates :name, uniqueness: { scope: [:community_id], case_sensitive: false }
 
+  COLORS = ['turquoise',
+            'green',
+            'blue',
+            'darkblue',
+            'purple',
+            'gray',
+            'bluegray',
+            'yellow',
+            'orange',
+            'pink',
+            'red'].freeze
+
   # Can anyone view the category (even if not logged in)?
   # @return [Boolean] check result
   def public?

--- a/app/views/admin/setup.html.erb
+++ b/app/views/admin/setup.html.erb
@@ -16,9 +16,10 @@
       <div class="form-group">
         <%= label_tag :primary_color, 'Primary color', class: 'form-element' %>
         <span class="form-caption">Select a primary color for this site. Will be used as default for all categories.</span>
-        <%= select_tag :primary_color, options_for_select(['turquoise', 'green', 'blue', 'darkblue', 'purple', 'gray', 'bluegray', 'yellow', 'orange', 'pink', 'red'],
-                                                          selected: SiteSetting['SiteCategoryHeaderDefaultColor']),
-                      class: 'form-element' %>
+        <%= select_tag :primary_color,
+                       options_for_select(Category::COLORS,
+                       selected: SiteSetting['SiteCategoryHeaderDefaultColor']),
+                       class: 'form-element' %>
       </div>
 
       <div class="form-group">

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -150,7 +150,10 @@
       <%= f.label :default_filter_id, class: 'form-element' %>
       <span class="form-caption">The default filter for this category, used for anonymous users.</span>
       <% system_filters = User.find(-1).filters.to_h { |filter| [filter.name, filter.id] } %>
-      <%= f.select :default_filter_id, options_for_select(system_filters, selected: @category.default_filter_id), { include_blank: "No default" } %>
+      <%= f.select :default_filter_id,
+                   options_for_select(system_filters, selected: @category.default_filter_id),
+                   { include_blank: "No default" },
+                   class: 'form-element' %>
     </div>
   </details>
 

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -133,8 +133,10 @@
     <div class="form-group">
       <%= f.label :color_code, 'Header color', class: 'form-element' %>
       <span class="form-caption">Select a color to be used for the header within this category. Leave empty for site-wide default.</span>
-      <%= f.select :color_code, options_for_select(['turquoise', 'green', 'blue', 'darkblue', 'purple', 'gray', 'bluegray', 'yellow', 'orange', 'pink', 'red'], selected: @category.color_code),
-                   { include_blank: true }, class: 'form-element' %>
+      <%= f.select :color_code,
+                   options_for_select(Category::COLORS, selected: @category.color_code),
+                   { include_blank: true },
+                   class: 'form-element' %>
     </div>
 
     <div class="form-group">

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -39,7 +39,8 @@
       <span class="form-caption">
         These post types will be displayed on the category's homepage. For a Q&A category, you might only want to show questions.
       </span>
-      <%= f.select :display_post_types, options_for_select(PostType.mapping.to_a, selected: @category.display_post_types),
+      <%= f.select :display_post_types,
+                   options_for_select(PostType.mapping.to_a, selected: @category.display_post_types),
                    { include_blank: true }, multiple: true, class: 'form-element' %>
     </div>
 
@@ -58,7 +59,8 @@
     <div class="form-group">
       <%= f.label :tag_set_id, 'Tag set', class: 'form-element' %>
       <span class="form-caption">Which tag set may posts in this category draw from?</span>
-      <%= f.select :tag_set_id, options_for_select(TagSet.all.map { |ts|  [ts.name, ts.id] }, selected: @category.tag_set_id),
+      <%= f.select :tag_set_id,
+                   options_for_select(TagSet.all.map { |ts|  [ts.name, ts.id] }, selected: @category.tag_set_id),
                    { include_blank: true }, class: 'form-element js-category-tag-set-select' %>
     </div>
 
@@ -87,7 +89,8 @@
         Users must have at least this trust level to post in this category. Leave blank to allow
         anyone to post.
       </span>
-      <%= f.select :min_trust_level, options_for_select(Ability.trust_levels.invert.each_pair, selected: @category.min_trust_level),
+      <%= f.select :min_trust_level,
+                   options_for_select(Ability.trust_levels.invert.each_pair, selected: @category.min_trust_level),
                    {}, class: 'form-element' %>
     </div>
 
@@ -97,7 +100,8 @@
         Users under this trust level cannot see that this category exists. Leave blank to leave the category public.
         This can be different (higher or lower) than the minimum posting trust level.
       </span>
-      <%= f.select :min_view_trust_level, options_for_select(Ability.trust_levels.invert.each_pair, selected: @category.min_view_trust_level),
+      <%= f.select :min_view_trust_level,
+                   options_for_select(Ability.trust_levels.invert.each_pair, selected: @category.min_view_trust_level),
                    {}, class: 'form-element' %>
     </div>
 
@@ -132,7 +136,9 @@
 
     <div class="form-group">
       <%= f.label :color_code, 'Header color', class: 'form-element' %>
-      <span class="form-caption">Select a color to be used for the header within this category. Leave empty for site-wide default.</span>
+      <span class="form-caption">
+        Select a color to be used for the header within this category. Leave empty for site-wide default.
+      </span>
       <%= f.select :color_code,
                    options_for_select(Category::COLORS, selected: @category.color_code),
                    { include_blank: true },
@@ -154,7 +160,7 @@
       <% system_filters = User.find(-1).filters.to_h { |filter| [filter.name, filter.id] } %>
       <%= f.select :default_filter_id,
                    options_for_select(system_filters, selected: @category.default_filter_id),
-                   { include_blank: "No default" },
+                   { include_blank: 'No default' },
                    class: 'form-element' %>
     </div>
   </details>
@@ -168,15 +174,17 @@
     <div class="form-group">
       <%= f.label :asking_guidance_override, class: 'form-element' %>
       <span class="form-caption">
-      This field overrides the default asking guidance and is shown when a new post is created. Leave blank to use site-default.
-    </span>
+        This field overrides the default asking guidance and is shown when a new post is created.<br/>
+        Leave blank to use site-default.
+      </span>
       <%= f.text_area :asking_guidance_override, class: 'form-element' %>
     </div>
 
     <div class="form-group">
       <%= f.label :answering_guidance_override, class: 'form-element' %>
       <span class="form-caption">
-      This field overrides the default answering guidance and is shown when a new answer is created. Leave blank to use site-default.
+      This field overrides the default answering guidance and is shown when a new answer is created.<br/>
+      Leave blank to use site-default.
     </span>
       <%= f.text_area :answering_guidance_override, class: 'form-element' %>
     </div>
@@ -193,7 +201,8 @@
       <span class="form-caption">
       Whether the posts of this category are eligible to be selected as hot posts.
     </span>
-      <%= f.select :use_for_hot_posts, options_for_select([['yes', true], ['no', false]], selected: @category.use_for_hot_posts),
+      <%= f.select :use_for_hot_posts,
+                   options_for_select([['yes', true], ['no', false]], selected: @category.use_for_hot_posts),
                    {}, class: 'form-element' %>
     </div>
 
@@ -202,7 +211,8 @@
       <span class="form-caption">
       Whether the posts of this category are eligible to be selected as random advertisement.
     </span>
-      <%= f.select :use_for_advertisement, options_for_select([['yes', true], ['no', false]], selected: @category.use_for_advertisement),
+      <%= f.select :use_for_advertisement,
+                   options_for_select([['yes', true], ['no', false]], selected: @category.use_for_advertisement),
                    {}, class: 'form-element' %>
     </div>
   </details>


### PR DESCRIPTION
closes #1759

A fix so small, I had to make a couple linter-related fixes and add a constant (DRY) to justify the time spent on the PR itself.