### PR TITLE
Assorted fixes

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
 
   before_action :authenticate_user!, only: [:edit_profile, :update_profile, :stack_redirect, :transfer_se_content,
                                             :qr_login_code, :me, :preferences, :set_preference, :my_vote_summary,
-                                            :disconnect_sso, :confirm_disconnect_sso, :filters]
+                                            :disconnect_sso, :confirm_disconnect_sso]
   before_action :verify_moderator, only: [:mod, :destroy, :soft_delete, :role_toggle, :full_log,
                                           :annotate, :annotations, :mod_privileges, :mod_privilege_action]
   before_action :set_user, only: [:show, :mod, :destroy, :soft_delete, :posts, :role_toggle, :full_log, :activity,

--- a/app/views/admin/_error_report.html.erb
+++ b/app/views/admin/_error_report.html.erb
@@ -28,7 +28,7 @@
     <% if report.version? %>
       <br/>
       <strong>Version:</strong>
-      <%= report.version %>
+      <%= link_to report.version, request.params.merge(version: report.version) %>
     <% end %>
   </p>
 

--- a/app/views/admin/_error_report.html.erb
+++ b/app/views/admin/_error_report.html.erb
@@ -28,7 +28,7 @@
     <% if report.version? %>
       <br/>
       <strong>Version:</strong>
-      <%= link_to report.version, request.params.merge(version: report.version) %>
+      <%= link_to report.version, query_url(version: report.version) %>
     <% end %>
   </p>
 

--- a/app/views/admin/audit_log.html.erb
+++ b/app/views/admin/audit_log.html.erb
@@ -35,15 +35,15 @@
 
   <div class="button-list is-gutterless">
     <% classes = 'button is-outlined is-muted' %>
-    <%= link_to t('g.age'), request.params.merge(sort: 'age'),
+    <%= link_to t('g.age'), query_url(sort: 'age'),
                 class: "#{classes} #{params[:sort] == 'age' || params[:sort].nil? ? 'is-active' : ''}" %>
-    <%= link_to t('g.type'), request.params.merge(sort: 'type'),
+    <%= link_to t('g.type'), query_url(sort: 'type'),
                 class: "#{classes} #{params[:sort] == 'type' ? 'is-active' : ''}" %>
-    <%= link_to t('g.event'), request.params.merge(sort: 'event'),
+    <%= link_to t('g.event'), query_url(sort: 'event'),
                 class: "#{classes} #{params[:sort] == 'event' ? 'is-active' : ''}" %>
-    <%= link_to t('g.related'), request.params.merge(sort: 'related'),
+    <%= link_to t('g.related'), query_url(sort: 'related'),
                 class: "#{classes} #{params[:sort] == 'related' ? 'is-active' : ''}" %>
-    <%= link_to t('g.user'), request.params.merge(sort: 'user'),
+    <%= link_to t('g.user'), query_url(sort: 'user'),
                 class: "#{classes} #{params[:sort] == 'user' ? 'is-active' : ''}" %>
   </div>
 </div>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -26,22 +26,22 @@
   </span>
 
   <div class="button-list is-gutterless has-margin-2">
-    <%= link_to 'Activity', request.params.merge(sort: 'activity'),
+    <%= link_to 'Activity', query_url(sort: 'activity'),
                 class: "button is-muted is-outlined #{(params[:sort].nil?) && !current_page?(questions_lottery_path) ||
                     params[:sort] == 'activity' ? 'is-active' : ''}",
                 title: 'most recent changes: new posts, edits, close/open, delete/undelete' %>
-    <%= link_to 'Age', request.params.merge(sort: 'age'),
+    <%= link_to 'Age', query_url(sort: 'age'),
                 class: "button is-muted is-outlined #{params[:sort] == 'age' ? 'is-active' : ''}",
                 title: 'newest posts (ignores other activity)' %>
-    <%= link_to 'Score', request.params.merge(sort: 'score'),
+    <%= link_to 'Score', query_url(sort: 'score'),
                 class: "button is-muted is-outlined #{params[:sort] == 'score' ? 'is-active' : ''}",
                 title: 'highest score first (not the same as net votes)' %>
     <% if SiteSetting['AllowContentTransfer'] %>
-      <%= link_to 'Native', request.params.merge(sort: 'native'),
+      <%= link_to 'Native', query_url(sort: 'native'),
                   class: "button is-muted is-outlined #{params[:sort] == 'native' ? 'is-active' : ''}",
                   title: 'exclude imported posts' %>
     <% end %>
-    <%= link_to 'Random', request.params.merge(sort: 'lottery'),
+    <%= link_to 'Random', query_url(sort: 'lottery'),
         class: "button is-muted is-outlined #{params[:sort] == 'lottery' ? 'is-active' : ''}",
         title: 'random set of questions, usually older ones' %>
   </div>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -48,7 +48,7 @@
 </div>
 
 <details class="category-filters">
