### PR TITLE
Add versions to error reports

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -31,6 +31,7 @@ select.form-element {
   & > .actions {
     display: flex;
     align-items: flex-end;
+    margin: 4px 0;
   }
 }
 

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -20,10 +20,11 @@ class ErrorsController < ApplicationController
     end
 
     if @exception.present? && [422, 500].include?(@status)
+      sha, _date = helpers.current_commit
       @log = ErrorLog.create(community: RequestContext.community, user: current_user, klass: @exception&.class,
                              message: @exception&.message, backtrace: @exception&.backtrace&.join("\n"),
                              request_uri: request.original_url, host: request.raw_host_with_port,
-                             uuid: SecureRandom.uuid, user_agent: request.user_agent)
+                             uuid: SecureRandom.uuid, user_agent: request.user_agent, version: sha)
     end
 
     render views[@status] || 'errors/error', formats: :html, status: @status, layout: 'without_sidebar'

--- a/app/views/admin/_error_report.html.erb
+++ b/app/views/admin/_error_report.html.erb
@@ -24,6 +24,12 @@
 
     <strong>UUID:</strong>
     <span class="raw-markdown"><%= report.uuid %></span>
+
+    <% if report.version? %>
+      <br/>
+      <strong>Version:</strong>
+      <%= report.version %>
+    <% end %>
   </p>
 
   <% backtrace_lines = report.backtrace.split("\n").select { |l| l.include? Rails.root.to_s } %>

--- a/app/views/admin/error_reports.html.erb
+++ b/app/views/admin/error_reports.html.erb
@@ -17,8 +17,8 @@
   <%= form_tag admin_error_reports_path, method: :get, class: 'has-margin-bottom-4 primary' do %>
     <div class="form-group-horizontal">
       <div class="form-group">
-        <%= label_tag :uuid, t('admin.error_search_version') %>
-        <%= text_field_tag :uuid, params[:uuid], class: 'form-element', placeholder: '(full SHA)' %>
+        <%= label_tag :version, t('admin.error_search_version') %>
+        <%= text_field_tag :version, params[:version], class: 'form-element', placeholder: '(full SHA)' %>
       </div>
       <div class="actions">
         <div class="button-list">
@@ -29,7 +29,6 @@
     </div>
   <% end %>
 </div>
-
 
 <% @reports.each do |report| %>
   <%= render 'error_report', report: report %>

--- a/app/views/admin/error_reports.html.erb
+++ b/app/views/admin/error_reports.html.erb
@@ -1,11 +1,35 @@
 <h1><%= t 'admin.tools.error_reports' %></h1>
 <p class="is-lead"><%= pluralize(@reports.count, t('g.error')) %> <%= t 'g.logged' %></p>
 
-<%= form_tag admin_error_reports_path, method: :get, class: 'has-margin-bottom-4' do %>
-  <%= label_tag :uuid, t('admin.error_search_uuid') %>
-  <%= text_field_tag :uuid, params[:uuid], class: 'form-element', placeholder: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' %>
-  <%= submit_tag t('g.search').capitalize, class: 'button is-filled' %>
-<% end %>
+<div class="flex-row">
+  <%= form_tag admin_error_reports_path, method: :get, class: 'has-margin-bottom-4 primary' do %>
+    <div class="form-group-horizontal">
+      <div class="form-group">
+        <%= label_tag :uuid, t('admin.error_search_uuid') %>
+        <%= text_field_tag :uuid, params[:uuid], class: 'form-element', placeholder: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' %>
+      </div>
+      <div class="actions">
+        <%= submit_tag t('g.search').capitalize, class: 'button is-filled' %>
+      </div>
+    </div>
+  <% end %>
+
+  <%= form_tag admin_error_reports_path, method: :get, class: 'has-margin-bottom-4 primary' do %>
+    <div class="form-group-horizontal">
+      <div class="form-group">
+        <%= label_tag :uuid, t('admin.error_search_version') %>
+        <%= text_field_tag :uuid, params[:uuid], class: 'form-element', placeholder: '(full SHA)' %>
+      </div>
+      <div class="actions">
+        <div class="button-list">
+          <button type="submit" class="button is-filled"><%= t('g.search').capitalize %></button>
+          <%= link_to 'Current', query_url(version: 'current'), class: 'button is-outlined' %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>
+
 
 <% @reports.each do |report| %>
   <%= render 'error_report', report: report %>

--- a/config/locales/strings/en.admin.yml
+++ b/config/locales/strings/en.admin.yml
@@ -16,6 +16,7 @@ en:
       organisation-wide changes like privacy policy or TOS changes. Format in a way that will be legible when Markdown
       is removed.
     error_search_uuid: 'Search for an error UUID'
+    error_search_version: 'Errors from version (commit)'
     privileges_blurb: >
       Here you can define the reputation required to gain each available privilege. Click on a value to edit it.
     email_query_blurb: >

--- a/db/migrate/20250920103432_add_version_to_error_logs.rb
+++ b/db/migrate/20250920103432_add_version_to_error_logs.rb
@@ -1,0 +1,5 @@
+class AddVersionToErrorLogs < ActiveRecord::Migration[7.2]
+  def change
+    add_column :error_logs, :version, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_05_231140) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_20_103432) do
   create_table "abilities", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "community_id"
     t.string "name"
@@ -253,6 +253,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_05_231140) do
     t.datetime "updated_at", precision: nil, null: false
     t.string "uuid"
     t.string "user_agent"
+    t.string "version"
     t.index ["community_id"], name: "index_error_logs_on_community_id"
     t.index ["user_id"], name: "index_error_logs_on_user_id"
   end

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -111,6 +111,20 @@ class AdminControllerTest < ActionController::TestCase
     assert_not_nil assigns(:reports)
   end
 
+  test 'should search error reports by version' do
+    sign_in users(:admin)
+    get :error_reports, params: { version: 'abc123' }
+    assert_response(:success)
+    assert_not_nil assigns(:reports)
+  end
+
+  test 'should search error reports from current version' do
+    sign_in users(:admin)
+    get :error_reports, params: { version: 'current' }
+    assert_response(:success)
+    assert_not_nil assigns(:reports)
+  end
+
   test 'should get audit log' do
     sign_in users(:admin)
     get :audit_log


### PR DESCRIPTION
Adds a commit hash to the error_logs table to allow us to search error reports by version, or by current version.