### PR TITLE
Rename system test to follow convention of being plural

### DIFF
--- a/test/system/posts_test.rb
+++ b/test/system/posts_test.rb
@@ -1,8 +1,6 @@
 require 'application_system_test_case'
 
-# Renamed from PostTest to PostSystemTest to avoid clash with test/models/post_test.rb
-# when running rails test:all
-class PostSystemTest < ApplicationSystemTestCase
+class PostsTest < ApplicationSystemTestCase
   # -------------------------------------------------------
   # Create
   # -------------------------------------------------------


### PR DESCRIPTION
I'd previously renamed the PostTest system test to PostSystemTest to avoid an error when running tests and systems tests together (since the non-system tests also have a PostTest). However, I've since discovered that the convention for avoiding this clash is to have non-system tests named with singular nouns, and system tests named with plural nouns.

Updating to reflect this allows removing my previous explanatory comment, which is no longer required now that convention is being followed.