### PR TITLE
Eager load improvements for post lists

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -261,7 +261,7 @@ class ApplicationController < ActionController::Base
     end
 
     # eager loading revived collections' used relation to prevent N+1 queries
-    @pinned_links = @pinned_links.includes(post: [:community])
+    @pinned_links = @pinned_links.list_includes
     @hot_questions = @hot_questions.list_includes
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -259,6 +259,10 @@ class ApplicationController < ActionController::Base
             .order('score DESC').limit(SiteSetting['HotQuestionsCount']).all
       end
     end
+
+    # eager loading revived collections' used relation to prevent N+1 queries
+    @pinned_links = @pinned_links.includes(post: [:community])
+    @hot_questions = @hot_questions.list_includes
   end
 
   def pull_categories

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -167,8 +167,10 @@ class CategoriesController < ApplicationController
                               SiteSetting['LotteryAgeDeprecationSpeed']],
                     native: Arel.sql('att_source IS NULL DESC, last_activity DESC') }
     sort_param = sort_params[params[:sort]&.to_sym] || { last_activity: :desc }
-    @posts = @category.posts.undeleted.where(post_type_id: @category.display_post_types)
-                      .includes(:post_type, :tags).list_includes
+    @posts = @category.posts
+                      .undeleted
+                      .where(post_type_id: @category.display_post_types)
+                      .list_includes
     filter_qualifiers = helpers.params_to_qualifiers(params)
     @active_filter = helpers.active_filter
 

--- a/app/models/pinned_link.rb
+++ b/app/models/pinned_link.rb
@@ -2,6 +2,10 @@ class PinnedLink < ApplicationRecord
   include MaybeCommunityRelated
   belongs_to :post, optional: true
 
+  scope :list_includes, lambda {
+    includes(:post, post: [:community])
+  }
+
   validate :check_post_or_url
 
   # Is the link time-constrained?

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -51,7 +51,7 @@ class Post < ApplicationRecord
   scope :parent_by, ->(user) { includes(:parent).where(parents_posts: { user_id: user.id }) }
   scope :qa_only, -> { where(post_type_id: [Question.post_type_id, Answer.post_type_id, Article.post_type_id]) }
   scope :list_includes, lambda {
-                          includes(:user, :tags, :post_type, :category, :last_activity_by,
+                          includes(:user, :tags, :post_type, :category, :community, :last_activity_by,
                                    user: :avatar_attachment)
                         }
   scope :has_duplicates, -> { joins(:inbound_duplicates) } # uses INNER JOIN by default so no where required

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -52,6 +52,7 @@ class Post < ApplicationRecord
   scope :qa_only, -> { where(post_type_id: [Question.post_type_id, Answer.post_type_id, Article.post_type_id]) }
   scope :list_includes, lambda {
                           includes(:user, :tags, :post_type, :category, :community, :last_activity_by,
+                                   category: [:moderator_tags, :required_tags, :topic_tags],
                                    user: :avatar_attachment)
                         }
   scope :has_duplicates, -> { joins(:inbound_duplicates) } # uses INNER JOIN by default so no where required

--- a/app/views/posts/_list.html.erb
+++ b/app/views/posts/_list.html.erb
@@ -1,6 +1,3 @@
-<%# is_question = post.post_type_id == Question.post_type_id %>
-<%# is_article = post.post_type_id == Article.post_type_id %>
-<%# is_meta = (is_question && post.meta?) || (!is_question && post.parent&.meta?) %>
 <% @show_type_tag = !!defined?(show_type_tag) ? show_type_tag : false %>
 <% @show_category_tag = !!defined?(show_category_tag) ? show_category_tag : false %>
 <% @last_activity = !!defined?(last_activity) ? last_activity : true %>


### PR DESCRIPTION
This PR ensures we eager load associations used in post lists to avoid N+1 queries when loading category post lists. In particular, it significantly reduces the amount of queries made by `generic_share_link` (that needs `community`) and category tag ids getters (that need respective tags).