### PR TITLE
 Sorting options for flags

### DIFF
--- a/app/assets/stylesheets/flags.scss
+++ b/app/assets/stylesheets/flags.scss
@@ -1,0 +1,4 @@
+.flags-list-header {
+  display: flex;
+  justify-content: space-between;
+}

--- a/app/assets/stylesheets/flags.scss
+++ b/app/assets/stylesheets/flags.scss
@@ -2,3 +2,14 @@
   display: flex;
   justify-content: space-between;
 }
+
+.header {
+  .header--menu {
+    .header--item {
+      .header--alert {
+        min-width: 2em;
+        padding: 0 0.5em;
+      }
+    }
+  }
+}

--- a/app/controllers/flags_controller.rb
+++ b/app/controllers/flags_controller.rb
@@ -123,10 +123,16 @@ class FlagsController < ApplicationController
 
   def set_sorting
     sort_orders = { asc: :asc, desc: :desc }
-    sort_types = { age: :created_at, handled: :handled_at }
+    sort_types = { age: :created_at,
+                   escalated: :escalated_at,
+                   handled: :handled_at }
 
-    @default_sort_order = :asc
-    @default_sort_type = :age
+    @default_sort_type, @default_sort_order = case params[:action]
+                                              when 'escalated_queue' then [:escalated, :desc]
+                                              when 'handled' then [:handled, :desc]
+                                              else [:age, :asc]
+                                              end
+
     @sort_order = sort_orders[params[:order]&.to_sym] || sort_orders[@default_sort_order]
     @sort_type = sort_types[params[:sort]&.to_sym] || sort_types[@default_sort_type]
   end

--- a/app/views/flags/_flag.html.erb
+++ b/app/views/flags/_flag.html.erb
@@ -1,11 +1,11 @@
 <%#
-    Single flag handling view.
+   "Single flag handling view.
 
-    Params:
-     * flag : the flag to display
-     * controls : boolean, whether or not to display handling controls - true by default
-     * escalation : boolean, if true will display escalation comment - false by default
-%>
+    Variables:
+      flag : the flag to display
+      controls : boolean, whether or not to display handling controls - true by default
+      escalation : boolean, if true will display escalation comment - false by default
+"%>
 
 <% controls ||= defined?(controls) && !controls.nil? ? controls : true %>
 <% escalation ||= defined?(escalation) && !escalation.nil? ? escalation : false %>
@@ -36,7 +36,7 @@
         <%= user_link flag.escalated_by, { host: flag.community.host } %> at <%= flag.escalated_at.iso8601 %>
       </p>
       <p>
-	      <strong>Attention</strong>: The reply to the flag will be shown to the flagger, not the mod escalating this
+        <strong>Attention</strong>: The reply to the flag will be shown to the flagger, not the mod escalating this
         flag. Do not share sensitive, mod-only information.
       </p>
     </div>

--- a/app/views/flags/handled.html.erb
+++ b/app/views/flags/handled.html.erb
@@ -3,12 +3,18 @@
 <h1>Handled Flags</h1>
 <p>The following list contains flags that have already been handled. You can't change the outcome of these any more.</p>
 
-<div class="button-list is-gutterless">
-  <%= link_to 'Active', flag_queue_path, class: 'button is-muted is-outlined' %>
-  <%= link_to 'Handled', handled_flags_path, class: 'button is-muted is-outlined is-active' %>
-  <% if admin? %>
-    <%= link_to 'Escalated', escalated_flags_path, class: 'button is-muted is-outlined' %>
-  <% end %>
+<div class="flags-list-header">
+  <div class="button-list is-gutterless">
+    <%= link_to 'Active', flag_queue_path, class: 'button is-muted is-outlined' %>
+    <%= link_to 'Handled', handled_flags_path, class: 'button is-muted is-outlined is-active' %>
+    <% if admin? %>
+      <%= link_to 'Escalated', escalated_flags_path, class: 'button is-muted is-outlined' %>
+    <% end %>
+  </div>
+
+  <%= render 'shared/sorting', default_order: @default_sort_order,
+                               default_type: @default_sort_type,
+                               types: %w[age handled] %>
 </div>
 
 <% @flags.each do |flag| %>

--- a/app/views/flags/handled.html.erb
+++ b/app/views/flags/handled.html.erb
@@ -14,7 +14,7 @@
 
   <%= render 'shared/sorting', default_order: @default_sort_order,
                                default_type: @default_sort_type,
-                               types: %w[age handled] %>
+                               types: ['age', { type: 'handled', title: 'time handled' }] %>
 </div>
 
 <% @flags.each do |flag| %>

--- a/app/views/flags/queue.html.erb
+++ b/app/views/flags/queue.html.erb
@@ -19,9 +19,13 @@
     <% end %>
   </div>
 
+  <% sorting_types = current_page?(escalated_flags_path) ?
+                      ['age', { type: 'escalated', title: 'time escalated' }] :
+                      %w[age] %>
+
   <%= render 'shared/sorting', default_order: @default_sort_order,
                                default_type: @default_sort_type,
-                               types: current_page?(escalated_flags_path) ? %w[age escalated] : %w[age] %>
+                               types: sorting_types %>
 </div>
 
 <% @flags.each do |flag| %>

