### PR TITLE
Wrap comment actions to a new line on narrow screens

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -22,12 +22,15 @@
 }
 
 .comment .comment-meta {
-  font-size: 0.9em;
-  color: #666;
   background-color: rgba(0, 0, 0, 0.05);
-  padding: 0.5rem 0.75rem;
-  margin-bottom: 0.5rem;
+  color: #666;
   display: flex;
+  flex-wrap: wrap;
+  font-size: 0.9em;
+  gap: 0.5em;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem 0.75rem;
 
   .comment--reference {
     position: relative;
@@ -42,12 +45,14 @@
   }
 
   .comment--links {
-    flex-grow: 1;
     display: flex;
-    justify-content: right;
 
     a {
       margin: 0 0.25rem;
+
+      &:first-child {
+        margin-left: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
closes #1786

Comment actions now properly wrap to a new line when there's not enough space instead (as they are supposed to):

<img width="313" height="106" alt="Screenshot from 2025-08-15 03-41-22" src="https://github.com/user-attachments/assets/1b46058d-6a69-48b6-bfdc-606a7f2ba982" />
