### PR TITLE
JSON response handling improvements

### DIFF
--- a/app/assets/javascripts/filters.js
+++ b/app/assets/javascripts/filters.js
@@ -122,7 +122,7 @@ $(() => {
     async function saveFilter() {
       if (!$form[0].reportValidity()) { return; }
 
-      const filter = /** @type {QPixelFlag} */({});
+      const filter = /** @type {QPixelFilter} */({});
 
       for (const el of $formFilters) {
         filter[el.dataset.name] = $(el).val();

--- a/app/assets/javascripts/notifications.js
+++ b/app/assets/javascripts/notifications.js
@@ -21,6 +21,9 @@ $(() => {
     return template;
   };
 
+  /**
+   * @param {number} change 
+   */
   const changeInboxCount = (change) => {
     const counter = $('.inbox-count');
     let count;

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -239,12 +239,6 @@ window.QPixel = {
     return data.name;
   },
 
-  setFilterAsDefault: async (categoryId, name) => {
-    await QPixel.fetchJSON(`/categories/${categoryId}/filters/default`, { name }, {
-      headers: { 'Accept': 'application/json' }
-    });
-  },
-
   setFilter: async (name, filter, category, isDefault) => {
     const resp = await QPixel.fetchJSON('/users/me/filters',
       Object.assign(filter, {name, category, is_default: isDefault}), {

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -414,7 +414,7 @@ window.QPixel = {
     const is_success = data.status === 'success';
 
     if (is_success) {
-      onSuccess(data);
+      onSuccess(/** @type {Extract<typeof data, { status: 'success' }>} */(data));
     }
     else {
       QPixel.createNotification('danger', data.message);
@@ -503,6 +503,14 @@ window.QPixel = {
     const resp = await QPixel.fetchJSON(`/categories/${categoryId}/tags/${tagId}/rename`, { name }, {
       headers: { 'Accept': 'application/json' }
     });
+
+    const data = await resp.json();
+
+    return data;
+  },
+
+  retractVote: async (id) => {
+    const resp = await QPixel.fetchJSON(`/votes/${id}`, {}, { method: 'DELETE' });
 
     const data = await resp.json();
 

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -110,7 +110,7 @@ window.QPixel = {
   },
 
   /**
-   * @type {QPixelFlag[]|null}
+   * @type {QPixelFilter[]|null}
    */
   _filters: null,
 
@@ -250,16 +250,14 @@ window.QPixel = {
       Object.assign(filter, {name, category, is_default: isDefault}), {
         headers: { 'Accept': 'application/json' }
       });
+
+    /** @type {QPixelResponseJSON<{ filters: QPixelFilter[] }>} */
+    const data = await QPixel.parseJSONResponse(resp, 'Failed to save filter');
     
-    const data = await resp.json();
-    if (data.status !== 'success') {
-      console.error(`Filter persist failed (${name})`);
-      console.error(resp);
-    }
-    else {
+    QPixel.handleJSONResponse(data, (data) => {
       this._filters = data.filters;
       QPixel.Storage?.set('user_filters', this._filters);
-    }
+    });
   },
 
   deleteFilter: async (name, system = false) => {

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -410,6 +410,24 @@ window.QPixel = {
     return content;
   },
 
+  parseJSONResponse: async (response, errorMessage) => {
+    try {
+      const data = await response.json();
+
+      return data;
+    }
+    catch (error) {
+      if (response.ok) {
+        console.error(error);
+      }
+
+      return {
+        status: 'failed',
+        message: errorMessage
+      };
+    }
+  },
+
   handleJSONResponse: (data, onSuccess, onFinally) => {
     const is_modified = data.status === 'modified';
     const is_success = data.status === 'success';
@@ -431,9 +449,7 @@ window.QPixel = {
       headers: { 'Accept': 'application/json' }
     });
 
-    const data = await resp.json();
-
-    return data;
+    return QPixel.parseJSONResponse(resp, 'Failed to flag');
   },
 
   vote: async (postId, voteType) => {
@@ -442,9 +458,7 @@ window.QPixel = {
       vote_type: voteType
     });
 
-    const data = await resp.json();
-
-    return data;
+    return QPixel.parseJSONResponse(resp, 'Failed to vote');
   },
 
   deleteComment: async (id) => {
@@ -453,9 +467,7 @@ window.QPixel = {
       method: 'DELETE'
     });
 
-    const data = await resp.json();
-
-    return data;
+    return QPixel.parseJSONResponse(resp, 'Failed to delete comment');
   },
 
   followComments: async (postId) => {
@@ -463,9 +475,7 @@ window.QPixel = {
       headers: { 'Accept': 'application/json' }
     });
 
-    const data = await resp.json();
-
-    return data;
+    return QPixel.parseJSONResponse(resp, 'Failed to follow post comments');
   },
 
   deleteDraft: async () => {
@@ -475,9 +485,7 @@ window.QPixel = {
       headers: { 'Accept': 'application/json' }
     });
 
-    const data = await resp.json();
-
-    return data;
+    return QPixel.parseJSONResponse(resp, 'Failed to delete post draft');
   },
 
   undeleteComment: async (id) => {
@@ -486,9 +494,7 @@ window.QPixel = {
       method: 'PATCH'
     });
 
-    const data = await resp.json();
-
-    return data;
+    return QPixel.parseJSONResponse(resp, 'Failed to undelete comment');
   },
 
   unfollowComments: async (postId) => {
@@ -496,9 +502,7 @@ window.QPixel = {
       headers: { 'Accept': 'application/json' }
     });
 
-    const data = await resp.json();
-
-    return data;
+    return QPixel.parseJSONResponse(resp, 'Failed to unfollow post comments');
   },
 
   lockThread: async (id) => {
@@ -506,9 +510,7 @@ window.QPixel = {
       type: 'lock'
     });
 
-    const data = await resp.json();
-
-    return data;
+    return QPixel.parseJSONResponse(resp, 'Failed to lock thread');
   },
 
   renameTag: async (categoryId, tagId, name) => {
@@ -516,17 +518,13 @@ window.QPixel = {
       headers: { 'Accept': 'application/json' }
     });
 
-    const data = await resp.json();
-
-    return data;
+    return QPixel.parseJSONResponse(resp, 'Failed to rename tag');
   },
 
   retractVote: async (id) => {
     const resp = await QPixel.fetchJSON(`/votes/${id}`, {}, { method: 'DELETE' });
 
-    const data = await resp.json();
-
-    return data;
+    return QPixel.parseJSONResponse(resp, 'Failed to retract vote');
   },
 
   saveDraft: async (draft) => {
@@ -535,8 +533,6 @@ window.QPixel = {
       path: location.pathname
     });
 
-    const data = await resp.json();
-
-    return data;
+    return QPixel.parseJSONResponse(resp, 'Failed to save draft');
   },
 };

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -206,7 +206,8 @@ window.QPixel = {
       headers: { 'Accept': 'application/json' }
     });
 