-  <summary>Filters (<%= @filtered ? @active_filter[:name].empty? ? 'Custom' : @active_filter[:name] : 'None' %>)</summary>
+  <summary>Filters (<%= @filtered ? @active_filter[:name].blank? ? 'Custom' : @active_filter[:name] : 'None' %>)</summary>
   <% if @active_filter[:default] == :user %>
     <div class="notice is-info">
       You are currently filtering by <strong><%= @active_filter[:name] %></strong> because it is set as your default for this category

--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -33,7 +33,8 @@
                  (post.closed && !post.duplicate_post ? " [closed]" : "") +
                  (post.duplicate_post ? " [duplicate]" : "") %>
       <a href="<%= generic_share_link(post) %>" class="post--title-text"><%= title %></a>
-      <% if category.display_post_types.reject { |e| e.to_s.empty? }.size > 1 %>
+      <% post_types = category&.display_post_types || [] %>
+      <% if post_types.reject(&:empty?).size > 1 %>
         <%= post_type_badge(post_type) %>
       <% end %>
     </h1>
@@ -125,7 +126,7 @@
                 <% end %>
               <% elsif current_user.present? %>
                 <% if post.pending_suggested_edit? %>
-                      <%= link_to 'suggested edit pending...',
+                  <%= link_to 'suggested edit pending...',
                                    suggested_edit_url(post.pending_suggested_edit.id),
                                    class: "tools--item" %>
                 <% elsif post_type.is_freely_editable %>
@@ -254,12 +255,12 @@
           <% available_count = current_user&.post_privilege?('flag_curate', post) ?
                                  post.comment_threads.count : post.comment_threads.publicly_available.count %>
           <div class="post--comments-header">
-          <h4 class="has-margin-0">
-            <%= pluralize(public_count, 'comment thread') %>
-          </h4>
-          <% if user_signed_in? %>
-            <%= render 'posts/follow_comments_link', post: post, user: current_user %>
-          <% end %>
+            <h4 class="has-margin-0">
+              <%= pluralize(public_count, 'comment thread') %>
+            </h4>
+            <% if user_signed_in? %>
+              <%= render 'posts/follow_comments_link', post: post, user: current_user %>
+            <% end %>
           </div>
           <div class="post--comments-container" role="list">
             <%= render 'comments/threads_list', comment_threads: comment_threads.first(5),

--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -34,7 +34,7 @@
                  (post.duplicate_post ? " [duplicate]" : "") %>
       <a href="<%= generic_share_link(post) %>" class="post--title-text"><%= title %></a>
       <% post_types = category&.display_post_types || [] %>
-      <% if post_types.reject(&:empty?).size > 1 %>
+      <% if post_types.reject(&:blank?).size > 1 %>
         <%= post_type_badge(post_type) %>
       <% end %>
     </h1>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -27,13 +27,13 @@
   <% end %>
   <% if num_answers > 1 %>
     <div class="button-list is-gutterless has-float-right">
-      <%= link_to 'Score', request.params.merge(sort: 'score'),
+      <%= link_to 'Score', query_url(sort: 'score'),
           class: "button is-muted is-outlined #{params[:sort].nil? || params[:sort] == 'score' ? 'is-active' : ''}",
     title: 'highest score first (not the same as net votes)' %>
-      <%= link_to 'Active', request.params.merge(sort: 'active'),
+      <%= link_to 'Active', query_url(sort: 'active'),
           class: "button is-muted is-outlined #{params[:sort] == 'active' ? 'is-active' : ''}",
     title: 'most recent changes first: new answers, edits, delete/undelete' %>
-      <%= link_to 'Age', request.params.merge(sort: 'age'),
+      <%= link_to 'Age', query_url(sort: 'age'),
     class: "button is-muted is-outlined #{params[:sort] == 'age' ? 'is-active' : ''}",
     title: 'newest posts first (ignores other activity)' %>
     </div>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -14,19 +14,19 @@
       </span>
       <div class="search-sorting-types button-list is-gutterless">
         <%= link_to 'Relevance',
-                    request.params.merge(sort: 'relevance'),
+                    query_url(sort: 'relevance'),
                     class: "button is-outlined is-muted #{'is-active' if params[:sort] == 'relevance' || params[:sort].nil?}",
                     role: 'button', 'aria-label': 'Sort by relevance' %>
         <%= link_to 'Activity',
-                    request.params.merge(sort: 'activity'),
+                    query_url(sort: 'activity'),
                     class: "button is-outlined is-muted #{'is-active' if params[:sort] == 'activity'}",
                     role: 'button', 'aria-label': 'Sort by activity' %>
         <%= link_to 'Age',
