### PR TITLE
Fix user deletions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ node_modules
 
 # YARD data
 .yardoc
+doc/

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -58,36 +58,38 @@ class ApplicationRecord < ActiveRecord::Base
     end
   end
 
+  # rubocop:disable Metrics/MethodLength
   def self.useful_err_msg
     [
       'The inverted database guide has found an insurmountable problem. Please poke it with a ' \
-        'paperclip before anyone finds out.',
+      'paperclip before anyone finds out.',
       'The integral output port has found a problem. Please take it back to the shop and take ' \
-        'the rest of the day off.',
+      'the rest of the day off.',
       'Congratulations. You have reached the end of the internet.',
       'The Spanish Inquisition raised an unexpected error. Cannot continue without comfy-chair-interrogation.',
       'The server halted in an after-you loop.',
       'A five-level precedence operation shifted too long and cannot be recovered without data loss. ' \
-        'Please re-enable the encryption protocol.',
+      'Please re-enable the encryption protocol.',
       'The server\'s headache has not improved in the last 24 hours. It needs to be rebooted.',
       'The primary LIFO data recipient is currently on a holiday and will not be back before next Thursday.',
       'The operator is currently trying to solve their Rubik\'s cube. We will come back to you when the ' \
-        'second layer is completed.',
+      'second layer is completed.',
       'The encryption protocol offered by the client predates the invention of irregular logarithmic ' \
-        'functions.',
+      'functions.',
       'The data in the secondary (backup) user registry is corrupted and needs to be re-filled with ' \
-        'random data again.',
+      'random data again.',
       'This community has reached a critical mass and collapsed into a black hole. Currently trying to ' \
-        'recover using Hawking radiation.',
+      'recover using Hawking radiation.',
       'Operations are on pause while we attempt to recapture the codidactyl. Please hold.',
       'The data center is on fire. Please hold while we activate fire suppression systems.',
       'The reciprocal controller flag is set incorrectly. Please stand on your head and rickroll yourself to fix this.',
       'The quantum cache has become uncertain. Please observe it again after making a cup of tea.',
       'The recursive handshake timed out while waiting for itself to finish. Try waving at yourself in a mirror ' \
-        'until it responds.',
-      'The left-handed API key doesn\'t fit this right-handed endpoint. Please rotate it 180 degrees while humming the API theme song.',
+      'until it responds.',
+      'The left-handed API key doesn\'t fit this right-handed endpoint. Please rotate it 180 degrees while humming ' \
+      'the API theme song.',
       'Your session was garbage-collected for leaving crumbs in the cookie jar. Kindly sweep the cookies into a ' \
-        'jar-shaped folder.',
+      'jar-shaped folder.',
       'Your request fell through a race condition and finished second. Present it with a silver medal and try again.',
       'The DNS insists today it stands for \'Did Not Start\'. Please send it motivational cat posters.',
       'The OAuth token is shy. Whisper your scopes softly and offer it a comfort blanket.',
@@ -153,6 +155,7 @@ class ApplicationRecord < ActiveRecord::Base
       'The API versioning strategy is writing its memoir. Offer an editor.'
     ]
   end
+  # rubocop:enable Metrics/MethodLength
 end
 
 module UserSortable

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -20,7 +20,10 @@ class ApplicationRecord < ActiveRecord::Base
   end
 
   def attributes_print(join: ', ')
