### PR TITLE
Further caching fixes

### DIFF
--- a/app/assets/javascripts/notifications.js
+++ b/app/assets/javascripts/notifications.js
@@ -52,9 +52,8 @@ $(() => {
     ev.preventDefault();
     const $inbox = $('.inbox');
     if($inbox.hasClass("is-active")) {
-      const resp = await QPixel.getJSON(`/users/me/notifications`);
+      const data = await QPixel.getNotifications();
 
-      const data = await resp.json();
       const $inboxContainer = $inbox.find(".inbox--container");
       $inboxContainer.html('');
   

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -374,6 +374,16 @@ window.QPixel = {
     return data;
   },
 
+  getNotifications: async () => {
+    const resp = await QPixel.getJSON(`/users/me/notifications`, {
+      headers: { 'Cache-Control': 'no-cache' }
+    });
+
+    const data = await resp.json();
+
+    return data;
+  },
+
   getThreadContent: async (id, options) => {
     const inline = options?.inline ?? true;
     const showDeleted = options?.showDeleted ?? false;

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -194,11 +194,12 @@ class CommentsController < ApplicationController
   end
 
   def thread_content
-    fresh_when last_modified: @comment_thread.last_activity_at.utc, etag: @comment_thread
-
-    render partial: 'comment_threads/expanded', locals: { inline: params[:inline] == 'true',
-                                                          show_deleted: params[:show_deleted_comments] == '1',
-                                                          thread: @comment_thread }
+    if stale?(last_modified: @comment_thread.last_activity_at.utc)
+      render partial: 'comment_threads/expanded',
+             locals: { inline: params[:inline] == 'true',
+                       show_deleted: params[:show_deleted_comments] == '1',
+                       thread: @comment_thread }
+    end
   end
 
   def thread_followers

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -7,13 +7,16 @@ class NotificationsController < ApplicationController
   def index
     @notifications = Notification.unscoped.where(user: current_user).paginate(page: params[:page], per_page: 100)
                                  .order(Arel.sql('is_read ASC, created_at DESC'))
-    respond_to do |format|
-      format.html { render :index, layout: 'without_sidebar' }
-      format.json do
-        render json: (@notifications.to_a.map do |notif|
-          notif.as_json.merge(content: helpers.render_pings_text(notif.content),
-                              community_name: notif.community_name)
-        end)
+
+    if stale?(@notifications)
+      respond_to do |format|
+        format.html { render :index, layout: 'without_sidebar' }
+        format.json do
+          render json: (@notifications.to_a.map do |notif|
+            notif.as_json.merge(content: helpers.render_pings_text(notif.content),
+                                community_name: notif.community_name)
+          end)
+        end
       end
     end
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,8 +13,10 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports and disable caching.
+  perform_caching = ActiveRecord::Type::Boolean.new.cast(ENV['PERFORM_CACHING'])
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = ActiveRecord::Type::Boolean.new.cast(ENV['PERFORM_CACHING']) || false
+  config.action_controller.perform_caching = perform_caching || false
+  Rack::MiniProfiler.config.disable_caching = !perform_caching
 
   # Enable server timing
   config.server_timing = true

--- a/global.d.ts
+++ b/global.d.ts
@@ -505,10 +505,15 @@ interface QPixel {
   getJSON?: (uri: string, options?: Omit<RequestInit, 'method'>) => Promise<Response>;
 
   /**
-   * Attempts get a JSON reprentation of a comment
+   * Attempts to get a JSON reprentation of a comment
    * @param id id of the comment to get
    */
   getComment?: (id: string) => Promise<QPixelComment>
+
+  /**
+   * Attempts to get a list of notifications for the current user
+   */
+  getNotifications?: () => Promise<QPixelNotification[]>
 
   /**
    * Attempts to dynamically load thread content


### PR DESCRIPTION
This PR ensures fixes caching behavior for user notifications (currently, in production we allow those to get cached for a day with no regard to new notifications). It also makes it possible to test response caching in development as it turns out Rack::MiniProfiler overwrites cache control headers even if `perform_caching` is set to `true`. Finally, it _also_ fixes a `DoubleRenderError` when requesting `thread_content` twice in a row (that's not in production yet, I made a mistake when adding `fresh_when` with `respond_to`).