-                    request.params.merge(sort: 'age'),
+                    query_url(sort: 'age'),
                     class: "button is-outlined is-muted #{'is-active' if params[:sort] == 'age'}",
                     role: 'button', 'aria-label': 'Sort by age' %>
         <%= link_to 'Score',
-                    request.params.merge(sort: 'score'),
+                    query_url(sort: 'score'),
                     class: "button is-outlined is-muted #{'is-active' if params[:sort] == 'score'}",
                     role: 'button', 'aria-label': 'Sort by score' %>
       </div>

--- a/app/views/shared/_sorting.html.erb
+++ b/app/views/shared/_sorting.html.erb
@@ -20,7 +20,7 @@
     <% type = option.is_a?(String) ? option : option[:type] %>
     <% title = "Sort by #{option.is_a?(String) ? option.humanize.downcase : option[:title]}" %>
     <% is_active = params[:sort] == type || (params[:sort].nil? && default_type.to_s == type) %>
-    <%= link_to request.params.merge(sort: type, order: is_active ? reverse_order : nil),
+    <%= link_to query_url(sort: type, order: is_active ? reverse_order : nil),
                 class: "button is-muted is-outlined #{'is-active' if is_active}",
                 role: 'button',
                 title: title,

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -9,17 +9,18 @@
       <%= text_field_tag :search, params[:search], class: 'form-element' %>
       <%= hidden_field_tag :sort, params[:sort] || @sort_param  %>
     </div>
-    <div class="actions has-padding-bottom-1">
+    <div class="actions">
       <button type="submit" class="button is-filled is-medium"><i class="fas fa-search"></i><span class="sr-only">Search</span></button>
     </div>
   </div>
 <% end %>
 
 <div class="button-list is-gutterless has-margin-bottom-4">
-  <%= link_to 'Reputation', request.params.merge(sort: 'reputation'),
+  <%= link_to 'Reputation', query_url(sort: 'reputation'),
       class: "button is-muted is-outlined #{params[:sort] == 'reputation' || (params[:sort].nil? && params[:search].nil?) ? 'is-active' : ''}",
       role: 'button', 'aria-label': 'Sort by reputation' %>
-  <%= link_to 'Age', request.params.merge(sort: 'age'), class: "button is-muted is-outlined #{params[:sort] == 'age' ? 'is-active' : ''}",
+  <%= link_to 'Age', query_url(sort: 'age'),
+              class: "button is-muted is-outlined #{params[:sort] == 'age' ? 'is-active' : ''}",
               role: 'button', 'aria-label': 'Sort by age' %>
 </div>
 

--- a/app/views/users/posts.html.erb
+++ b/app/views/users/posts.html.erb
@@ -10,17 +10,17 @@
 <div class="has-color-tertiary-500 category-meta">
   <span title="<%= post_count %> posts">
     <%= short_number_to_human post_count, precision: 1, significant: false %>
-    <%= 'post'.pluralize(post_count) %> 
+    <%= 'post'.pluralize(post_count) %>
   </span>
 
   <div class="button-list is-gutterless has-margin-2">
-    <%= link_to 'Activity', request.params.merge(sort: 'activity'), 
+    <%= link_to 'Activity', query_url(sort: 'activity'), 
                             class: 'button is-muted is-outlined ' + (active_search?('last_activity') ? 'is-active' : ''),
                             role: 'button', 'aria-label': 'Sort by activity' %>
-    <%= link_to 'Age', request.params.merge(sort: 'age'), 
+    <%= link_to 'Age', query_url(sort: 'age'), 
                        class: 'button is-muted is-outlined ' + (active_search?('created_at') ? 'is-active' : ''),
                        role: 'button', 'aria-label': 'Sort by age' %>
-    <%= link_to 'Score', request.params.merge(sort: 'score'), 
+    <%= link_to 'Score', query_url(sort: 'score'), 
                          class: 'button is-muted is-outlined ' + (active_search?('score') ? 'is-active' : ''),
                          role: 'button', 'aria-label': 'Sort by score' %>
   </div>


### PR DESCRIPTION
This PR contains several assorted fixes:

- we should not require users to be signed in to get `filters` - it breaks filter select for signed out users (the action had all the necessary checks inside);
- server error (500) when `@active_filter` is missing a name (to reproduce, append a `predefined_filter` search query param **without a value**);
- server error (500) when trying to directly access a post without a category (any post with a post type that doesn't belong to one);
- server error (500) when trying to render user cards for users without a community user;
- not a fix, but related: the "Version" line of error reports is now a link for searching by that option now that we can do that;