--- a/app/views/flags/queue.html.erb
+++ b/app/views/flags/queue.html.erb
@@ -8,14 +8,20 @@
   moderator attention; use that to help you determine what needs to be done.</p>
 <p>You can mark a flag helpful even if you take no action. If a post was edited after the flag was raised, for example, the problem might already be fixed.</p>
 
-<div class="button-list is-gutterless">
-  <%= link_to 'Active', flag_queue_path,
+<div class="flags-list-header">
+  <div class="button-list is-gutterless">
+    <%= link_to 'Active', flag_queue_path,
               class: "button is-muted is-outlined #{current_page?(flag_queue_path) ? 'is-active' : ''}" %>
-  <%= link_to 'Handled', handled_flags_path, class: 'button is-muted is-outlined' %>
-  <% if admin? %>
-    <%= link_to 'Escalated', escalated_flags_path,
+    <%= link_to 'Handled', handled_flags_path, class: 'button is-muted is-outlined' %>
+    <% if admin? %>
+      <%= link_to 'Escalated', escalated_flags_path,
                 class: "button is-muted is-outlined #{current_page?(escalated_flags_path) ? 'is-active' : ''}" %>
-  <% end %>
+    <% end %>
+  </div>
+
+  <%= render 'shared/sorting', default_order: @default_sort_order,
+                               default_type: @default_sort_type,
+                               types: %w[age] %>
 </div>
 
 <% @flags.each do |flag| %>

--- a/app/views/flags/queue.html.erb
+++ b/app/views/flags/queue.html.erb
@@ -11,17 +11,17 @@
 <div class="flags-list-header">
   <div class="button-list is-gutterless">
     <%= link_to 'Active', flag_queue_path,
-              class: "button is-muted is-outlined #{current_page?(flag_queue_path) ? 'is-active' : ''}" %>
+              class: "button is-muted is-outlined #{'is-active' if current_page?(flag_queue_path)}" %>
     <%= link_to 'Handled', handled_flags_path, class: 'button is-muted is-outlined' %>
     <% if admin? %>
       <%= link_to 'Escalated', escalated_flags_path,
-                class: "button is-muted is-outlined #{current_page?(escalated_flags_path) ? 'is-active' : ''}" %>
+                class: "button is-muted is-outlined #{'is-active' if current_page?(escalated_flags_path)}" %>
     <% end %>
   </div>
 
   <%= render 'shared/sorting', default_order: @default_sort_order,
                                default_type: @default_sort_type,
-                               types: %w[age] %>
+                               types: current_page?(escalated_flags_path) ? %w[age escalated] : %w[age] %>
 </div>
 
 <% @flags.each do |flag| %>

--- a/app/views/shared/_sorting.html.erb
+++ b/app/views/shared/_sorting.html.erb
@@ -2,7 +2,7 @@
    "Renders a sorting widget
 
     Variables:
-      types : Array<String> of available sorting types
+      types         : list of available sorting types
     ? default_order : Defualt sorting order, if any
     ? default_type  : Default sorting type, if any
 "%>
@@ -16,13 +16,15 @@
 
 <div class="button-list is-gutterless">
 
-  <% types.each do |type| %>
+  <% types.each do |option| %>
+    <% type = option.is_a?(String) ? option : option[:type] %>
+    <% title = "Sort by #{option.is_a?(String) ? option.humanize.downcase : option[:title]}" %>
     <% is_active = params[:sort] == type || (params[:sort].nil? && default_type.to_s == type) %>
     <%= link_to request.params.merge(sort: type, order: is_active ? reverse_order : nil),
                 class: "button is-muted is-outlined #{'is-active' if is_active}",
                 role: 'button',
-                title: "Sort by #{type.humanize.downcase}",
-                aria: { label: "Sort by #{type.humanize.downcase}" } do %>
+                title: title,
+                aria: { label: title } do %>
       <% if is_active %>
         <i class="has-margin-right-1 fa fa-caret-<%= order == :asc ? 'up' : 'down' %>"></i> <%= type.humanize %>
       <% else %>


### PR DESCRIPTION
closes #1838 as a followup to #1842

Escalated flags (defaults - sort by escalation time, newest first):

<img width="770" height="231" alt="Screenshot from 2025-09-22 13-33-54" src="https://github.com/user-attachments/assets/ad939144-c71e-4dac-97b6-34fc5dbd3c36" />

Active flags (defaults - sort by age, oldest first [as before, we intentionally order oldest first so as pending flags don't get buried]) - there's only one sorting type for now as there's nothing else to sort on:

<img width="770" height="231" alt="Screenshot from 2025-09-22 12-50-33" src="https://github.com/user-attachments/assets/c2357eb2-4405-4683-b4ed-89bb3c4b2137" />

Handled flags (defaults - sort by handled time, newest first):

<img width="770" height="231" alt="Screenshot from 2025-09-22 13-36-20" src="https://github.com/user-attachments/assets/826f21b9-2daa-4994-84ee-fa10bdb36582" />

Also adds a minor fix for flags (and as a side-effect - notifications) count in page headers.

After:

<img width="425" height="57" alt="Screenshot from 2025-09-22 14-26-43" src="https://github.com/user-attachments/assets/42ef4479-d4aa-4e47-b220-bcf56f7a9210" />

Before:

<img width="425" height="57" alt="Screenshot from 2025-09-22 14-28-57" src="https://github.com/user-attachments/assets/e61f4953-6d7d-4f1b-97f4-a0ed78dbe3f1" />


