### PR TITLE
Remove min length attr from the new thread title field

### DIFF
--- a/app/views/comments/_new_thread.html.erb
+++ b/app/views/comments/_new_thread.html.erb
@@ -1,11 +1,11 @@
 <%#
-  Renders new comment thread button & modal
+   "Renders new comment thread button & modal
 
-  Variables:
-    post : post to create a new thread for
-    text : text to display on the button
-    user : user that will create a new thread
-%>
+    Variables:
+      post : post to create a new thread for
+      text : text to display on the button
+      user : user that will create a new thread
+"%>
 
 <%
   can_comment = user.can_comment_on?(post)

--- a/app/views/comments/_new_thread_modal.html.erb
+++ b/app/views/comments/_new_thread_modal.html.erb
@@ -47,7 +47,6 @@
                                  markdown: 'strip' } %>
       <%= render 'shared/char_count',
                  type: "thread-title-#{post.id}",
-                 min: 1,
                  max: maximum_thread_title_length %>
 
       <%= submit_tag 'Create thread',

--- a/app/views/comments/_rename_thread_modal.html.erb
+++ b/app/views/comments/_rename_thread_modal.html.erb
@@ -1,8 +1,8 @@
 <%#
    "Helper for rendering comment thread rename action modal
 
-  Variables:
-    thread : Comment thread to create the modal for
+    Variables:
+      thread : Comment thread to create the modal for
 "%>
 
 <div class="modal is-with-backdrop is-small js--rename-thread-<%= thread.id %>">

--- a/app/views/comments/_reply_to_thread.html.erb
+++ b/app/views/comments/_reply_to_thread.html.erb
@@ -1,13 +1,13 @@
 <%#
-  Renders reply to comment thread button & input
+   "Renders reply to comment thread button & input
 
-  Variables:
-    inline : whether the reply is done via inline thread view
-    post : post the thread is for
-    text : text to display on the button
-    thread : thread to create a reply for
-    user : user that will create a reply to the thread
-%>
+    Variables:
+      inline : whether the reply is done via inline thread view
+      post : post the thread is for
+      text : text to display on the button
+      thread : thread to create a reply for
+      user : user that will create a reply to the thread
+"%>
 
 <%
   # TODO: make configurable

--- a/app/views/comments/_skip_deleted.erb
+++ b/app/views/comments/_skip_deleted.erb
@@ -1,11 +1,11 @@
 <%#
-    Renders widgets indicating that deleted comments are not shown
+   "Renders widgets indicating that deleted comments are not shown
 
     Variables:
       num_skipped : number of skipped deleted comments
       inline      : whether the thread is shown inline or not
       thread      : CommentThread to display the widget for
-%>
+"%>
 
 <div class="widget--body widget--deleted-comments" role="listitem">
   <p>

--- a/app/views/comments/_thread_follow_link.html.erb
+++ b/app/views/comments/_thread_follow_link.html.erb
@@ -1,10 +1,10 @@
 <%#
-  Helper for rendering comment thread follow/unfollow link buttons
+   "Helper for rendering comment thread follow/unfollow link buttons
 
-  Variables:
-    thread : Comment thread to create the link for
-    user : user to show the link for
-%>
+    Variables:
+      thread : Comment thread to create the link for
+      user : user to show the link for
+"%>
 
 <% if thread.followed_by?(user) %>
   <a href="#"

--- a/app/views/comments/_thread_followers_modal.html.erb
+++ b/app/views/comments/_thread_followers_modal.html.erb
@@ -1,9 +1,9 @@
 <%#
-  Helper for rendering comment thread followers action modal
+   "Helper for rendering comment thread followers action modal
 
-  Variables:
-    thread : Comment thread to create the modal for
-%>
+    Variables:
+      thread : Comment thread to create the modal for
+"%>
 
 <div class="modal is-with-backdrop is-small" id="js-followers-<%= thread.id %>">
   <div class="modal--container">

--- a/app/views/comments/_thread_tools_link.html.erb
+++ b/app/views/comments/_thread_tools_link.html.erb
@@ -1,9 +1,9 @@
 <%#
-  Helper for rendering comment thread tools link buttons
+   "Helper for rendering comment thread tools link buttons
 
-  Variables:
-    thread : Comment thread to create the link for
-%>
+    Variables:
+      thread : Comment thread to create the link for
+"%>
 
 <a href="javascript:void(0)"
    class="widget--header-link"

--- a/app/views/comments/_threads_list.html.erb
+++ b/app/views/comments/_threads_list.html.erb
@@ -1,12 +1,12 @@
 <%#
-    List of comment threads below a post.
+   "List of comment threads below a post.
 
     Variables:
       comment_threads : an Array of CommentThread instances to list
     ? comment_id      : Comment to show even if it would be hidden otherwise
     ? thread_id       : CommentThread ID to render expanded view for
     ? show_deleted    : whether to display deleted comments in the expanded view
-%>
+"%>
 
 <%
   comment_id ||= defined?(comment_id) ? comment_id : nil

--- a/app/views/comments/thread.html.erb
+++ b/app/views/comments/thread.html.erb
@@ -1,5 +1,5 @@
 <%#
-    Comment thread view.
+   "Comment thread view.
 
     Parameters:
       params[:inline]                : whether the parent thread is displayed inline
@@ -8,7 +8,7 @@
     Instance variables:
       @comment_thread : CommentThread to display
       @post           : Post the thread belongs to
-%>
+"%>
 
 <h1>Comments on
   <a href="<%= generic_share_link(@post) %>"><%= @post.title.blank? && @post.parent.present? ? @post.parent.title : @post.title %></a>


### PR DESCRIPTION
closes #1799 

Overfixed #1731 a bit - `min` is not needed on the create new thread field

As it's an extremely minor fix, the rest of the PR is just a bunch of fixes for the comment docs for our views.
In case someone wonders what's that all about, this is how our comments look otherwise (and the rest of the views' highlighting breaks as well):

<img width="502" height="112" alt="image" src="https://github.com/user-attachments/assets/11580293-0a5c-48ed-987f-c5056fc48c0b" />

As opposed to how it's expected to look like:

<img width="502" height="112" alt="image" src="https://github.com/user-attachments/assets/0a7382cc-bbfc-4123-867f-614bcd67cdc4" />

