### PR TITLE
Tour fixes

### DIFF
--- a/app/assets/stylesheets/tour.scss
+++ b/app/assets/stylesheets/tour.scss
@@ -1,16 +1,29 @@
 .codidactyl {
-    width: 80px;
-    padding: 2rem;
-    margin-top: 1rem;
+  width: 80px;
+  padding: 2rem;
+  margin-top: 1rem;
 }
-.codidactyl + .is-flexible { width: 0; }
+
+.codidactyl + .is-flexible {
+  width: 0;
+}
 
 .codidactyl-sticky {
-    position: sticky;
-    top: 0.5rem;
-    padding: 1rem;
+  position: sticky;
+  top: 0.5rem;
+  padding: 1rem;
 }
 
 .codidactyl-small {
-    max-height: 1em;
+  max-height: 1em;
+}
+
+@media (max-width: 768px) {
+  .tour-editor-wrapper {
+    order: 2;
+  }
+
+  .tour-hints-wrapper {
+    order: 1;
+  }
 }

--- a/app/views/tour/question2.html.erb
+++ b/app/views/tour/question2.html.erb
@@ -21,7 +21,7 @@
 <hr>
 
 <div class="grid">
-  <div class="grid--cell is-8">
+  <div class="grid--cell is-8-lg is-12-md is-12-sm tour-editor-wrapper">
     <h1>New Post in Q&amp;A</h1>
     <div class="notice is-info">
       <%= raw(sanitize(render_markdown(SiteSetting['AskingGuidance']), scrubber: scrubber)) %>
@@ -54,7 +54,7 @@
     </div>
 
   </div>
-  <div class="grid--cell is-4">
+  <div class="grid--cell is-4-lg is-12-md is-12-sm tour-hints-wrapper">
     <div class="codidactyl-hints codidactyl-sticky">
       <div class="widget step-1 hide">
         <div class="widget--header">

--- a/app/views/tour/question2.html.erb
+++ b/app/views/tour/question2.html.erb
@@ -1,4 +1,5 @@
 <%= render 'posts/markdown_script' %>
+<%= render 'posts/image_upload' %>
 
 <div class="grid step-0">
   <div class="grid--cell codidactyl">


### PR DESCRIPTION
closes #1777 
closes #247

In addition to fixing a runtime error breaking modals on the tour page, this PR also fixes overflow of the tour hints content on narrow screens - we now move the hints section to the top when the breakpoint is reach (when we can, we should also collapse them in such cases, but it's a "good enough" solution for the time being):

<img width="329" height="820" alt="Screenshot from 2025-08-13 04-13-19" src="https://github.com/user-attachments/assets/4b572255-b5c9-480e-a9bf-3a0c0e256785" />
