### PR TITLE
Fix for required tags duplication & improvements to tag renaming

### DIFF
--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -494,5 +494,15 @@ window.QPixel = {
     const data = await resp.json();
 
     return data;
+  },
+
+  renameTag: async (categoryId, tagId, name) => {
+    const resp = await QPixel.fetchJSON(`/categories/${categoryId}/tags/${tagId}/rename`, { name }, {
+      headers: { 'Accept': 'application/json' }
+    });
+
+    const data = await resp.json();
+
+    return data;
   }
 };

--- a/app/assets/javascripts/tags.js
+++ b/app/assets/javascripts/tags.js
@@ -193,17 +193,15 @@ $(() => {
     const tagName = $tgt.attr('data-name');
 
     const renameTo = prompt(`Rename tag ${tagName} to:`);
-    if (!!renameTo) {
-      const resp = await QPixel.fetchJSON(`/categories/${categoryId}/tags/${tagId}/rename`, { name: renameTo });
-  
-      const data = await resp.json();
 
-      if (data.success) {
-        location.reload();
-      }
-      else {
-        QPixel.createNotification('danger', `Failed to rename the tag. (${resp.status})`);
-      }
+    if (!renameTo) {
+      return;
     }
+
+    const data = await QPixel.renameTag(categoryId, tagId, renameTo);
+
+    QPixel.handleJSONResponse(data, () => {
+      location.reload();
+    });
   });
 });

--- a/app/assets/javascripts/tags.js
+++ b/app/assets/javascripts/tags.js
@@ -176,7 +176,7 @@ $(() => {
     const tagId = $tgt.attr('data-tag-id');
     const tagName = $tgt.attr('data-tag-name');
     const $select = $tgt.parents('.form-group').find('select');
-    const existing = $select.find(`option[value=${tagId}]`);
+    const existing = $select.find(`option[value='${tagName}']`);
     if (existing.length > 0) {
       $select.val([useIds ? tagId : tagName, ...($select.val() || [])]).trigger('change');
     }

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -141,7 +141,14 @@ class TagsController < ApplicationController
       end
     end
 
-    render json: { success: status, tag: @tag }, status: status ? :ok : :bad_request
+    if status
+      render json: { status: 'success', tag: @tag }
+    else
+      render json: { status: 'failed',
+                     message: 'Failed to rename the tag.',
+                     tag: @tag },
+             status: :bad_request
+    end
   end
 
   def select_merge; end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -145,7 +145,7 @@ class TagsController < ApplicationController
       render json: { status: 'success', tag: @tag }
     else
       render json: { status: 'failed',
-                     message: 'Failed to rename the tag.',
+                     message: I18n.t('tags.errors.rename_generic'),
                      tag: @tag },
              status: :bad_request
     end

--- a/config/locales/strings/en.tags.yml
+++ b/config/locales/strings/en.tags.yml
@@ -1,0 +1,5 @@
+en:
+  tags:
+    errors:
+      rename_generic: >
+        Failed to rename the tag.

--- a/global.d.ts
+++ b/global.d.ts
@@ -365,6 +365,15 @@ interface QPixel {
   lockThread?: (id: string) => Promise<QPixelResponseJSON>
 
   /**
+   * Attempts to rename a tag
+   * @param categoryId id of the category to rename the tag in
+   * @param tagId id of the tag to rename
+   * @param name new tag name
+   * @returns result of the operation
+   */
+  renameTag?: (categoryId: string, tagId: string, name: string) => Promise<QPixelResponseJSON>
+
+  /**
    * Attempts to raise a flag
    * @param flag new flag data
    * @returns result of the operation

--- a/test/controllers/tags_controller_test.rb
+++ b/test/controllers/tags_controller_test.rb
@@ -207,7 +207,7 @@ class TagsControllerTest < ActionController::TestCase
     res_body = JSON.parse(response.body)
 
     assert_equal 'failed', res_body['status']
-    assert_no_nil res_body['message']
+    assert_equal I18n.t('tags.errors.rename_generic'), res_body['message']
     tag.reload
     assert_equal tag.name, old_tag_name
   end

--- a/test/controllers/tags_controller_test.rb
+++ b/test/controllers/tags_controller_test.rb
@@ -176,23 +176,16 @@ class TagsControllerTest < ActionController::TestCase
     sign_in users(:moderator)
 
     tag = tags(:base)
-
     new_tag_name = 'renamed'
 
-    post :rename, params: {
-      format: :json,
-      id: categories(:main).id,
-      name: new_tag_name,
-      tag_id: tag.id,
-      tag: tag
-    }
+    try_rename_tag(categories(:main), tag, new_tag_name)
 
     assert_response(:success)
     assert_valid_json_response
 
     res_body = JSON.parse(response.body)
 
-    assert_equal true, res_body['success']
+    assert_equal 'success', res_body['status']
     assert_equal new_tag_name, res_body['tag']['name']
 
     log_entry = AuditLog.last
@@ -204,24 +197,33 @@ class TagsControllerTest < ActionController::TestCase
     sign_in users(:moderator)
 
     tag = tags(:base)
-
     old_tag_name = tag.name
 
-    post :rename, params: {
-      format: :json,
-      id: categories(:main).id,
-      name: '',
-      tag_id: tag.id,
-      tag: tag
-    }
+    try_rename_tag(categories(:main), tag, '')
 
     assert_response(:bad_request)
     assert_valid_json_response
 
     res_body = JSON.parse(response.body)
 
-    assert_equal false, res_body['success']
+    assert_equal 'failed', res_body['status']
+    assert_no_nil res_body['message']
     tag.reload
     assert_equal tag.name, old_tag_name
+  end
+
+  private
+
+  # @param category [Category] category to rename the tag in
+  # @param tag [Tag] tag to rename
+  # @param name [String] new tag name
+  def try_rename_tag(category, tag, name)
+    post :rename, params: {
+      format: :json,
+      id: category.id,
+      name: name,
+      tag_id: tag.id,
+      tag: tag
+    }
   end
 end


### PR DESCRIPTION
closes #939 

Given that the fix is extremely minor, I've thrown in a couple of improvements to tag renaming, specifically, aligned the JSON response structure with the other methods (part of #1754) + the failure message is now server-side. 

Note to reviewers: new locale string files are only picked up by Rails servers only after reload