-    attributes.map { |k, v| "#{k}: #{v.inspect}" }.join(join)
+    attributes.map do |k, v|
+      val = v.inspect.length > 100 ? "#{v.inspect[0, 100]}..." : v.inspect
+      "#{k}: #{val}"
+    end.join(join)
   end
 
   def self.sanitize_for_search(term, **cols)

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -58,31 +58,96 @@ class ApplicationRecord < ActiveRecord::Base
   def self.useful_err_msg
     [
       'The inverted database guide has found an insurmountable problem. Please poke it with a ' \
-      'paperclip before anyone finds out.',
-      'The modular cable meter has found a problem. You need to kick your IT technician in the ' \
-      'shins immediately.',
+        'paperclip before anyone finds out.',
       'The integral output port has found a problem. Please take it back to the shop and take ' \
-      'the rest of the day off.',
-      'The integral expansion converter has encountered a terminal error. You must take legal ' \
-      'advice urgently.',
+        'the rest of the day off.',
       'Congratulations. You have reached the end of the internet.',
       'The Spanish Inquisition raised an unexpected error. Cannot continue without comfy-chair-interrogation.',
       'The server halted in an after-you loop.',
       'A five-level precedence operation shifted too long and cannot be recovered without data loss. ' \
-      'Please re-enable the encryption protocol.',
+        'Please re-enable the encryption protocol.',
       'The server\'s headache has not improved in the last 24 hours. It needs to be rebooted.',
       'The primary LIFO data recipient is currently on a holiday and will not be back before next Thursday.',
       'The operator is currently trying to solve their Rubik\'s cube. We will come back to you when the ' \
-      'second layer is completed.',
+        'second layer is completed.',
       'The encryption protocol offered by the client predates the invention of irregular logarithmic ' \
-      'functions.',
+        'functions.',
       'The data in the secondary (backup) user registry is corrupted and needs to be re-filled with ' \
-      'random data again.',
+        'random data again.',
       'This community has reached a critical mass and collapsed into a black hole. Currently trying to ' \
-      'recover using Hawking radiation.',
+        'recover using Hawking radiation.',
       'Operations are on pause while we attempt to recapture the codidactyl. Please hold.',
       'The data center is on fire. Please hold while we activate fire suppression systems.',
-      'The reciprocal controller flag is set incorrectly. Please stand on your head and rickroll yourself to fix this.'
+      'The reciprocal controller flag is set incorrectly. Please stand on your head and rickroll yourself to fix this.',
+      'The quantum cache has become uncertain. Please observe it again after making a cup of tea.',
+      'The recursive handshake timed out while waiting for itself to finish. Try waving at yourself in a mirror ' \
+        'until it responds.',
+      'The left-handed API key doesn\'t fit this right-handed endpoint. Please rotate it 180 degrees while humming the API theme song.',
+      'Your session was garbage-collected for leaving crumbs in the cookie jar. Kindly sweep the cookies into a ' \
+        'jar-shaped folder.',
+      'Your request fell through a race condition and finished second. Present it with a silver medal and try again.',
+      'The DNS insists today it stands for \'Did Not Start\'. Please send it motivational cat posters.',
+      'The OAuth token is shy. Whisper your scopes softly and offer it a comfort blanket.',
+      'The distributed consensus reached a polite disagreement. Break the tie with a round of rock-paper-scissors.',
+      'The feature flag tripped over a rug and toggled itself off. Please help it up and brush off the dust.',
+      'The uptime counter overflowed into nap time. Wake it gently with a teaspoon of coffee.',
+      'The cron job saw its shadow and scheduled six more weeks of maintenance. Offer it a flashlight and try again.',
+      'The heisenbug vanished when we opened the logs. Please look away and try again.',
+      'The Kubernetes pod drifted out to sea. Dispatch a small boat with sandwiches.',
+      'The retry policy is composing a strongly worded letter to the server. Offer a thesaurus for better results.',
+      'The message queue joined a queue. Estimated wait time: variable. Send it a good book.',
+      'The microservice macroed itself and forgot how to be small. Remind it of its humble beginnings.',
+      'The database index is on a gap year. Send postcards to encourage its return.',
+      'The deploy canary learned to sing and flew away. Try luring it back with birdseed.',
+      'Single sign-on stepped out to find itself. Back soon. Leave a trail of breadcrumbs.',
+      'The entropy pool is empty. Kindly imagine wiggling your mouse.',
+      'The RAID array eloped with a NAS. Send congratulations and request a postcard.',
+      'The config file contains more opinions than agreement. Appoint a moderator.',
+      'The null pointer was so moved it pointed somewhere. Politely direct it back.',
+      'The stack is overflowing with feelings. Fetching tissues. Offer emotional support.',
+      'The exception handler forgot its mitts. Knit it a pair.',
+      'The SSL certificate expired in dog years. Bake it a birthday cake.',
+      'The WebSocket is sulking in silent mode. Send a heartfelt apology.',
+      'The API gateway misplaced the keys to the database. Check under the welcome mat.',
+      'The firmware updated its relationship status to \'complicated\'. Send couples counselling pamphlets.',
+      'The load balancer is weighing its options. Provide a set of calibrated scales.',
+      'The build pipeline tripped over a merge conflict and needs a plaster. Apply gentle pressure.',
+      'The logger switched to interpretive dance. Learn the choreography to decode the message.',
+      'The search index refuses to be found. Host a welcome‑back party.',
+      'The container misplaced its container. Check the lost‑and‑found container.',
+      'The recursive acronym needs a breather before it expands again. Offer a paper bag.',
+      'The data lake froze over. Please try ice skating.',
+      'The fiber was delayed by a lorry attempting a three-point turn. Offer to navigate.',
+      'The server popped out for a bacon butty. Back shortly. Fry an extra one for its return.',
+      'The permissions matrix rotated 90 degrees and became modern art. Hang it in a gallery.',
+      'Your cookie consent banner ate the cookies. Supply a healthy snack alternative.',
+      'The scheduler double-booked Tuesday with next Tuesday. Buy it a new calendar.',
+      'The GPU is busy appreciating gradients in a sunset. Offer it a camera.',
+      'The CLI took everything literally and nothing personally. Send it idioms to process.',
+      'The time server is early, the database is late, and reality is pending. Send them a group chat invite.',
+      'Your session collided with a parallel universe and yielded a merge conflict. Try diplomatic talks.',
+      'The health check caught a cold. Sending soup packets. Add a warm blanket.',
+      'The sandbox discovered a cat and refuses to collapse the wavefunction. Provide a cardboard box.',
+      'The debugger hit a breakpoint and started journaling. Offer coloured pens.',
+      'The profiler is timing itself. Results may vary. Suggest it use a stopwatch.',
+      'The error reporter experienced an error and needs a quiet moment. Light a scented candle.',
+      'The audit log is practicing mindfulness and noticed your request drift by. Join it for meditation.',
+      'The dependency tree is climbing itself. Mind the branches. Offer a ladder.',
+      'The semaphore got stage fright and won’t signal. Provide an encouraging audience.',
+      'The background job went foreground and now refuses to blend in. Offer camouflage.',
+      'The clipboard copied the vibe but not the content. Try a mood reset.',
+      'The keyboard buffer is full of unsent compliments. Press send on kindness.',
+      'The ops runbook recommends tea, biscuits, and a gentle retry. Add a scone.',
+      'The metrics exporter is measuring twice and cutting never. Provide scissors.',
+      'The NTP sync is waiting for time to catch up with itself. Send it a postcard from the future.',
+      'The transaction forgot its commit vows and wandered off. Hold a recommitment ceremony.',
+      'The scheduler moved your slot to the next available epoch. Estimated delay: 73 years.',
+      'The test suite passed locally and moved abroad. Mail it a travel adaptor.',
+      'The feature toggle is indecisive and would like a coin flip. Supply a two‑headed coin.',
+      'The namespace is arguing about space. Offer a tape measure.',
+      'The host machine asked politely for a host gift. Bring flowers.',
+      'The compliance engine needs a hug from a certified hugger. Book a professional cuddle.',
+      'The API versioning strategy is writing its memoir. Offer an editor.'
     ]
   end
 end
