### PR TITLE
Fix N+1 query on tag_synonyms when loading lists of tags

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -10,11 +10,16 @@ class TagsController < ApplicationController
     @tag_set = if params[:tag_set].present?
                  TagSet.find(params[:tag_set])
                end
+
     @tags = if params[:term].present?
               (@tag_set&.tags || Tag).search(params[:term])
             else
               (@tag_set&.tags || Tag.all).order(:name)
-            end.includes(:tag_synonyms).paginate(page: params[:page], per_page: 50)
+            end
+
+    @tags = @tags.includes(:tag_synonyms)
+                 .paginate(page: params[:page], per_page: 50)
+
     respond_to do |format|
       format.json do
         render json: @tags.to_json(include: { tag_synonyms: { only: :name } })

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -17,7 +17,7 @@ class TagsController < ApplicationController
               (@tag_set&.tags || Tag.all).order(:name)
             end
 
-    @tags = @tags.includes(:tag_synonyms)
+    @tags = @tags.list_includes
                  .paginate(page: params[:page], per_page: 50)
 
     respond_to do |format|
@@ -43,7 +43,7 @@ class TagsController < ApplicationController
               @tag_set.tags.where(excerpt: ['', nil])
             else
               @tag_set.tags
-            end
+            end.list_includes
 
     table = params[:hierarchical].present? ? 'tags_paths' : 'tags'
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -18,6 +18,9 @@ class Tag < ApplicationRecord
   validate :synonym_unique
   validates :name, uniqueness: { scope: [:tag_set_id], case_sensitive: false }
 
+  # scopes
+  scope :list_includes, -> { includes(:tag_synonyms) }
+
   # Fuzzy-searches tags by name, excerpt, and synonym name
   # @param term [String] search term
   # @return [ActiveRecord::Relation<Tag>]


### PR DESCRIPTION
This is particularly noticeable on the category tags (`/categores/<category id>/tags`) page.

Before (note the huge number of single queries loading synonyms for every tag listed on the page, one by one):

<img width="550" height="480" alt="Screenshot from 2025-09-22 12-17-51" src="https://github.com/user-attachments/assets/81249342-3db2-4eeb-b7fd-8b6bdbc24d6b" />

And after:

<img width="550" height="155" alt="Screenshot from 2025-09-22 12-18-08" src="https://github.com/user-attachments/assets/0d3dd52d-9b34-4471-8bbc-7d9a90d91777" />

