### PR TITLE
Use labels in user preferences for accessibility and testability

### DIFF
--- a/app/views/users/_prefs.html.erb
+++ b/app/views/users/_prefs.html.erb
@@ -1,6 +1,6 @@
 <% prefs.each do |name, value| %>
   <% pref_config = AppConfig.preferences[name] %>
-  <div class="user-pref">
+  <label class="user-pref">
     <div class="user-pref--meta">
       <strong><%= name.humanize %></strong><br/>
       <span class="desc"><%= pref_config['description'] %></span>
@@ -23,5 +23,5 @@
                data-community="<%= community %>" />
       <% end %>
     </div>
-  </div>
+  </label>
 <% end %>


### PR DESCRIPTION
Fixes #1567.

The rest of the codebase appears to already use labels correctly, so this pull request simply fixes the case described in that issue. That is, the Preferences tab of the user page.