### PR TITLE
Fix for inbox notifications community_name

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -11,8 +11,9 @@ class NotificationsController < ApplicationController
       format.html { render :index, layout: 'without_sidebar' }
       format.json do
         render json: (@notifications.to_a.map do |notif|
-          notif.as_json.merge(content: helpers.render_pings_text(notif.content))
-        end), methods: :community_name
+          notif.as_json.merge(content: helpers.render_pings_text(notif.content),
+                              community_name: notif.community_name)
+        end)
       end
     end
   end

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -5,9 +5,26 @@ class NotificationsControllerTest < ActionController::TestCase
 
   test 'should get index as JSON' do
     sign_in users(:standard_user)
-    get :index, params: { format: :json }
-    assert_not_nil assigns(:notifications)
-    assert_response(:success)
+
+    [:json, :html].each do |format|
+      try_index(format: format)
+
+      assert_response(:success)
+
+      if format == :html
+        @notifications = assigns(:notifications)
+        assert_not_nil @notifications
+      else
+        assert_valid_json_response
+        notifications = JSON.parse(response.body)
+
+        notifications.each do |notification|
+          assert notification['content'].present?
+          assert notification['community_name'].present?
+        end
+
+      end
+    end
   end
 
   test 'should mark notification as read' do
@@ -40,5 +57,11 @@ class NotificationsControllerTest < ActionController::TestCase
     sign_out :user
     get :index, params: { format: :json }
     assert_response(:unauthorized) # Devise seems to respond 401 for JSON requests.
+  end
+
+  private
+
+  def try_index(format: :json)
+    get :index, params: { format: format }
   end
 end


### PR DESCRIPTION
Forgot that `methods` does not work on JSON and silently fails otherwise leading to `community_name` being `undefined`.

<img width="420" height="263" alt="Screenshot from 2025-08-17 22-25-58" src="https://github.com/user-attachments/assets/d75c7669-347b-484d-a5d8-b05422d73ee8" />

This PR also ensures we actually test that the notifications are returned in a valid format.