### PR TITLE
Allow <kbd> tags to be rendered in posts

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -263,8 +263,8 @@ $(() => {
         const converter = window.converter;
         const unsafe_html = converter.render(text);
         const html = DOMPurify.sanitize(unsafe_html, {
-          ALLOWED_TAGS: QPIXEL_ALLOWED_POST_TAGS,
-          ALLOWED_ATTR: QPIXEL_ALLOWED_POST_ATTRS
+          ALLOWED_TAGS: QPixel.ALLOWED_POST_TAGS,
+          ALLOWED_ATTR: QPixel.ALLOWED_POST_ATTRS
         });
 
         const removedElements = [...new Set(DOMPurify.removed

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -1,9 +1,3 @@
-// IF YOU CHANGE THESE VALUES YOU MUST ALSO CHANGE app/helpers/posts_helper.rb
-const ALLOWED_TAGS = ['a', 'p', 'span', 'b', 'i', 'em', 'strong', 'hr', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-  'blockquote', 'img', 'strike', 'del', 'code', 'pre', 'br', 'ul', 'ol', 'li', 'sup', 'sub', 'section', 'details',
-  'summary', 'ins', 'table', 'thead', 'tbody', 'tr', 'th', 'td', 's'];
-const ALLOWED_ATTR = ['id', 'class', 'href', 'title', 'src', 'height', 'width', 'alt', 'rowspan', 'colspan', 'lang',
-  'start', 'dir'];
 // this is a list of constructors to ignore even if they are removed by sanitizer (mostly comments & body)
 const IGNORE_UNSUPPORTED = [Comment, HTMLBodyElement];
 
@@ -269,8 +263,8 @@ $(() => {
         const converter = window.converter;
         const unsafe_html = converter.render(text);
         const html = DOMPurify.sanitize(unsafe_html, {
-          ALLOWED_TAGS,
-          ALLOWED_ATTR
+          ALLOWED_TAGS: QPIXEL_ALLOWED_POST_TAGS,
+          ALLOWED_ATTR: QPIXEL_ALLOWED_POST_ATTRS
         });
 
         const removedElements = [...new Set(DOMPurify.removed

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -294,16 +294,19 @@ kbd {
     style: solid;
     width: 1px;
   };
-  font-family: $font-stack-code;
-  font-size: map-get($font-sizes, 'sm');
+  font: {
+    family: $font-stack-code;
+    size: map-get($font-sizes, 'xxs');
+  };
   margin: {
     left: 0.15em;
     right: 0.15em;
   };
   padding: {
-    top: 0.15em;
-    bottom: 0.15em;
-    left: 0.5em;
-    right: 0.5em;
+    top: 0.1em;
+    bottom: 0.1em;
+    left: 0.25em;
+    right: 0.25em;
   };
+  vertical-align: text-bottom;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -286,3 +286,24 @@ mjx-container {
     overflow-x: auto;
     overflow-y: hidden;
 }
+
+kbd {
+  border: {
+    color: $muted-graphic;
+    radius: 0.25em;
+    style: solid;
+    width: 1px;
+  };
+  font-family: $font-stack-code;
+  font-size: map-get($font-sizes, 'sm');
+  margin: {
+    left: 0.15em;
+    right: 0.15em;
+  };
+  padding: {
+    top: 0.15em;
+    bottom: 0.15em;
+    left: 0.5em;
+    right: 0.5em;
+  };
+}

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -80,7 +80,7 @@ module PostsHelper
     ALLOWED_ATTRS = %w[id class href title src height width alt rowspan colspan lang start dir].freeze
 
     ALLOWED_TAGS = %w[a p span b i em strong hr h1 h2 h3 h4 h5 h6 blockquote img
-                      strike del code pre br ul ol li sup sub
+                      strike del code pre br ul ol li sup sub kbd
                       section details summary ins table thead tbody tr th td s].freeze
 
     def initialize

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -77,12 +77,16 @@ module PostsHelper
   end
 
   class PostScrubber < Rails::Html::PermitScrubber
+    ALLOWED_ATTRS = %w[id class href title src height width alt rowspan colspan lang start dir].freeze
+
+    ALLOWED_TAGS = %w[a p span b i em strong hr h1 h2 h3 h4 h5 h6 blockquote img
+                      strike del code pre br ul ol li sup sub
+                      section details summary ins table thead tbody tr th td s].freeze
+
     def initialize
       super
-      # IF YOU CHANGE THESE VALUES YOU MUST ALSO CHANGE app/assets/javascripts/posts.js
-      self.tags = %w[a p span b i em strong hr h1 h2 h3 h4 h5 h6 blockquote img strike del code pre br ul ol li sup sub
-                     section details summary ins table thead tbody tr th td s]
-      self.attributes = %w[id class href title src height width alt rowspan colspan lang start dir]
+      self.tags = ALLOWED_TAGS
+      self.attributes = ALLOWED_ATTRS
     end
 
     def skip_node?(node)

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -36,8 +36,17 @@
 <script src="https://cdn.jsdelivr.net/npm/@codidact/co-design@latest/js/co-design.js" defer></script>
 
 <script type="application/javascript">
-  window.QPIXEL_ALLOWED_POST_ATTRS = Object.freeze(<%= raw PostsHelper::PostScrubber::ALLOWED_ATTRS %>);
-  window.QPIXEL_ALLOWED_POST_TAGS = Object.freeze(<%= raw PostsHelper::PostScrubber::ALLOWED_TAGS %>);
+  Object.defineProperty(window, 'QPIXEL_ALLOWED_POST_ATTRS', {
+    configurable: false,
+    value: Object.freeze(<%= raw PostsHelper::PostScrubber::ALLOWED_ATTRS %>),
+    writable: false,
+  });
+
+  Object.defineProperty(window, 'QPIXEL_ALLOWED_POST_TAGS', {
+    configurable: false,
+    value: Object.freeze(<%= raw PostsHelper::PostScrubber::ALLOWED_TAGS %>),
+    writable: false,
+  });
 </script>
 
 <% if SiteSetting['SyntaxHighlightingEnabled'] %>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -36,13 +36,15 @@
 <script src="https://cdn.jsdelivr.net/npm/@codidact/co-design@latest/js/co-design.js" defer></script>
 
 <script type="application/javascript">
-  Object.defineProperty(window, 'QPIXEL_ALLOWED_POST_ATTRS', {
+  window.QPixel ||= {};
+
+  Object.defineProperty(QPixel, 'ALLOWED_POST_ATTRS', {
     configurable: false,
     value: Object.freeze(<%= raw PostsHelper::PostScrubber::ALLOWED_ATTRS %>),
     writable: false,
   });
 
-  Object.defineProperty(window, 'QPIXEL_ALLOWED_POST_TAGS', {
+  Object.defineProperty(QPixel, 'ALLOWED_POST_TAGS', {
     configurable: false,
     value: Object.freeze(<%= raw PostsHelper::PostScrubber::ALLOWED_TAGS %>),
     writable: false,

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -35,6 +35,11 @@
 <%= javascript_include_tag 'application' %>
 <script src="https://cdn.jsdelivr.net/npm/@codidact/co-design@latest/js/co-design.js" defer></script>
 
+<script type="application/javascript">
+  window.QPIXEL_ALLOWED_POST_ATTRS = Object.freeze(<%= raw PostsHelper::PostScrubber::ALLOWED_ATTRS %>);
+  window.QPIXEL_ALLOWED_POST_TAGS = Object.freeze(<%= raw PostsHelper::PostScrubber::ALLOWED_TAGS %>);
+</script>
+
 <% if SiteSetting['SyntaxHighlightingEnabled'] %>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/default.min.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/highlight.min.js"></script>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -5,11 +5,11 @@
       post          : a Post instance to work on (either via .new or .find - doesn't matter if it has content or not)
       submit_path   : the URL to submit the form to (must accept POST requests)
       post_type     : a PostType instance describing the requested post type
-      category      : a Category instance, required if the post type has a category, indicating which category to post in
-      parent        : a Post instance containing the parent for this post (required if the post type has a parent)
-      inline_parent : optional, default  true: display an inline copy of the parent? (if present)
-      type_summary  : optional, default  true: display a summary of the requested post type?
-      edit_comment  : optional, default false: include a field for an edit comment?
+    ? category      : a Category instance, required if the post type has a category, indicating which category to post in
+    ? parent        : a Post instance containing the parent for this post (required if the post type has a parent)
+    ? inline_parent : optional, default  true: display an inline copy of the parent? (if present)
+    ? type_summary  : optional, default  true: display a summary of the requested post type?
+    ? edit_comment  : optional, default false: include a field for an edit comment?
 "%>
 
 <%

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -92,8 +92,6 @@ sorted.each do |f, type|
       end
 
       if type == Post && ENV['UPDATE_POSTS'] == 'true'
-        puts "Running full Posts update..."
-
         seed['body'] = ApplicationController.helpers.render_markdown(seed['body_markdown'])
 
         system_usr = User.find(-1)

--- a/db/seeds/posts/advanced-formatting.html
+++ b/db/seeds/posts/advanced-formatting.html
@@ -1,86 +1,123 @@
-<p
-    >Posts on Codidact, including questions, answers, articles, tag wikis, help pages, and user
-    profiles, support the use of the following HTML tags:</p
->
+<p>
+  Posts, including questions, answers, articles, tag wikis, help pages, and user profiles, support the use of the
+  following HTML tags:
+</p>
 <ul>
-    <li><code>a</code></li>
-    <li><code>p</code></li>
-    <li><code>span</code></li>
-    <li><code>b</code></li>
-    <li><code>i</code></li>
-    <li><code>em</code></li>
-    <li><code>s</code></li>
-    <li><code>strong</code></li>
-    <li><code>hr</code></li>
-    <li
-        ><code>h1</code>, <code>h2</code>, <code>h3</code>, <code>h4</code>, <code>h5</code>,
-        <code>h6</code></li
-    >
-    <li><code>blockquote</code></li>
-    <li><code>img</code></li>
-    <li><code>strike</code></li>
-    <li><code>del</code>, <code>ins</code></li>
-    <li><code>code</code></li>
-    <li><code>pre</code></li>
-    <li><code>br</code></li>
-    <li><code>ul</code>, <code>ol</code>, <code>li</code></li>
-    <li><code>sup</code>, <code>sub</code></li>
-    <li><code>section</code></li>
-    <li><code>details</code>, <code>summary</code></li>
-    <li
-        ><code>table</code>, <code>thead</code>, <code>tbody</code>, <code>tr</code>,
-        <code>th</code>, <code>td</code></li
-    >
+  <li><code>a</code></li>
+  <li><code>p</code></li>
+  <li><code>span</code></li>
+  <li><code>b</code></li>
+  <li><code>i</code></li>
+  <li><code>em</code></li>
+  <li><code>s</code></li>
+  <li><code>strong</code></li>
+  <li><code>hr</code></li>
+  <li>
+    <code>h1</code>
+    ,
+    <code>h2</code>
+    ,
+    <code>h3</code>
+    ,
+    <code>h4</code>
+    ,
+    <code>h5</code>
+    ,
+    <code>h6</code>
+  </li>
+  <li><code>blockquote</code></li>
+  <li><code>img</code></li>
+  <li><code>strike</code></li>
+  <li>
+    <code>del</code>
+    ,
+    <code>ins</code>
+  </li>
+  <li><code>code</code></li>
+  <li><code>pre</code></li>
+  <li><code>br</code></li>
+  <li>
+    <code>ul</code>
+    ,
+    <code>ol</code>
+    ,
+    <code>li</code>
+  </li>
+  <li>
+    <code>sup</code>
+    ,
+    <code>sub</code>
+  </li>
+  <li><code>section</code></li>
+  <li>
+    <code>details</code>
+    ,
+    <code>summary</code>
+  </li>
+  <li>
+    <code>table</code>
+    ,
+    <code>thead</code>
+    ,
+    <code>tbody</code>
+    ,
+    <code>tr</code>
+    ,
+    <code>th</code>
+    ,
+    <code>td</code>
+  </li>
 </ul>
 <p>These tags may have the following attributes:</p>
 <ul>
-    <li><code>id</code></li>
-    <li><code>class</code></li>
-    <li><code>href</code></li>
-    <li><code>title</code></li>
-    <li><code>src</code></li>
-    <li><code>height</code></li>
-    <li><code>width</code></li>
-    <li><code>alt</code></li>
-    <li><code>dir</code></li>
-    <li><code>lang</code></li>
-    <li><code>start</code></li>
-    <li><code>rowspan</code></li>
-    <li><code>colspan</code></li>
+  <li><code>id</code></li>
+  <li><code>class</code></li>
+  <li><code>href</code></li>
+  <li><code>title</code></li>
+  <li><code>src</code></li>
+  <li><code>height</code></li>
+  <li><code>width</code></li>
+  <li><code>alt</code></li>
+  <li><code>dir</code></li>
+  <li><code>lang</code></li>
+  <li><code>start</code></li>
+  <li><code>rowspan</code></li>
+  <li><code>colspan</code></li>
 </ul>
 <p>Shorter text forms, such as comments, support the following HTML tags:</p>
 <ul>
-    <li><code>a</code></li>
-    <li><code>b</code></li>
-    <li><code>i</code></li>
-    <li><code>em</code></li>
-    <li><code>strong</code></li>
-    <li><code>strike</code></li>
-    <li><code>del</code></li>
-    <li><code>code</code></li>
+  <li><code>a</code></li>
+  <li><code>b</code></li>
+  <li><code>i</code></li>
+  <li><code>em</code></li>
+  <li><code>strong</code></li>
+  <li><code>strike</code></li>
+  <li><code>del</code></li>
+  <li><code>code</code></li>
 </ul>
 <p>These tags may have the following attributes:</p>
 <ul>
-    <li><code>href</code></li>
-    <li><code>title</code></li>
+  <li><code>href</code></li>
+  <li><code>title</code></li>
 </ul>
 <hr />
-<p
-    >HTML tags that do not appear on this list will be stripped out and not displayed if they are
-    included in posts or comments. The source code for supported tags in posts can be found in
-    <a href="https://github.com/codidact/qpixel/blob/develop/app/helpers/posts_helper.rb#L46"
-        ><code>posts_helper.rb</code></a
-    >, and for comments in
-    <a href="https://github.com/codidact/qpixel/blob/develop/app/helpers/comments_helper.rb#L81"
-        ><code>comments_helper.rb</code></a
-    >.</p
->
+<p>
+  HTML tags not on this list will be stripped out and not displayed if they are included in posts or comments. The
+  source code for supported tags in posts can be found in
+  <a href="https://github.com/codidact/qpixel/blob/develop/app/helpers/posts_helper.rb#L79">
+    <code>posts_helper.rb</code>
+  </a>
+  , and for comments in
+  <a href="https://github.com/codidact/qpixel/blob/develop/app/helpers/comments_helper.rb#L195">
+    <code>comments_helper.rb</code>
+  </a>
+  .
+</p>
 <hr />
-<p
-    ><sub
-        >Much of the content of this page came from
-        <a href="https://meta.codidact.com/posts/277420/277424#answer-277424"
-            >this answer by luap42</a
-        >.</sub
-    ></p
->
+<p>
+  <sub>
+    Much of the content of this page came from
+    <a href="https://meta.codidact.com/posts/277420/277424#answer-277424">this answer by luap42</a>
+    .
+  </sub>
+</p>

--- a/db/seeds/posts/advanced-formatting.html
+++ b/db/seeds/posts/advanced-formatting.html
@@ -34,6 +34,7 @@
     <code>ins</code>
   </li>
   <li><code>code</code></li>
+  <li><code>kbd</code></li>
   <li><code>pre</code></li>
   <li><code>br</code></li>
   <li>

--- a/global.d.ts
+++ b/global.d.ts
@@ -182,6 +182,17 @@ interface GetThreadContentOptions {
 }
 
 interface QPixel {
+  // constants
+
+  /**
+   * List of HTML tags allowed in posts, supplied by the server
+   */
+  readonly ALLOWED_POST_TAGS?: readonly string[]
+  /**
+   * List of attributes allowed on HTML tags in posts, supplied by the server
+   */
+  readonly ALLOWED_POST_ATTRS?: readonly string[]
+
   // private properties
   _filters?: Filter[] | null;
   _pendingUserResponse?: Promise<Response> | null;
@@ -458,12 +469,3 @@ interface Window {
   markdownit?: (...args: any[]) => any;
   markdownitFootnote?: (...args: any[]) => any;
 }
-
-/**
- * List of HTML tags allowed in posts, supplied by the server
- */
-declare var QPIXEL_ALLOWED_POST_TAGS: readonly string[]
-/**
- * List of attributes allowed on HTML tags in posts, supplied by the server
- */
-declare var QPIXEL_ALLOWED_POST_ATTRS: readonly string[]

--- a/global.d.ts
+++ b/global.d.ts
@@ -458,3 +458,12 @@ interface Window {
   markdownit?: (...args: any[]) => any;
   markdownitFootnote?: (...args: any[]) => any;
 }
+
+/**
+ * List of HTML tags allowed in posts, supplied by the server
+ */
+declare var QPIXEL_ALLOWED_POST_TAGS: readonly string[]
+/**
+ * List of attributes allowed on HTML tags in posts, supplied by the server
+ */
+declare var QPIXEL_ALLOWED_POST_ATTRS: readonly string[]


### PR DESCRIPTION
closes #1804 
closes #1596

This PR allows `<kbd>` HTML tags to be used in posts (to be more precise, it allows their rendering, we don't scrub them from Markdown). Not married to any particular styling, so open to suggestions:

<img width="750" height="258" alt="Screenshot from 2025-08-24 21-39-27" src="https://github.com/user-attachments/assets/94d0d02f-ece0-4188-83c9-0ddfa6ea7ab1" />


It also solves the issue of having to keep `ALLOWED_TAGS` + `ALLOWED_ATTR` in our JS assets synced with the `PostScurbber`'s corresponding lists. The server now defines two global **non-deletable non-writable non-changable** constants on the `QPixel` global object: `ALLOWED_POST_TAGS` and `ALLOWED_POST_ATTRS` respectively which are auto-populated with the server-provided values.

Note that it also updates an HC seed for advanced formatting, so `UPDATE_POSTS=true rails db:seed` should be run (but is not required).
