### PR TITLE
Fix for the homepage runtime error when no categories are configured as such

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -21,6 +21,12 @@ class CategoriesController < ApplicationController
 
   def homepage
     @category = Category.where(is_homepage: true).first
+
+    unless @category.present?
+      redirect_to categories_path
+      return
+    end
+
     update_last_visit(@category)
     set_list_posts
     render :show
@@ -199,6 +205,9 @@ class CategoriesController < ApplicationController
     @posts = @posts.paginate(page: params[:page], per_page: 50).order(sort_param)
   end
 
+  # Updates last visit cache for a given category
+  # @param category [Category] category to update
+  # @return [Boolean] whether the cache entry is deleted
   def update_last_visit(category)
     return if current_user.blank?
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -15,6 +15,12 @@ class Category < ApplicationRecord
 
   validates :name, uniqueness: { scope: [:community_id], case_sensitive: false }
 
+  # Is the category set as the homepage?
+  # @return [Boolean] check result
+  def homepage?
+    is_homepage == true
+  end
+
   # Can anyone view the category (even if not logged in)?
   # @return [Boolean] check result
   def public?

--- a/test/controllers/categories_controller_test.rb
+++ b/test/controllers/categories_controller_test.rb
@@ -9,6 +9,22 @@ class CategoriesControllerTest < ActionController::TestCase
     assert_not_nil assigns(:categories)
   end
 
+  test ':homepage should correctly show the homepage category' do
+    get :homepage
+    assert_response(:success)
+    @category = assigns(:category)
+    assert_not_nil @category
+    assert @category.homepage?
+  end
+
+  test ':homepage should redirect to the categories list if there is no default category' do
+    Category.where(is_homepage: true).destroy_all
+
+    get :homepage
+    assert_response(:found)
+    assert_redirected_to(categories_path)
+  end
+
   test 'should correctly show public categories' do
     public_categories = categories.select(&:public?)
 


### PR DESCRIPTION
closes #794

Technically not possible unless the user setting up QPixel never runs the initial seeds as we set the `Q&A` category as homepage _or_ unless an admin unchecks the "Set as homepage?" checkbox later. The former is unlikely, but the latter is very much plausible - we now redirect to the list of categories in such a case.