### PR TITLE
Sign out button visibility & suspension check fix

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -6,6 +6,8 @@ class AdminController < ApplicationController
   before_action :verify_developer, only: [:change_users, :impersonate]
   before_action :set_user, only: [:change_users, :hellban, :impersonate]
 
+  skip_before_action :check_if_warning_or_suspension_pending, only: [:change_back, :verify_elevation]
+
   def index; end
 
   def error_reports

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :set_globals
   before_action :enforce_signed_in, unless: :devise_controller?
-  before_action :check_if_warning_or_suspension_pending
+  before_action :check_if_warning_or_suspension_pending, if: [:user_signed_in?], unless: [:devise_controller?]
   before_action :distinguish_fake_community
   before_action :stop_the_awful_troll
 
@@ -272,13 +272,7 @@ class ApplicationController < ActionController::Base
   end
 
   def check_if_warning_or_suspension_pending
-    return if current_user.nil?
-
-    warning = ModWarning.to(current_user).active.any?
-    return unless warning
-
-    # Ignore devise and warning routes
-    return if devise_controller? || ['custom_sessions', 'mod_warning', 'errors'].include?(controller_name)
+    return unless ModWarning.to(current_user).active.any?
 
     flash.clear
 

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -3,6 +3,7 @@
 # Note that it requires +consider_all_requests_local+ to be +false+ (see environment config files for details)
 class ErrorsController < ApplicationController
   protect_from_forgery with: :exception, except: [:error], store: :cookie
+  skip_before_action :check_if_warning_or_suspension_pending, only: [:error]
 
   def error
     @exception = request.env['action_dispatch.exception']

--- a/app/controllers/mod_warning_controller.rb
+++ b/app/controllers/mod_warning_controller.rb
@@ -1,8 +1,9 @@
 class ModWarningController < ApplicationController
   before_action :verify_moderator, only: [:log, :new, :create, :lift]
-
   before_action :set_warning, only: [:current, :approve]
   before_action :set_user, only: [:log, :new, :create, :lift]
+
+  skip_before_action :check_if_warning_or_suspension_pending, only: [:current, :approve]
 
   def current
     render layout: 'without_sidebar'

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,20 +3,20 @@
 <% sticky_header = user_preference('sticky_header', community: false) == 'true' %>
 
 <script>
-const toggleSearchFocus = () => {
-  const $input = $('#search');
+  const toggleSearchFocus = () => {
+    const $input = $('#search');
 
-  if ($input.is(':focus')) {
-    $input.blur();
-  }
-  else {
-      $input.focus();
-  }
-};
+    if ($input.is(':focus')) {
+      $input.blur();
+    }
+    else {
+        $input.focus();
+    }
+  };
 
-$(() => {
-  $('a[data-header-slide="#search-slide"]').on('click', toggleSearchFocus);
-});
+  $(() => {
+    $('a[data-header-slide="#search-slide"]').on('click', toggleSearchFocus);
+  });
 </script>
 
 <header class="header is-small has-margin-0<%=' is-dark' if SiteSetting['SiteHeaderIsDark'] %><%= ' sticky' if sticky_header %>">
