### PR TITLE
minor styling fix for error report summaries

### DIFF
--- a/app/assets/stylesheets/errors.scss
+++ b/app/assets/stylesheets/errors.scss
@@ -23,7 +23,8 @@
 .error-report-summary {
   display: flex;
   align-items: center;
-  gap: 0.15em;
+  gap: 1em;
+  word-break: break-word;
 
   .details {
     flex: 1;


### PR DESCRIPTION
This PR fixes a small visual bug that I noticed while investigating an error report on our dev server:

Before:

<img width="1318" height="126" alt="Screenshot from 2025-09-25 03-34-35" src="https://github.com/user-attachments/assets/019983c2-b02a-4049-b3ea-6118e234ee94" />

After:

<img width="870" height="126" alt="Screenshot from 2025-09-25 03-34-14" src="https://github.com/user-attachments/assets/7044306e-a2ba-4dcd-a001-12e514f7c2dc" />
