### PR TITLE
Fix ordering of cached collections upon revive

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -256,9 +256,9 @@ class ApplicationController < ActionController::Base
             .joins(:category).where(categories: { use_for_hot_posts: true })
             .where('score >= ?', SiteSetting['HotPostsScoreThreshold'])
             .where.not(id: pinned_post_ids)
-            .order('score DESC').limit(SiteSetting['HotQuestionsCount']).all
+            .limit(SiteSetting['HotQuestionsCount'])
       end
-    end
+    end.order('score DESC')
 
     # eager loading revived collections' used relation to prevent N+1 queries
     @pinned_links = @pinned_links.list_includes
@@ -267,8 +267,8 @@ class ApplicationController < ActionController::Base
 
   def pull_categories
     @header_categories = Rails.cache.fetch_collection('header_categories') do
-      Category.all.order(sequence: :asc, id: :asc)
-    end
+      Category.all
+    end.order(sequence: :asc, id: :asc)
   end
 
   def check_if_warning_or_suspension_pending

--- a/app/models/post_type.rb
+++ b/app/models/post_type.rb
@@ -15,8 +15,8 @@ class PostType < ApplicationRecord
         ReactionType.active.where(post_type: self)
       else
         ReactionType.active.where(post_type: self).or(ReactionType.active.where(post_type: nil))
-      end.order(position: :asc).all
-    end
+      end
+    end.order(position: :asc)
   end
 
   # @return [Boolean] whether the post type is a system type

--- a/test/controllers/categories_controller_test.rb
+++ b/test/controllers/categories_controller_test.rb
@@ -9,6 +9,22 @@ class CategoriesControllerTest < ActionController::TestCase
     assert_not_nil assigns(:categories)
   end
 
+  test 'homepage should show categories in the correct order' do
+    get :homepage
+    assert_not_nil assigns(:header_categories)
+    seq = 0
+    id = 0
+    assigns(:header_categories).each do |category|
+      if category.sequence.nil?
+        assert category.id > id, "Category #{category.id} not after #{id}"
+      else
+        assert category.sequence >= seq, "Category #{category.id} sequence #{category.sequence} not greater than #{seq}"
+      end
+      seq = category.sequence || seq
+      id = category.id
+    end
+  end
+
   test ':homepage should correctly show the homepage category' do
     get :homepage
     assert_response(:success)

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -7,6 +7,7 @@ main:
     - <%= Article.post_type_id %>
   tag_set: main
   license: cc_by_sa
+  sequence: 1
 
 meta:
   community: sample
@@ -16,6 +17,7 @@ meta:
     - <%= Question.post_type_id %>
   tag_set: meta
   license: cc_by_sa
+  sequence: 2
 
 high_trust:
   community: sample
@@ -26,6 +28,7 @@ high_trust:
   tag_set: main
   min_trust_level: 3
   license: cc_by_sa
+  sequence: 3
 
 admin_only:
   community: sample
@@ -37,6 +40,7 @@ admin_only:
   min_trust_level: 5
   min_view_trust_level: 5
   license: cc_by_sa
+  sequence: 99
 
 articles_only:
   community: sample


### PR DESCRIPTION
Moves order clauses out of `fetch_collection` blocks.