### PR TITLE
Separate post unfollow to avoid reversal on accidental second call

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -276,11 +276,13 @@ class CommentsController < ApplicationController
 
   def post_follow
     @post = Post.find(params[:post_id])
-    if @post.followed_by?(current_user)
-      ThreadFollower.where(post: @post, user: current_user).destroy_all
-    else
-      ThreadFollower.create(post: @post, user: current_user)
-    end
+    ThreadFollower.create(post: @post, user: current_user)
+    redirect_to post_path(@post)
+  end
+
+  def post_unfollow
+    @post = Post.find(params[:post_id])
+    ThreadFollower.where(post: @post, user: current_user).destroy_all
     redirect_to post_path(@post)
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -423,3 +423,4 @@ class CommentsController < ApplicationController
                              user: current_user)
   end
 end
+# rubocop:disable Metrics/ClassLength

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -276,7 +276,9 @@ class CommentsController < ApplicationController
 
   def post_follow
     @post = Post.find(params[:post_id])
-    ThreadFollower.create(post: @post, user: current_user)
+    if ThreadFollower.where(post: @post, user: current_user).count == 0
+      ThreadFollower.create(post: @post, user: current_user)
+    end
     redirect_to post_path(@post)
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 # Provides mainly web actions for using and making comments.
 class CommentsController < ApplicationController
   before_action :authenticate_user!, except: [:post, :show, :thread, :thread_content]
@@ -423,4 +424,4 @@ class CommentsController < ApplicationController
                              user: current_user)
   end
 end
-# rubocop:disable Metrics/ClassLength
+# rubocop:enable Metrics/ClassLength

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -276,7 +276,7 @@ class CommentsController < ApplicationController
 
   def post_follow
     @post = Post.find(params[:post_id])
-    if ThreadFollower.where(post: @post, user: current_user).count == 0
+    if ThreadFollower.where(post: @post, user: current_user).none?
       ThreadFollower.create(post: @post, user: current_user)
     end
     redirect_to post_path(@post)

--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -6,7 +6,7 @@
     ? @post_type : PostType of the post
 
     Parameters:
-    ? params[:comment_id] : Comment ID to show even if it would be hidden otherwise 
+    ? params[:comment_id] : Comment ID to show even if it would be hidden otherwise
     ? params[:thread_id]  : CommentThread ID to render expanded view for
     ? params[:sort]       : sorting type for the post's children
 
@@ -243,8 +243,8 @@
           <div class="tools">
             <%= render "shared/copy_link", classes: ["tools--item"],
                                            desc: "Copy a permanent link to this post",
-                                           id: post.id, 
-                                           md: generic_share_link_md(post), 
+                                           id: post.id,
+                                           md: generic_share_link_md(post),
                                            raw: generic_share_link(post) %>
             <%= link_to post_history_path(post), class: 'tools--item', 'aria-label': 'View history of this post' do %>
               <i class="fa fa-history"></i>
@@ -533,7 +533,7 @@
           </h4>
           <% if user_signed_in? %>
             <% if post.followed_by?(current_user) %>
-              <%= link_to follow_post_comments_path(post_id: post.id), method: :post,
+              <%= link_to unfollow_post_comments_path(post_id: post.id), method: :post,
                           class: "button is-muted is-outlined is-small",
                           title: 'Don\'t follow new comment threads on this post',
                           role: 'button',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   mount Rack::Directory.new('coverage/'), at: '/coverage' if Rails.env.development?
   mount MaintenanceTasks::Engine, at: '/maintenance'
-  
+
   scope 'admin' do
     root                                   to: 'admin#index', as: :admin
     get    'errors',                       to: 'admin#error_reports', as: :admin_error_reports
@@ -244,6 +244,7 @@ Rails.application.routes.draw do
     get    'thread/:id/followers',         to: 'comments#thread_followers', as: :comment_thread_followers
     get    'post/:post_id',                to: 'comments#post', as: :post_comments
     post   'post/:post_id/follow',         to: 'comments#post_follow', as: :follow_post_comments
+    post   'post/:post_id/unfollow',       to: 'comments#post_unfollow', as: :unfollow_post_comments
     get    ':id',                          to: 'comments#show', as: :comment
     get    'thread/:id',                   to: 'comments#thread', as: :comment_thread
     get    'thread/:id/content',           to: 'comments#thread_content', as: :comment_thread_content

--- a/test/comments_test_helpers.rb
+++ b/test/comments_test_helpers.rb
@@ -80,7 +80,7 @@ module CommentsControllerTestHelpers
   # Attempts to unfollow new threads on a given post
   # @param post [Post] post to unfollow
   def try_post_unfollow(test_post)
-    post :post_follow, params: { post_id: test_post.id }
+    post :post_unfollow, params: { post_id: test_post.id }
   end
 
   # Attempts to lock a given comment thread

--- a/test/controllers/comments/post_follow_test.rb
+++ b/test/controllers/comments/post_follow_test.rb
@@ -34,4 +34,19 @@ class CommentsControllerTest < ActionController::TestCase
     # Assert user follows post
     assert_equal 1, ThreadFollower.where(['post_id = ? AND user_id = ?', question, user]).count
   end
+
+  test 'follower cannot duplicate the following of a post' do
+    user = users(:standard_user)
+    sign_in user
+    question = posts(:question_one)
+
+    # Assert user follows post
+    assert_equal 1, ThreadFollower.where(['post_id = ? AND user_id = ?', question, user]).count
+
+    try_post_follow(question)
+    assert_response(:found)
+
+    # Assert user still only follows post once
+    assert_equal 1, ThreadFollower.where(['post_id = ? AND user_id = ?', question, user]).count
+  end
 end


### PR DESCRIPTION
Unlike following and unfollowing comment threads, which are already separate routes, following new threads on a post was using a single route that toggled the state, which could cause unintended results if accidentally called multiple times. This pull request splits it into a follow route and an unfollow route, so when the user clicks they can only get the advertised result.

AKA [idempotence](https://en.wikipedia.org/wiki/Idempotence).