### PR TITLE
Improvements to site settings wrapping

### DIFF
--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -44,46 +44,23 @@ class SiteSetting < ApplicationRecord
       SiteSetting.where(name: name).any?
   end
 
-  # Checks whether the setting is a global site setting
-  # @return [Boolean]
+  # Is the setting global?
+  # @return [Boolean] check result
   def global?
     community_id.nil?
   end
 
-  # Is the setting array-valued?
-  # @return [Boolean] check result
-  def array?
-    value_type.downcase == 'array'
+  # Defines predicates for each value type
+  [:array, :boolean, :float, :integer, :string, :text].each do |method|
+    define_method "#{method}?" do
+      value_type.downcase.to_sym == method
+    end
   end
 
-  # Is the setting boolean-valued?
+  # Is the setting numeric-valued?
   # @return [Boolean] check result
-  def boolean?
-    value_type.downcase == 'boolean'
-  end
-
-  # Is the setting floating point number-valued?
-  # @return [Boolean] check result
-  def float?
-    value_type.downcase == 'float'
-  end
-
-  # Is the setting integer-valued?
-  # @return [Boolean] check result
-  def integer?
-    value_type.downcase == 'integer'
-  end
-
-  # Is the setting string-valued (plain text)?
-  # @return [Boolean] check result
-  def string?
-    value_type.downcase == 'string'
-  end
-
-  # Is the setting text-valued (HTML-aware text)?
-  # @return [Boolean] check result
-  def text?
-    value_type.downcase == 'text'
+  def numeric?
+    float? || integer?
   end
 
   def typed

--- a/app/views/site_settings/index.html.erb
+++ b/app/views/site_settings/index.html.erb
@@ -27,7 +27,7 @@
               <div class="form-caption"><%= setting.description %></div>
             </td>
             <% nowrap = setting.boolean? || setting.numeric? %>
-            <td class="site-setting--value js-setting-value<%= ' nowrap' if nowrap %>"
+            <td class="site-setting--value js-setting-value<%= nowrap ? ' nowrap' : ' wrap-word' %>"
                 data-type="<%= setting.value_type %>" data-name="<%= setting.name %>"
                 data-community-id="<%= current_page?(global_settings_path) ? nil : RequestContext.community_id %>">
               <%= setting.typed %>

--- a/app/views/site_settings/index.html.erb
+++ b/app/views/site_settings/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, 'Site Settings' %>
 
-<h1><%= current_page?(global_settings_path) ? 'Global' : '' %> Site Settings</h1>
+<h1><%= 'Global' if current_page?(global_settings_path)%> Site Settings</h1>
 <p>
   The settings on this page control various aspects of the display or operation of the site. Change these
   rarely and with care. Bear in mind that setting changes will generally not be retroactive - so if you change
@@ -26,7 +26,7 @@
               <h4><%= setting.name %></h4>
               <div class="form-caption"><%= setting.description %></div>
             </td>
-            <td class="site-setting--value js-setting-value<%= setting.text? ? '' : ' nowrap' %>"
+            <td class="site-setting--value js-setting-value<%= ' nowrap' if setting.text? %>"
                 data-type="<%= setting.value_type %>" data-name="<%= setting.name %>"
                 data-community-id="<%= current_page?(global_settings_path) ? nil : RequestContext.community_id %>">
               <%= setting.typed %>

--- a/app/views/site_settings/index.html.erb
+++ b/app/views/site_settings/index.html.erb
@@ -12,7 +12,7 @@
 <% @settings.each do |category, settings| %>
   <details>
     <summary><%= category&.underscore&.humanize || 'Uncategorized' %></summary>
-    <table class="table is-full-width">
+    <table class="table fixed is-full-width">
       <tbody>
         <% settings.each do |setting| %>
           <tr>

--- a/app/views/site_settings/index.html.erb
+++ b/app/views/site_settings/index.html.erb
@@ -23,7 +23,7 @@
                 <span class="badge is-tag">site</span>
               <% end %>
               <span class="badge is-tag"><%= setting.value_type %></span>
-              <h4><%= setting.name %></h4>
+              <h4 class="nowrap"><%= setting.name %></h4>
               <div class="form-caption"><%= setting.description %></div>
             </td>
             <% nowrap = setting.boolean? || setting.numeric? %>

--- a/app/views/site_settings/index.html.erb
+++ b/app/views/site_settings/index.html.erb
@@ -26,7 +26,8 @@
               <h4><%= setting.name %></h4>
               <div class="form-caption"><%= setting.description %></div>
             </td>
-            <td class="site-setting--value js-setting-value<%= ' nowrap' if setting.text? %>"
+            <% nowrap = setting.boolean? || setting.numeric? %>
+            <td class="site-setting--value js-setting-value<%= ' nowrap' if nowrap %>"
                 data-type="<%= setting.value_type %>" data-name="<%= setting.name %>"
                 data-community-id="<%= current_page?(global_settings_path) ? nil : RequestContext.community_id %>">
               <%= setting.typed %>

--- a/test/fixtures/site_settings.yml
+++ b/test/fixtures/site_settings.yml
@@ -13,6 +13,16 @@ int:
   value: 42
   value_type: integer
 
+float:
+  name: SettingWithFloatValue
+  value: 3.14
+  value_type: float
+
+string:
+  name: SettingWithStringValue
+  value: plain text value
+  value_type: string
+
 text:
   name: SettingWithTextValue
   value: "<p>a paragraph of text</p>"

--- a/test/models/site_setting_test.rb
+++ b/test/models/site_setting_test.rb
@@ -54,11 +54,18 @@ class SiteSettingTest < ActiveSupport::TestCase
     assert_equal SiteSetting.where(name: 'test').first, setting1
   end
 
-  test 'text? should correctly check if the setting accepts long text values' do
-    text_setting = site_settings(:text)
-    int_setting = site_settings(:int)
+  test 'type predicates should correctly check the setting\'s value type' do
+    [:array, :boolean, :float, :integer, :string, :text].each do |method|
+      site_settings.each do |setting|
+        assert_equal setting.value_type == method.to_s, setting.send("#{method}?")
+      end
+    end
+  end
 
-    assert_equal text_setting.text?, true
-    assert_equal int_setting.text?, false
+  test 'numeric? should correctly check if the setting\'s value is numeric' do
+    assert site_settings(:int).numeric?
+    assert site_settings(:float).numeric?
+    assert_not site_settings(:string).numeric?
+    assert_not site_settings(:text).numeric?
   end
 end


### PR DESCRIPTION
closes #1809

This PR applies normal wrapping rules to string & text values, while keeping the nowrap behavior for `boolean` and numeric (`integer` and `float`) types (as it doesn't make sense to wrap those). It also switches the table to the "fixed" layout preventing the width from jumping around depending on content size:

<img width="750" height="258" alt="Screenshot from 2025-08-26 01-32-59" src="https://github.com/user-attachments/assets/c0a51026-3d47-44f6-bcb6-b2a61430f23e" />