-    const data = await resp.json();
+    /** @type {QPixelResponseJSON<{ preferences: UserPreferences }>} */
+    const data = await QPixel.parseJSONResponse(resp, 'Failed to save preference');
 
     QPixel.handleJSONResponse(data, (data) => {
       QPixel._updatePreferencesLocally(data.preferences);

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -266,16 +266,13 @@ window.QPixel = {
       method: 'DELETE'
     });
 
-    const data = await resp.json();
+    /** @type {QPixelResponseJSON<{ filters: QPixelFilter[] }>} */
+    const data = await QPixel.parseJSONResponse(resp, 'Failed to delete filter');
 
-    if (data.status !== 'success') {
-      console.error(`Filter deletion failed (${name})`);
-      console.error(resp);
-    }
-    else {
+    QPixel.handleJSONResponse(data, (data) => {
       this._filters = data.filters;
       QPixel.Storage?.set('user_filters', this._filters);
-    }
+    });
   },
 
   _preferencesLocalStorageKey: () => {

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -411,10 +411,11 @@ window.QPixel = {
   },
 
   handleJSONResponse: (data, onSuccess, onFinally) => {
+    const is_modified = data.status === 'modified';
     const is_success = data.status === 'success';
 
-    if (is_success) {
-      onSuccess(/** @type {Extract<typeof data, { status: 'success' }>} */(data));
+    if (is_modified || is_success) {
+      onSuccess(/** @type {Parameters<typeof onSuccess>[0]} */(data));
     }
     else {
       QPixel.createNotification('danger', data.message);
@@ -428,6 +429,17 @@ window.QPixel = {
   flag: async (flag) => {
     const resp = await QPixel.fetchJSON(`/flags/new`, { ...flag }, {
       headers: { 'Accept': 'application/json' }
+    });
+
+    const data = await resp.json();
+
+    return data;
+  },
+
+  vote: async (postId, voteType) => {
+    const resp = await QPixel.fetchJSON('/votes/new', {
+      post_id: postId,
+      vote_type: voteType
     });
 
     const data = await resp.json();

--- a/app/assets/javascripts/votes.js
+++ b/app/assets/javascripts/votes.js
@@ -1,4 +1,4 @@
-$(() => {
+document.addEventListener('DOMContentLoaded', () => {
   $(document).on('click', '.vote-button', async (evt) => {
     const $tgt = $(evt.target).is('button') ? $(evt.target) : $(evt.target).parents('button');
     const $post = $tgt.parents('.post');

--- a/app/assets/javascripts/votes.js
+++ b/app/assets/javascripts/votes.js
@@ -13,22 +13,15 @@ document.addEventListener('DOMContentLoaded', () => {
     if (voted) {
       const voteId = $tgt.attr('data-vote-id');
 
-      const resp = await QPixel.fetchJSON(`/votes/${voteId}`, {}, { method: 'DELETE' });
+      const data = await QPixel.retractVote(voteId);
 
-      const data = await resp.json();
-
-      if (data.status === 'OK') {
+      QPixel.handleJSONResponse(data, (data) => {
         $up.text(`+${data.upvotes}`);
         $down.html(`&minus;${data.downvotes}`);
         $container.attr("title", `Score: ${data.score}`);
         $tgt.removeClass('is-active')
             .removeAttr('data-vote-id');
-      }
-      else {
-        console.error('Vote delete failed');
-        console.log(resp);
-        QPixel.createNotification('danger', `<strong>Failed:</strong> ${data.message} (${resp.status})`);
-      }
+      });
     }
     else {
       const resp = await QPixel.fetchJSON('/votes/new', {

--- a/app/assets/javascripts/votes.js
+++ b/app/assets/javascripts/votes.js
@@ -7,6 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const $up = $container.find('.js-upvote-count');
     const $down = $container.find('.js-downvote-count');
+    const postId = $post.data('post-id');
     const voteType = $tgt.data('vote-type');
     const voted = $tgt.hasClass('is-active');
 
@@ -24,14 +25,9 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     }
     else {
-      const resp = await QPixel.fetchJSON('/votes/new', {
-        post_id: $post.data('post-id'),
-        vote_type: voteType
-      });
+      const data = await QPixel.vote(postId, voteType);
 
-      const data = await resp.json();
-
-      if (data.status === 'modified' || data.status === 'OK') {
+      QPixel.handleJSONResponse(data, (data) => {
         $up.text(`+${data.upvotes}`);
         $down.html(`&minus;${data.downvotes}`);
         $container.attr("title", `Score: ${data.score}`);
@@ -43,12 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
           $oppositeVote.removeClass('is-active')
                        .removeAttr('data-vote-id');
         }
-      }
-      else {
-        console.error('Vote create failed');
-        console.log(resp);
-        QPixel.createNotification('danger', `<strong>Failed:</strong> ${data.message} (${resp.status})`);
-      }
+      });
     }
   });
 });

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -42,7 +42,7 @@ class VotesController < ApplicationController
     AbilityQueue.add(post.user, "Vote Change on ##{post.id}")
 
     modified = !destroyed.empty?
-    state = { status: (modified ? 'modified' : 'OK'),
+    state = { status: (modified ? 'modified' : 'success'),
               vote_id: vote.id,
               upvotes: post.upvote_count,
               downvotes: post.downvote_count,

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -62,7 +62,7 @@ class VotesController < ApplicationController
 
     if vote.destroy
       AbilityQueue.add(post.user, "Vote Change on ##{post.id}")
-      render json: { status: 'OK',
+      render json: { status: 'success',
                      upvotes: post.upvote_count,
                      downvotes: post.downvote_count,
                      score: post.score }

--- a/global.d.ts
+++ b/global.d.ts
@@ -461,7 +461,6 @@ interface QPixel {
    */
   replaceSelection?: ($field: JQuery<HTMLInputElement | HTMLTextAreaElement>, text: string) => void;
   setFilter?: (name: string, filter: QPixelFilter, category: string, isDefault: boolean) => Promise<void>;
-  setFilterAsDefault?: (categoryId: string, name: string) => Promise<void>;
 
   /**
    * Set a user preference by name to the value provided.

--- a/global.d.ts
+++ b/global.d.ts
@@ -241,7 +241,7 @@ type QPixelComment = {
   references_comment_id: string | null
 }
 
-type QPixelFlag = {
+type QPixelFilter = {
   exclude_tags: [string, number][]
   include_tags: [string, number][]
   max_answers: number | null
@@ -343,7 +343,7 @@ interface QPixel {
   readonly ALLOWED_POST_ATTRS?: readonly string[]
 
   // private properties
-  _filters?: QPixelFlag[] | null;
+  _filters?: QPixelFilter[] | null;
   _pendingUserResponse?: Promise<Response> | null;
   _popups?: Record<string, QPixelPopup>;
   _preferences?: UserPreferences | null;
@@ -437,7 +437,7 @@ interface QPixel {
    */
   defaultFilter?: (categoryId: string) => Promise<string>;
   deleteFilter?: (name: string, system?: boolean) => Promise<void>;
-  filters?: () => Promise<Record<string, QPixelFlag>>;
+  filters?: () => Promise<Record<string, QPixelFilter>>;
 
   /**
    * Get the absolute offset of an element.
@@ -460,7 +460,7 @@ interface QPixel {
    * @param text the text with which to replace the selection
    */
   replaceSelection?: ($field: JQuery<HTMLInputElement | HTMLTextAreaElement>, text: string) => void;
-  setFilter?: (name: string, filter: QPixelFlag, category: string, isDefault: boolean) => Promise<void>;
+  setFilter?: (name: string, filter: QPixelFilter, category: string, isDefault: boolean) => Promise<void>;
   setFilterAsDefault?: (categoryId: string, name: string) => Promise<void>;
 
   /**

--- a/global.d.ts
+++ b/global.d.ts
@@ -525,6 +525,13 @@ interface QPixel {
   getThreadsListContent?: (id: string) => Promise<string>
 
   /**
+   * Safely parses a JSON response from QPixel API
+   * @param response API response to parse
+   * @param errorMessage error to set on failure to parse
+   */
+  parseJSONResponse?: <T extends QPixelResponseJSON>(response: Response, errorMessage: string) => Promise<T>
+
+  /**
    * Processes JSON responses from QPixel API
    * @param data parsed response JSON body from the API
    * @param onSuccess callback to call for successful requests

--- a/global.d.ts
+++ b/global.d.ts
@@ -190,13 +190,19 @@ declare class QPixelPopup {
   updatePosition: () => void;
 }
 
+type QPixelSuccessResponseStatusJSON = 'success' | 'modified'
+
+type QPixelFailedResponseStatusJSON = 'failed'
+
+type QPixelResponseStatusJSON = QPixelSuccessResponseStatusJSON | QPixelFailedResponseStatusJSON
+
 type QPixelBaseResponseJSON = {
-  status: 'success' | 'failed'
+  status: QPixelResponseStatusJSON
   message?: string
 }
 
 type QPixelSuccessResponseJSON = QPixelBaseResponseJSON & {
-  status: 'success'
+  status: QPixelSuccessResponseStatusJSON
 }
 
 type QPixelFailedResponseJSON = QPixelBaseResponseJSON & {
@@ -204,10 +210,17 @@ type QPixelFailedResponseJSON = QPixelBaseResponseJSON & {
 }
 
 type QPixelResponseJSON<
-  Success extends QPixelSuccessResponseJSON = QPixelSuccessResponseJSON
-> = Success | QPixelFailedResponseJSON
+  Success extends object = object
+> = (Success & QPixelSuccessResponseJSON) | QPixelFailedResponseJSON
 
-type QPixelRetractVoteResponseJSON = QPixelResponseJSON<QPixelSuccessResponseJSON & {
+type QPixelVoteResponseJSON = QPixelResponseJSON<{
+  vote_id: number
+  upvotes: number
+  downvotes: number
+  score: number
+}>
+
+type QPixelRetractVoteResponseJSON = QPixelResponseJSON<{
   score: number
   downvotes: number
   upvotes: number
@@ -518,7 +531,7 @@ interface QPixel {
    * @param onFinally callback to call for all requests
    */
   handleJSONResponse?: <T extends QPixelResponseJSON>(data: T,
-                                                      onSuccess: (data: Extract<T , { status: 'success' }>) => void,
+                                                      onSuccess: (data: Extract<T, QPixelSuccessResponseJSON>) => void,
                                                       onFinally?: (data: T) => void) => boolean
 
   /**
@@ -591,6 +604,14 @@ interface QPixel {
    * @returns result of the operation
    */
   flag?: (flag: QPixelFlagData) => Promise<QPixelResponseJSON>
+
+  /**
+   * Attempts to vote on a given post
+   * @param postId id of the post to vote on
+   * @param voteType type of the vote
+   * @returns result of the operation
+   */
+  vote?: (postId: string, voteType: string) => Promise<QPixelVoteResponseJSON>
 
   // qpixel_dom
   DOM?: QPixelDOM;

--- a/global.d.ts
+++ b/global.d.ts
@@ -190,11 +190,28 @@ declare class QPixelPopup {
   updatePosition: () => void;
 }
 
-type QPixelResponseJSON = {
-  status: 'success' | 'failed',
-  message?: string,
+type QPixelBaseResponseJSON = {
+  status: 'success' | 'failed'
+  message?: string
+}
+
+type QPixelSuccessResponseJSON = QPixelBaseResponseJSON & {
+  status: 'success'
+}
+
+type QPixelFailedResponseJSON = QPixelBaseResponseJSON & {
   errors?: string[]
 }
+
+type QPixelResponseJSON<
+  Success extends QPixelSuccessResponseJSON = QPixelSuccessResponseJSON
+> = Success | QPixelFailedResponseJSON
+
+type QPixelRetractVoteResponseJSON = QPixelResponseJSON<QPixelSuccessResponseJSON & {
+  score: number
+  downvotes: number
+  upvotes: number
+}>
 
 type QPixelComment = {
   id: number
@@ -501,7 +518,7 @@ interface QPixel {
    * @param onFinally callback to call for all requests
    */
   handleJSONResponse?: <T extends QPixelResponseJSON>(data: T,
-                                                      onSuccess: (data: T) => void,
+                                                      onSuccess: (data: Extract<T , { status: 'success' }>) => void,
                                                       onFinally?: (data: T) => void) => boolean
 
   /**
@@ -560,6 +577,13 @@ interface QPixel {
    * @returns result of the operation
    */
   renameTag?: (categoryId: string, tagId: string, name: string) => Promise<QPixelResponseJSON>
+
+  /**
+   * Attempts to retract a vote
+   * @param id id of the vote to retract
+   * @returns result of the operation
+   */
+  retractVote?: (id: string) => Promise<QPixelRetractVoteResponseJSON>
 
   /**
    * Attempts to raise a flag

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -507,6 +507,15 @@ class UsersControllerTest < ActionController::TestCase
     assert(items.any? { |x| x.instance_of?(Flag) && x.id == declined_flag.id })
   end
 
+  test 'set_filter should correctly save valid filters' do
+    sign_in users(:standard_user)
+
+    [false, true].each do |is_default|
+      try_save_filter(is_default: is_default)
+      assert_json_success
+    end
+  end
+
   test 'set_preference should correclty save valid preferences' do
     sign_in users(:standard_user)
 
@@ -552,6 +561,11 @@ class UsersControllerTest < ActionController::TestCase
     other_user = User.create!(email: 'other@example.com', password: 'abcdefghijklmnopqrstuvwxyz', username: 'other_user')
     other_user.community_users.create!(community: other_community)
     other_user
+  end
+
+  def try_save_filter(**opts)
+    filter = { name: 'test filter' }.merge(opts)
+    post :set_filter, params: filter.merge({ format: :json })
   end
 
   def try_save_preference(name, value, community: nil)

--- a/test/controllers/votes_controller_test.rb
+++ b/test/controllers/votes_controller_test.rb
@@ -64,9 +64,7 @@ class VotesControllerTest < ActionController::TestCase
 
     delete :destroy, params: { id: votes(:one).id }
 
-    assert_response(:success)
-    assert_valid_json_response
-    assert_equal 'OK', JSON.parse(response.body)['status']
+    assert_json_success
   end
 
   test 'should prevent users removing others votes' do

--- a/test/controllers/votes_controller_test.rb
+++ b/test/controllers/votes_controller_test.rb
@@ -8,9 +8,7 @@ class VotesControllerTest < ActionController::TestCase
 
     post :create, params: { post_id: posts(:question_without_votes).id, vote_type: 1 }
 
-    assert_response(:success)
-    assert_valid_json_response
-    assert_equal 'OK', JSON.parse(response.body)['status']
+    assert_json_success
   end
 
   test 'should cast downvote' do
@@ -18,9 +16,7 @@ class VotesControllerTest < ActionController::TestCase
 
     post :create, params: { post_id: posts(:question_without_votes).id, vote_type: -1 }
 
-    assert_response(:success)
-    assert_valid_json_response
-    assert_equal 'OK', JSON.parse(response.body)['status']
+    assert_json_success
   end
 
   test 'should return correct modified status' do
@@ -31,9 +27,7 @@ class VotesControllerTest < ActionController::TestCase
     post :create, params: { post_id: post_id, vote_type: 1 }
     post :create, params: { post_id: post_id, vote_type: -1 }
 
-    assert_response(:success)
-    assert_valid_json_response
-    assert_equal 'modified', JSON.parse(response.body)['status']
+    assert_json_success(status: 'modified')
   end
 
   test 'should silently accept duplicate votes' do
@@ -44,9 +38,7 @@ class VotesControllerTest < ActionController::TestCase
     post :create, params: { post_id: post_id, vote_type: 1 }
     post :create, params: { post_id: post_id, vote_type: 1 }
 
-    assert_response(:success)
-    assert_valid_json_response
-    assert_equal 'modified', JSON.parse(response.body)['status']
+    assert_json_success(status: 'modified')
   end
 
   test 'should prevent self voting' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -136,12 +136,12 @@ class ActiveSupport::TestCase
     end
   end
 
-  def assert_json_success
+  def assert_json_success(status: 'success')
     assert_response(:success)
     assert_nothing_raised do
       parsed = JSON.parse(response.body)
       assert_not_nil(parsed)
-      assert_equal 'success', parsed['status']
+      assert_equal status, parsed['status']
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -136,6 +136,15 @@ class ActiveSupport::TestCase
     end
   end
 
+  def assert_json_success
+    assert_response(:success)
+    assert_nothing_raised do
+      parsed = JSON.parse(response.body)
+      assert_not_nil(parsed)
+      assert_equal 'success', parsed['status']
+    end
+  end
+
   def assert_json_response_message(expected)
     assert_equal expected, JSON.parse(response.body)['message']
   end


### PR DESCRIPTION
This PR further improves our handling of responses to JSON requests:

- adds a `QPixel#parseJSONResponse` helper preventing silent failures when our API responds unexpectedly (such as 422 Unprocessable entity with text/html type);
- adds several helper methods for standard handling of AJAX actions (`vote`, `retractVote`);
- fixes a couple of inconsistencies with what we return in the `status` field;
- makes several client API methods response parsing-safe & adds last resort notifications for end users;

I don't have time to apply these fixes _everywhere_ at once, but I tried to cover as many cases as I can right now.