@@ -96,10 +96,12 @@ $(() => {
          data-header-slide="#communities-slide"
          title="Show Communities"
          >
-          <i class="far fa-fw fa-caret-square-down"></i>
+        <i class="far fa-fw fa-caret-square-down"></i>
       </a>
-      <% unless user_signed_in? %>
-        <div class="header--item">
+      <div class="header--item">
+        <% if user_signed_in? %>
+          <%= render 'users/sessions/sign_out' %>
+        <% else %>
           <% if devise_sign_in_enabled? %>
             <%= link_to 'Sign Up', new_user_registration_path, class: 'button is-muted is-filled' %>
             <%= link_to 'Sign In', new_user_session_path, class: 'button is-muted is-outlined' %>
@@ -107,15 +109,16 @@ $(() => {
           <% if sso_sign_in_enabled? %>
             <%= link_to 'SSO Sign In', new_saml_user_session_path, class: 'button is-muted is-outlined' %>
           <% end %>
-        </div>
-      <% end %>
+
+        <% end %>
+      </div>
       <% unless @community.is_fake %>
         <a class="header--item is-mobile-menu is-complex" aria-label="Menu" href="#" data-header-slide="#js-mobile-menu">
-            <span class="header--menu-bars">
-              <span></span>
-              <span></span>
-              <span></span>
-            </span>
+          <span class="header--menu-bars">
+            <span></span>
+            <span></span>
+            <span></span>
+          </span>
         </a>
       <% end %>
     </nav>
@@ -123,13 +126,6 @@ $(() => {
 </header>
 
 <div class="header-slide" id="communities-slide">
-  <% if user_signed_in? %>
-    <% if devise_sign_in_enabled? %>
-      <%= link_to 'Sign Out', destroy_user_session_path, method: :delete, class: 'button is-muted has-float-right', role: 'button' %>
-    <% else %>
-      <%= link_to 'Sign Out', destroy_saml_user_session_path, method: :delete, class: 'button is-muted has-float-right', role: 'button' %>
-    <% end %>
-  <% end %>
   <h3 class="h-m-t-1">Communities</h3>
   <div class="community-header-list">
     <% logo_paths = SiteSetting.all_communities('SiteLogoPath') %>
@@ -173,165 +169,164 @@ $(() => {
     </div>
     <div class="grid--cell is-6 is-12-sm">
       <span>created:<1w</span> <span class="has-color-tertiary-600">created < 1 week ago</span>
-    </div>
-    <div class="grid--cell is-6 is-12-sm">
-      <span>post_type:xxxx</span> <span class="has-color-tertiary-600">type of post</span>
-    </div>
-  </div>
+            </div>
+            <div class="grid--cell is-6 is-12-sm">
+              <span>post_type:xxxx</span> <span class="has-color-tertiary-600">type of post</span>
+            </div>
+          </div>
 
-  <%= form_tag search_path, method: :get, role: 'search' do %>
-    <div class="grid is-nowrap">
-        <%= search_field_tag :search, params[:search], class: 'form-element' %>
-        <div class="h-m-1">
-          <%= button_tag type: :submit, class: 'button is-filled is-outlined', name: nil do %>
-            <i class="fa fa-search"></i>
+          <%= form_tag search_path, method: :get, role: 'search' do %>
+            <div class="grid is-nowrap">
+              <%= search_field_tag :search, params[:search], class: 'form-element' %>
+              <div class="h-m-1">
+                <%= button_tag type: :submit, class: 'button is-filled is-outlined', name: nil do %>
+                  <i class="fa fa-search"></i>
+                <% end %>
+              </div>
+            </div>
           <% end %>
+          <div class="has-padding-top-2 has-padding-right-1 has-float-right">
+            <a href="<%= help_path('search') %>">Search help</a>
+          </div>
         </div>
-    </div>
-  <% end %>
-  <div class="has-padding-top-2 has-padding-right-1 has-float-right">
-    <a href="<%= help_path('search') %>">Search help</a>
-  </div>
-</div>
 
-<div class="header-slide inbox h-p-0" id="js-inbox">
-  <div class="h-p-2 h-bg-tertiary-050 h-fw-bold">Notifications</div>
-  <div class="h-p-2 h-bg-tertiary-050 h-fw-bold">
-    <a class="no-unread js-read-all-notifs" href="#"><i class="fas fa-envelope-open"></i> Mark all as read</a>
-    <a href="/users/me/notifications" class="button is-muted is-small">See all your notifications &raquo;</a>
-  </div>
-  <div class="inbox--container h-p-2"></div>
-</div>
-<% unless @community.is_fake %>
-<div class="header-slide mobile-menu" id="js-mobile-menu">
-  <div class="menu">
-    <%= link_to 'Users', users_path, class: 'menu--item' %>
-    <%= link_to 'Search', search_path, class: 'menu--item' %>
-
-    <div class='header-slide--separator'></div>
-
-    <%= link_to 'Help', help_center_path, class: 'menu--item' %>	
-
-    <%= link_to 'Dashboard', dashboard_path, class: 'menu--item' %>
-
-    <% if user_signed_in? %>
-      <% if current_user.at_least_moderator? %>
-        <%= link_to (@open_flags > 0) ? flag_queue_path : moderator_path, class: 'menu--item' do %>
-          Mod
-          <% if @open_flags > 0 %>
-            <span class="badge is-status"><%= @open_flags %></span>
-          <% end %>
-        <% end %>
-      <% end %>
-      <% if devise_sign_in_enabled? %>
-        <%= link_to 'Sign Out', destroy_user_session_path, method: :delete, class: 'menu--item', role: 'button' %>
-      <% else %>
-        <%= link_to 'Sign Out', destroy_saml_user_session_path, method: :delete, class: 'menu--item', role: 'button' %>
-      <% end %>
-    <% else %>
-      <% if sso_sign_in_enabled? %>
-        <%= link_to 'SSO Sign In', new_saml_user_session_path, class: 'menu--item' %>
-      <% end %>
-      <% if devise_sign_in_enabled? %>
-        <%= link_to 'Sign In', new_user_session_path, class: 'menu--item' %>
-        <%= link_to 'Sign Up', new_user_registration_path, class: 'menu--item' %>
-      <% end %>
-    <% end %>
-  </div>
-</div>
-<% end %>
-
-
-<% unless @community.is_fake %>
-  <% if expandable? %>
-    <% current_cat = current_category %>
-    <% header_class = current_cat.color_code.present? ? current_cat.color_code : SiteSetting['SiteCategoryHeaderDefaultColor'] %>
-  <% else %>
-    <% header_class = SiteSetting['SiteCategoryHeaderDefaultColor'] %>
-  <% end %>
-  <header class="category-header is-<%= header_class %>">
-    <div class="category-header--tabs">
-      <div class="container category-header--tabs-container">
-        <% @header_categories.each do |cat| %>
-          <% next unless (current_user&.trust_level || 0) >= (cat.min_view_trust_level || -1) %>
-          <%= link_to category_path(cat), class: "category-header--tab #{active?(cat) ? 'is-active' : ''}" do %>
-            <%= cat.name %>
-            <% if user_signed_in? && cat.new_posts_for?(current_user) %>
-              <span class="badge is-status" title="unread activity in category"></span>
-            <% end %>
-          <% end %>
-        <% end %>
-      </div>
-    </div>
-    <% if expandable? %>
-      <div class="container category-header--container">
-        <% if (current_cat&.min_view_trust_level || -1) > 0 %>
-          <i class="fas fa-lock-open h-m-r-2" title="The access to this category is restricted, but you are exempt."></i>
-        <% end %>
-        <div class="category-header--name">
-          <%= current_cat.name %>
+        <div class="header-slide inbox h-p-0" id="js-inbox">
+          <div class="h-p-2 h-bg-tertiary-050 h-fw-bold">Notifications</div>
+          <div class="h-p-2 h-bg-tertiary-050 h-fw-bold">
+            <a class="no-unread js-read-all-notifs" href="#"><i class="fas fa-envelope-open"></i> Mark all as read</a>
+            <a href="/users/me/notifications" class="button is-muted is-small">See all your notifications &raquo;</a>
+          </div>
+          <div class="inbox--container h-p-2"></div>
         </div>
-        <div class="category-header--nav">
-          <%= link_to 'Posts', category_path(current_cat),
-                      class: "category-header--nav-item #{active?(current_cat) && !['tags', 'suggested_edit'].include?(controller_name) ? 'is-active' : ''}" %>
-          <%= link_to 'Tags', category_tags_path(current_cat),
-                      class: "category-header--nav-item #{active?(current_cat) && controller_name == 'tags' ? 'is-active' : ''}" %>
-          <%= link_to suggested_edits_queue_path(current_cat),
-                      class: "category-header--nav-item #{active?(current_cat) && controller_name == 'suggested_edit' ? 'is-active' : ''}" do %>
-            Edits
-            <% if pending_suggestions?  && check_your_privilege('edit_posts') %>
-              <span class="badge is-status" title="Suggested edits pending"></span>
-            <% end %>
-          <% end %>
-          <div class="category-header--nav-separator"></div>
-          <% button_text = current_cat.button_text.present? ? current_cat.button_text : 'Create Post' %>
-          <% if current_cat&.top_level_post_types.any? || admin? %>
-            <%= link_to category_post_types_path(current_cat.id),
-                        class: "category-header--nav-item is-button" do %>
-              <%= button_text %>
-            <% end %>
+        <% unless @community.is_fake %>
+          <div class="header-slide mobile-menu" id="js-mobile-menu">
+            <div class="menu">
+              <%= link_to 'Users', users_path, class: 'menu--item' %>
+              <%= link_to 'Search', search_path, class: 'menu--item' %>
+
+              <div class='header-slide--separator'></div>
+
+              <%= link_to 'Help', help_center_path, class: 'menu--item' %>
+
+              <%= link_to 'Dashboard', dashboard_path, class: 'menu--item' %>
+
+              <% if user_signed_in? %>
+                <% if current_user.at_least_moderator? %>
+                  <%= link_to (@open_flags > 0) ? flag_queue_path : moderator_path, class: 'menu--item' do %>
+                    Mod
+                    <% if @open_flags > 0 %>
+                      <span class="badge is-status"><%= @open_flags %></span>
+                    <% end %>
+                  <% end %>
+                <% end %>
+                <% if devise_sign_in_enabled? %>
+                  <%= link_to 'Sign Out', destroy_user_session_path, method: :delete, class: 'menu--item', role: 'button' %>
+                <% else %>
+                  <%= link_to 'Sign Out', destroy_saml_user_session_path, method: :delete, class: 'menu--item', role: 'button' %>
+                <% end %>
+              <% else %>
+                <% if sso_sign_in_enabled? %>
+                  <%= link_to 'SSO Sign In', new_saml_user_session_path, class: 'menu--item' %>
+                <% end %>
+                <% if devise_sign_in_enabled? %>
+                  <%= link_to 'Sign In', new_user_session_path, class: 'menu--item' %>
+                  <%= link_to 'Sign Up', new_user_registration_path, class: 'menu--item' %>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+
+        <% unless @community.is_fake %>
+          <% if expandable? %>
+            <% current_cat = current_category %>
+            <% header_class = current_cat.color_code.present? ? current_cat.color_code : SiteSetting['SiteCategoryHeaderDefaultColor'] %>
           <% else %>
-            <%= button_tag button_text, class: "button is-muted is-outlined",
+            <% header_class = SiteSetting['SiteCategoryHeaderDefaultColor'] %>
+          <% end %>
+          <header class="category-header is-<%= header_class %>">
+            <div class="category-header--tabs">
+              <div class="container category-header--tabs-container">
+                <% @header_categories.each do |cat| %>
+                  <% next unless (current_user&.trust_level || 0) >= (cat.min_view_trust_level || -1) %>
+                  <%= link_to category_path(cat), class: "category-header--tab #{active?(cat) ? 'is-active' : ''}" do %>
+                    <%= cat.name %>
+                    <% if user_signed_in? && cat.new_posts_for?(current_user) %>
+                      <span class="badge is-status" title="unread activity in category"></span>
+                    <% end %>
+                  <% end %>
+                <% end %>
+              </div>
+            </div>
+            <% if expandable? %>
+              <div class="container category-header--container">
+                <% if (current_cat&.min_view_trust_level || -1) > 0 %>
+                  <i class="fas fa-lock-open h-m-r-2" title="The access to this category is restricted, but you are exempt."></i>
+                <% end %>
+                <div class="category-header--name">
+                  <%= current_cat.name %>
+                </div>
+                <div class="category-header--nav">
+                  <%= link_to 'Posts', category_path(current_cat),
+                      class: "category-header--nav-item #{active?(current_cat) && !['tags', 'suggested_edit'].include?(controller_name) ? 'is-active' : ''}" %>
+                  <%= link_to 'Tags', category_tags_path(current_cat),
+                      class: "category-header--nav-item #{active?(current_cat) && controller_name == 'tags' ? 'is-active' : ''}" %>
+                  <%= link_to suggested_edits_queue_path(current_cat),
+                      class: "category-header--nav-item #{active?(current_cat) && controller_name == 'suggested_edit' ? 'is-active' : ''}" do %>
+                    Edits
+                    <% if pending_suggestions?  && check_your_privilege('edit_posts') %>
+                      <span class="badge is-status" title="Suggested edits pending"></span>
+                    <% end %>
+                  <% end %>
+                  <div class="category-header--nav-separator"></div>
+                  <% button_text = current_cat.button_text.present? ? current_cat.button_text : 'Create Post' %>
+                  <% if current_cat&.top_level_post_types.any? || admin? %>
+                    <%= link_to category_post_types_path(current_cat.id),
+                        class: "category-header--nav-item is-button" do %>
+                      <%= button_text %>
+                    <% end %>
+                  <% else %>
+                    <%= button_tag button_text, class: "button is-muted is-outlined",
                                         disabled: true,
                                         title: "The category doesn't have any allowed post types" %>
-          <% end %>
-        </div>
-      </div>
-    <% end %>
-  </header>
-<% end %>
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
+          </header>
+        <% end %>
 
-<% if Rails.env.development? %>
-  <div class="notice is-danger is-banner has-padding-2 notice__dev-mode has-color-red-900">
-    <div class="container">
-      <p>This site is in development mode!</p>
-    </div>
-  </div>
-<% end %>
+        <% if Rails.env.development? %>
+          <div class="notice is-danger is-banner has-padding-2 notice__dev-mode has-color-red-900">
+            <div class="container">
+              <p>This site is in development mode!</p>
+            </div>
+          </div>
+        <% end %>
 
-<% if read_only? %>
-  <div class="notice is-warning is-filled is-banner has-padding-2 has-color-yellow-900 has-font-size-caption">
-    <div class="container">
-      <p>This site is in read-only mode.</p>
-    </div>
-  </div>
-<% end %>
+        <% if read_only? %>
+          <div class="notice is-warning is-filled is-banner has-padding-2 has-color-yellow-900 has-font-size-caption">
+            <div class="container">
+              <p>This site is in read-only mode.</p>
+            </div>
+          </div>
+        <% end %>
 
-<% if user_signed_in? && session[:impersonator_id].present? %>
-  <div class="notice is-info is-banner is-filled has-padding-2">
-    <div class="container">
-      <p class="has-font-size-caption">
-        You are impersonating <%= current_user.username %>.
-        <%= link_to 'Stop impersonating', stop_impersonating_path, class: 'is-underlined' %>
-      </p>
-    </div>
-  </div>
-<% end %>
+        <% if user_signed_in? && session[:impersonator_id].present? %>
+          <div class="notice is-info is-banner is-filled has-padding-2">
+            <div class="container">
+              <p class="has-font-size-caption">
+                You are impersonating <%= current_user.username %>.
+                <%= link_to 'Stop impersonating', stop_impersonating_path, class: 'is-underlined' %>
+              </p>
+            </div>
+          </div>
+        <% end %>
 
-<% if RequestContext.redis.exists? 'banner_text' %>
-  <div class="notice is-filled <%= RequestContext.redis.get('banner_class') || 'is-warning' %> has-padding-2 is-banner">
-    <div class="container">
-      <%= RequestContext.redis.get 'banner_text' %>
-    </div>
-  </div>
-<% end %>
+        <% if RequestContext.redis.exists? 'banner_text' %>
+          <div class="notice is-filled <%= RequestContext.redis.get('banner_class') || 'is-warning' %> has-padding-2 is-banner">
+            <div class="container">
+              <%= RequestContext.redis.get 'banner_text' %>
+            </div>
+          </div>
+        <% end %>

--- a/app/views/mod_warning/current.html.erb
+++ b/app/views/mod_warning/current.html.erb
@@ -3,62 +3,49 @@
 <p class="is-lead">Hello <span dir="ltr"><%= rtl_safe_username(current_user) %></span>, you have an important message
   from the <%= SiteSetting['SiteName'] %> community moderation team:</p>
 
-
 <% if @warning.is_suspension %>
-    <% if @warning.suspension_active? %>
-        <div class="notice is-danger">
-            <%= raw(sanitize(@warning.body_as_html, scrubber: scrubber)) %>
-            <p>Your account has been <strong>temporarily suspended</strong> (ends <span title="<%= current_user.community_user.suspension_end.iso8601 %>">in <%= time_ago_in_words(current_user.community_user.suspension_end) %></span>). We look forward to your return and continued contributions to the site after this period. In the event of continued rule violations after this period, your account may be suspended for longer periods. If you have any questions about this suspension or would like to dispute it, <a href="mailto:<%= SiteSetting['AdministratorContactEmail'] %>">contact us</a>.</p>
-
-            <% if devise_sign_in_enabled? %>
-                <%= link_to 'Sign Out', destroy_user_session_path, method: :delete, class: 'button is-danger is-outlined', role: 'button' %>
-            <% else %>
-                <%= link_to 'Sign Out', destroy_saml_user_session_path, method: :delete, class: 'button is-danger is-outlined', role: 'button' %>
-            <% end %>
-        </div>
-    <% else %>
-        <div class="notice is-danger">
-            <%= raw(sanitize(@warning.body_as_html, scrubber: scrubber)) %>
-            <p>Your account was <strong>temporarily suspended</strong>, but the suspension period is now over. We look forward to your return and continued contributions to the site. In the event of continued rule violations after this period, however, your account may be suspended for longer periods. If you have any questions regarding the site rules, you can ask them in the Meta category of this site or on <a href="https://meta.codidact.com/">meta.codidact.com</a>.</p></p>
-
-            <%= form_with url: current_mod_warning_approve_path, method: 'post' do %>
-                <label for="approve-checkbox" class="form-element h-m-v-2">
-                    <input type="checkbox" class="form-checkbox-element" id="approve-checkbox" name="approve_checkbox">
-                    <% if @failed_to_click_checkbox %>
-                        <strong>You need to accept this in order to continue:</strong>
-                    <% end %>
-                    I have read this suspension message and will follow the rules from now on.
-                </label>
-
-                <%= submit_tag 'Continue', class: 'button is-filled' %>
-                <% if devise_sign_in_enabled? %>
-                    <%= link_to 'Sign Out', destroy_user_session_path, method: :delete, class: 'button is-danger is-outlined', role: 'button' %>
-                <% else %>
-                    <%= link_to 'Sign Out', destroy_saml_user_session_path, method: :delete, class: 'button is-danger is-outlined', role: 'button' %>
-                <% end %>
-            <% end %>
-        </div>
-    <% end %>
-<% else %>
-    <div class="notice is-warning">
-        <%= raw(sanitize(@warning.body_as_html, scrubber: scrubber)) %>
-        <p>This is <strong>a formal warning</strong> from the moderation team. In the event of continued violations of the site rules, your account may be suspended. If you have any questions regarding the site rules, you can ask them in the Meta category of this site or on <a href="https://meta.codidact.com/">meta.codidact.com</a>. If you have any questions about this warning or would like to dispute it, <a href="mailto:<%= SiteSetting['AdministratorContactEmail'] %>">contact us</a>.</p>
-
-        <%= form_with url: current_mod_warning_approve_path, method: 'post' do %>
-            <label for="approve-checkbox" class="form-element h-m-v-2">
-                <input type="checkbox" class="form-checkbox-element" id="approve-checkbox" name="approve_checkbox">
-                <% if @failed_to_click_checkbox %>
-                    <strong>You need to accept this in order to continue:</strong>
-                <% end %>
-                I have read this warning and will follow the rules from now on.
-            </label>
-
-            <%= submit_tag 'Continue', class: 'button is-filled' %>
-            <% if devise_sign_in_enabled? %>
-                <%= link_to 'Sign Out', destroy_user_session_path, method: :delete, class: 'button is-danger is-outlined', role: 'button' %>
-            <% else %>
-                <%= link_to 'Sign Out', destroy_saml_user_session_path, method: :delete, class: 'button is-danger is-outlined', role: 'button' %>
-            <% end %>
-        <% end %>
+  <% if @warning.suspension_active? %>
+    <div class="notice is-danger">
+      <%= raw(sanitize(@warning.body_as_html, scrubber: scrubber)) %>
+      <p>Your account has been <strong>temporarily suspended</strong> (ends <span title="<%= current_user.community_user.suspension_end.iso8601 %>">in <%= time_ago_in_words(current_user.community_user.suspension_end) %></span>). We look forward to your return and continued contributions to the site after this period. In the event of continued rule violations after this period, your account may be suspended for longer periods. If you have any questions about this suspension or would like to dispute it, <a href="mailto:<%= SiteSetting['AdministratorContactEmail'] %>">contact us</a>.</p>
+      <%= render 'users/sessions/sign_out', is_danger: true %>
     </div>
+  <% else %>
+    <div class="notice is-danger">
+      <%= raw(sanitize(@warning.body_as_html, scrubber: scrubber)) %>
+      <p>Your account was <strong>temporarily suspended</strong>, but the suspension period is now over. We look forward to your return and continued contributions to the site. In the event of continued rule violations after this period, however, your account may be suspended for longer periods. If you have any questions regarding the site rules, you can ask them in the Meta category of this site or on <a href="https://meta.codidact.com/">meta.codidact.com</a>.</p>
+    </p>
+
+    <%= form_with url: current_mod_warning_approve_path, method: 'post' do %>
+      <label for="approve-checkbox" class="form-element h-m-v-2">
+        <input type="checkbox" class="form-checkbox-element" id="approve-checkbox" name="approve_checkbox">
+        <% if @failed_to_click_checkbox %>
+          <strong>You need to accept this in order to continue:</strong>
+        <% end %>
+        I have read this suspension message and will follow the rules from now on.
+      </label>
+
+      <%= submit_tag 'Continue', class: 'button is-filled' %>
+      <%= render 'users/sessions/sign_out', is_danger: true %>
+    <% end %>
+  </div>
+<% end %>
+<% else %>
+  <div class="notice is-warning">
+    <%= raw(sanitize(@warning.body_as_html, scrubber: scrubber)) %>
+    <p>This is <strong>a formal warning</strong> from the moderation team. In the event of continued violations of the site rules, your account may be suspended. If you have any questions regarding the site rules, you can ask them in the Meta category of this site or on <a href="https://meta.codidact.com/">meta.codidact.com</a>. If you have any questions about this warning or would like to dispute it, <a href="mailto:<%= SiteSetting['AdministratorContactEmail'] %>">contact us</a>.</p>
+
+    <%= form_with url: current_mod_warning_approve_path, method: 'post' do %>
+      <label for="approve-checkbox" class="form-element h-m-v-2">
+        <input type="checkbox" class="form-checkbox-element" id="approve-checkbox" name="approve_checkbox">
+        <% if @failed_to_click_checkbox %>
+          <strong>You need to accept this in order to continue:</strong>
+        <% end %>
+        I have read this warning and will follow the rules from now on.
+      </label>
+
+      <%= submit_tag 'Continue', class: 'button is-filled' %>
+      <%= render 'users/sessions/sign_out', is_danger: true %>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/users/sessions/_sign_out.html.erb
+++ b/app/views/users/sessions/_sign_out.html.erb
@@ -1,0 +1,16 @@
+<%#
+   "Renders a sign out button depending on what sign in method is enabled (Devise or SAML)
+
+   Variables:
+   ? is_danger : whether the button should be rended as a dangerous action
+"%>
+
+<%
+  is_danger = defined?(is_danger) ? is_danger : false
+%>
+
+<%= link_to 'Sign Out',
+            devise_sign_in_enabled? ? destroy_user_session_path : destroy_saml_user_session_path,
+            class: "button #{is_danger ? 'is-outlined is-danger' : 'is-muted'}",
+            method: :delete,
+            role: 'button' %>


### PR DESCRIPTION
closes #1813

Also fixes an issue I noticed while testing the changes - it's impossible to stop impersonating suspended users because we forgot to add exceptions (I took the time to also heavily simplify the action callback).

The PR makes the "sign out" button always visible in the header for logged in users (as long as the screen's width allows for it) - it occupies the space otherwise taken by the "sign up" and "sign in" buttons:

<img width="1169" height="96" alt="Screenshot from 2025-09-25 14-27-48" src="https://github.com/user-attachments/assets/f3f1c33c-8eb5-4a09-a3f6-dee00df0f0af" />

Since the button is now always visible, it is removed from the community switcher to avoid duplication that's unnecessary in this case (if you are curious about what happened to the community list - this is how it looks like with communities without logos):

<img width="553" height="217" alt="Screenshot from 2025-09-25 14-28-10" src="https://github.com/user-attachments/assets/91d70f94-906c-41c5-acce-6d2465439c21" />

No changes on mobile (on narrow screens, to be precise) - the button is only shown inside the dropdown:

<img width="553" height="350" alt="Screenshot from 2025-09-25 14-28-02" src="https://github.com/user-attachments/assets/481be1ee-cf60-4278-b285-7b354f12c868" />