@@ -90,8 +155,12 @@ end
 module UserSortable
   # Sort a collection according to a user selection, by mapping user selectable values to column names.
   # SQL injection safe.
-  # @param term_opts Hash of search term options: { term: params[:sort], default: :created_at }
-  # @param field_mappings Hash of user-selectable values to column names: { age: :created_at, rep: :threshold }
+  # @param term_opts Hash of search term options
+  # @param field_mappings Hash of user-selectable values to column names: +{ age: :created_at, rep: :threshold }+
+  # @option term_opts :term [String] A user-provided search term to apply - usually from +params+, e.g. +params[:sort]+.
+  #   Should be one of the keys in +field_mappings+.
+  # @option term_opts :default [Symbol] A column name to apply as the default sort ordering.
+  # @return [ActiveRecord::Relation] A relation of the current type, with the sort ordering applied.
   def user_sort(term_opts, **field_mappings)
     default = term_opts[:default] || :created_at
     requested = term_opts[:term]

--- a/app/views/users/mod.html.erb
+++ b/app/views/users/mod.html.erb
@@ -25,8 +25,6 @@
     <p><strong>Take care!</strong> Actions in this section may not be reversible, and you will not be asked to confirm
       after initiating an action.</p>
     <div class="delete-actions">
-      <%= link_to 'Destroy user', destroy_user_path(@user.id), remote: true,
-                  method: :delete, class: 'js-destroy-user button is-danger is-filled', role: 'button' %>
       <%= link_to 'Delete community profile', soft_delete_user_path(@user.id, type: 'profile'), remote: true,
                   method: :delete, class: 'js-soft-delete button is-danger is-filled', role: 'button' %>
       <% if current_user.is_global_moderator || current_user.is_global_admin %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,7 +99,6 @@ Rails.application.routes.draw do
     get    'flags',                        to: 'flags#queue', as: :flag_queue
     get    'flags/handled',                to: 'flags#handled', as: :handled_flags
     get    'flags/escalated',              to: 'flags#escalated_queue', as: :escalated_flags
-    delete 'users/destroy/:id',            to: 'users#destroy', as: :destroy_user
     get    'users/votes/:id',              to: 'moderator#user_vote_summary', as: :mod_vote_summary
     post   'flags/:id/resolve',            to: 'flags#resolve', as: :resolve_flag
     post   'flags/:id/escalate',           to: 'flags#escalate', as: :escalate_flag

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -69,28 +69,6 @@ class UsersControllerTest < ActionController::TestCase
     assert_response(:not_found)
   end
 
-  test 'should destroy user' do
-    sign_in users(:global_admin)
-    delete :destroy, params: { id: users(:standard_user).id }
-    assert_not_nil assigns(:user)
-    assert_equal 'success', JSON.parse(response.body)['status']
-    assert_response(:success)
-  end
-
-  test 'should require authentication to destroy user' do
-    sign_out :user
-    delete :destroy, params: { id: users(:standard_user).id }
-    assert_nil assigns(:user)
-    assert_response(:not_found)
-  end
-
-  test 'should require moderator status to destroy user' do
-    sign_in users(:standard_user)
-    delete :destroy, params: { id: users(:standard_user).id }
-    assert_nil assigns(:user)
-    assert_response(:not_found)
-  end
-
   test 'should soft-delete user' do
     sign_in users(:global_admin)
     delete :soft_delete, params: { id: users(:standard_user).id, type: 'user' }


### PR DESCRIPTION
Limits attribute lengths to 100 when creating audit logs for deletions.

Also removes the ability to destroy users to prevent confusion over what option to use.

Closes #1772.