### PR TITLE
Improve tag rename error handling & messages

### DIFF
--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -430,9 +430,9 @@ window.QPixel = {
   },
 
   handleJSONResponse: (data, onSuccess, onFinally) => {
-    const is_failed = data.status === 'failed';
+    const isFailed = data.status === 'failed';
 
-    if(is_failed) {
+    if(isFailed) {
       if (data.message) {
         QPixel.createNotification('danger', data.message);
       }
@@ -447,7 +447,7 @@ window.QPixel = {
 
     onFinally?.(data);
 
-    return !is_failed;
+    return !isFailed;
   },
 
   flag: async (flag) => {

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -430,19 +430,24 @@ window.QPixel = {
   },
 
   handleJSONResponse: (data, onSuccess, onFinally) => {
-    const is_modified = data.status === 'modified';
-    const is_success = data.status === 'success';
+    const is_failed = data.status === 'failed';
 
-    if (is_modified || is_success) {
-      onSuccess(/** @type {Parameters<typeof onSuccess>[0]} */(data));
+    if(is_failed) {
+      if (data.message) {
+        QPixel.createNotification('danger', data.message);
+      }
+
+      for (const error of data.errors ?? []) {
+        QPixel.createNotification('danger', error);
+      }
     }
     else {
-      QPixel.createNotification('danger', data.message);
+      onSuccess(/** @type {Parameters<typeof onSuccess>[0]} */(data));
     }
 
     onFinally?.(data);
 
-    return is_success;
+    return !is_failed;
   },
 
   flag: async (flag) => {

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -433,12 +433,22 @@ window.QPixel = {
     const isFailed = data.status === 'failed';
 
     if(isFailed) {
-      if (data.message) {
-        QPixel.createNotification('danger', data.message);
-      }
+      const { errors = [], message } = data;
 
-      for (const error of data.errors ?? []) {
-        QPixel.createNotification('danger', error);
+      if (message) {
+        const fullMessage =
+          errors.length > 1
+            ? `${message}:<ul>${errors.map((e) => `<li>${e.trim()}</li>`).join('')}</ul>`
+            : errors.length === 1
+              ? `${message} (${errors[0].toLowerCase().trim()})`
+              : message;
+
+          QPixel.createNotification('danger', fullMessage);
+      }
+      else {
+        for (const error of errors) {
+          QPixel.createNotification('danger', error);
+        }
       }
     }
     else {

--- a/app/assets/javascripts/tags.js
+++ b/app/assets/javascripts/tags.js
@@ -1,4 +1,4 @@
-$(() => {
+document.addEventListener('DOMContentLoaded', () => {
   const sum = (/** @type {number[]} */ ary) => ary.reduce((a, b) => a + b, 0);
 
   /**
@@ -135,10 +135,10 @@ $(() => {
     $newTagSynonym.show();
 
     //Add handler for removing an element
-    $newTagSynonym.find(`.remove-tag-synonym`).click(removeTagSynonym);
+    $newTagSynonym.find(`.remove-tag-synonym`).on('click', removeTagSynonym);
   });
 
-  $('.remove-tag-synonym').click(removeTagSynonym);
+  $('.remove-tag-synonym').on('click', removeTagSynonym);
 
   function removeTagSynonym() {
     const synonym = $(this).closest('.tag-synonym');

--- a/app/assets/javascripts/tags.js
+++ b/app/assets/javascripts/tags.js
@@ -168,7 +168,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const tagId = $tgt.attr('data-tag');
     const tagName = $tgt.attr('data-name');
 
-    const renameTo = prompt(`Rename tag ${tagName} to:`);
+    const renameTo = prompt(`Rename tag "${tagName}" to:`);
 
     if (!renameTo) {
       return;

--- a/app/assets/javascripts/tags.js
+++ b/app/assets/javascripts/tags.js
@@ -1,12 +1,3 @@
-/**
- * @typedef {{
- *  id: number | string
- *  text: string
- *  desc: string
- *  synonyms?: string | QPixelTagSynonym[]
- * }} ProcessedTag
- */
-
 $(() => {
   const sum = (/** @type {number[]} */ ary) => ary.reduce((a, b) => a + b, 0);
 
@@ -35,11 +26,11 @@ $(() => {
     const tagSynonyms = !!tag.synonyms ? ` <i>(${tag.synonyms})</i>` : '';
     const tagSpan = `<span>${tag.text}${tagSynonyms}</span>`;
     let desc = !!tag.desc ? splitWordsMaxLength(tag.desc, 120) : '';
-    const descSpan = !!tag.desc ?
-      `<br/><span class="has-color-tertiary-900 has-font-size-caption">${desc[0]}${desc.length > 1 ? '...' : ''}</span>` :
-      '';
+    const descSpan = !!tag.desc
+      ? `<br/><span class="has-color-tertiary-900 has-font-size-caption">${desc[0]}${desc.length > 1 ? '...' : ''}</span>`
+      : '';
     return $(tagSpan + descSpan);
-  }
+  };
 
   $('.js-tag-select').each((_i, el) => {
     const $tgt = $(el);
@@ -49,10 +40,10 @@ $(() => {
       tags: $tgt.attr('data-create') !== 'false',
       /**
        * @param {Select2.IdTextPair[]} data
-       * @param {Select2.IdTextPair & { desc?: string }} tag 
+       * @param {Select2.IdTextPair & { desc?: string }} tag
        */
       insertTag: function (data, tag) {
-        tag.desc = "(Create new tag)"
+        tag.desc = '(Create new tag)';
         // Insert the tag at the end of the results
         data.push(tag);
       },
@@ -66,7 +57,7 @@ $(() => {
           }
           return Object.assign(params, { tag_set: $this.data('tag-set') });
         },
-        headers: { 'Accept': 'application/json' },
+        headers: { Accept: 'application/json' },
         delay: 100,
         /**
          * @param {QPixelTag[]} data
@@ -80,23 +71,23 @@ $(() => {
                 { id: 1, text: 'hot-red-firebreather', desc: 'Very cute dragon' },
                 { id: 2, text: 'training', desc: 'How to train a dragon' },
                 { id: 3, text: 'behavior', desc: 'How a dragon behaves' },
-                { id: 4, text: 'sapphire-blue-waterspouter', desc: 'Other cute dragon' }
-              ]
-            }
+                { id: 4, text: 'sapphire-blue-waterspouter', desc: 'Other cute dragon' },
+              ],
+            };
           }
           return {
             results: data.map((t) => ({
               id: useIds ? t.id : t.name,
               text: t.name.replace(/</g, '&#x3C;').replace(/>/g, '&#x3E;'),
               synonyms: processSynonyms($this, t.tag_synonyms),
-              desc: t.excerpt
-            }))
+              desc: t.excerpt,
+            })),
           };
         },
       },
       placeholder: '',
       templateResult: template,
-      allowClear: true
+      allowClear: true,
     });
   });
 
@@ -112,10 +103,13 @@ $(() => {
     if (synonyms.length > 3) {
       const searchValue = $search.data('select2').selection.$search.val().toLowerCase();
       displayedSynonyms = synonyms.filter((ts) => ts.name.includes(searchValue)).slice(0, 3);
-    } else {
+    }
+    else {
       displayedSynonyms = synonyms;
     }
-    let synonymsString = displayedSynonyms.map((ts) => `${ts.name.replace(/</g, '&#x3C;').replace(/>/g, '&#x3E;')}`).join(', ');
+    let synonymsString = displayedSynonyms
+      .map((ts) => `${ts.name.replace(/</g, '&#x3C;').replace(/>/g, '&#x3E;')}`)
+      .join(', ');
     if (synonyms.length > displayedSynonyms.length) {
       synonymsString += `, ${synonyms.length - displayedSynonyms.length} more synonyms`;
     }
@@ -128,10 +122,10 @@ $(() => {
     const newId = parseInt(lastId, 10) + 1;
 
     //Duplicate the first element at the end of the wrapper
-    const newField = $wrapper.find('.tag-synonym[data-id="0"]')[0]
-                             .outerHTML
-                             .replace(/data-id="0"/g, 'data-id="' + newId + '"')
-                             .replace(/(?<connector>attributes(\]\[)|(_))0/g, '$<connector>' + newId)
+    const newField = $wrapper
+      .find('.tag-synonym[data-id="0"]')[0]
+      .outerHTML.replace(/data-id="0"/g, 'data-id="' + newId + '"')
+      .replace(/(?<connector>attributes(\]\[)|(_))0/g, '$<connector>' + newId);
     $wrapper.append(newField);
 
     //Alter the newly added tag synonym

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -155,7 +155,7 @@ class TagsController < ApplicationController
       render json: { status: 'success', tag: @tag }
     else
       render json: { status: 'failed',
-                     message: helpers.tag_rename_error_msg(@tag),
+                     errors: @tag.errors.messages.values.flatten,
                      tag: @tag },
              status: :bad_request
     end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -94,10 +94,8 @@ class TagsController < ApplicationController
   def create
     @tag = Tag.new(tag_params.merge(tag_set_id: @category.tag_set.id))
     if @tag.save
-      flash[:danger] = nil
       redirect_to tag_path(id: @category.id, tag_id: @tag.id)
     else
-      flash[:danger] = @tag.errors.full_messages.join(', ')
       render :new, status: :bad_request
     end
   end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -155,7 +155,7 @@ class TagsController < ApplicationController
       render json: { status: 'success', tag: @tag }
     else
       render json: { status: 'failed',
-                     message: I18n.t('tags.errors.rename_generic'),
+                     message: helpers.tag_rename_error_msg(@tag),
                      tag: @tag },
              status: :bad_request
     end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -155,7 +155,8 @@ class TagsController < ApplicationController
       render json: { status: 'success', tag: @tag }
     else
       render json: { status: 'failed',
-                     errors: @tag.errors.messages.values.flatten,
+                     message: I18n.t('tags.errors.rename_generic'),
+                     errors: @tag.errors.full_messages,
                      tag: @tag },
              status: :bad_request
     end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -38,4 +38,15 @@ module TagsHelper
     sql = "SELECT post_id FROM posts_tags WHERE tag_id IN #{ApplicationRecord.sanitize_sql_in(tag_ids)}"
     ActiveRecord::Base.connection.execute(sql).to_a.flatten
   end
+
+  # Gets a standard tag rename error message for a tag
+  # @param post [Tag] target tag
+  # @return [String] error message
+  def tag_rename_error_msg(tag)
+    if tag.errors.where(:name, :taken)
+      I18n.t('tags.errors.rename_taken')
+    else
+      I18n.t('tags.errors.rename_generic')
+    end
+  end
 end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -38,15 +38,4 @@ module TagsHelper
     sql = "SELECT post_id FROM posts_tags WHERE tag_id IN #{ApplicationRecord.sanitize_sql_in(tag_ids)}"
     ActiveRecord::Base.connection.execute(sql).to_a.flatten
   end
-
-  # Gets a standard tag rename error message for a tag
-  # @param post [Tag] target tag
-  # @return [String] error message
-  def tag_rename_error_msg(tag)
-    if tag.errors.where(:name, :taken)
-      I18n.t('tags.errors.rename_taken')
-    else
-      I18n.t('tags.errors.rename_generic')
-    end
-  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -13,11 +13,11 @@ class Tag < ApplicationRecord
   validates :excerpt, length: { maximum: 600 }, allow_blank: true
   validates :wiki_markdown, length: { maximum: 30_000 }, allow_blank: true
   validates :name, presence: {
-    message: I18n.t('tags.errors.no_blank_name')
+    message: I18n.t('tags.validation.errors.no_blank_name')
   }
   validates :name, format: {
     with: /\A[^\s]+\Z/, # https://regex101.com/r/7BxgIn/1
-    message: I18n.t('tags.errors.no_spaces_in_name')
+    message: I18n.t('tags.validation.errors.no_spaces_in_name')
   }
   validate :parent_not_self
   validate :parent_not_own_child
@@ -25,7 +25,7 @@ class Tag < ApplicationRecord
   validates :name, uniqueness: {
     scope: [:tag_set_id],
     case_sensitive: false,
-    message: I18n.t('tags.errors.no_duplicate_names')
+    message: I18n.t('tags.validation.errors.no_duplicate_names')
   }
 
   # scopes

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -12,11 +12,21 @@ class Tag < ApplicationRecord
 
   validates :excerpt, length: { maximum: 600 }, allow_blank: true
   validates :wiki_markdown, length: { maximum: 30_000 }, allow_blank: true
-  validates :name, presence: true, format: { with: /[^ \t]+/, message: 'Tag names may not include spaces' }
+  validates :name, presence: {
+    message: I18n.t('tags.errors.no_blank_name')
+  }
+  validates :name, format: {
+    with: /\A[^\s]+\Z/, # https://regex101.com/r/7BxgIn/1
+    message: I18n.t('tags.errors.no_spaces_in_name')
+  }
   validate :parent_not_self
   validate :parent_not_own_child
   validate :synonym_unique
-  validates :name, uniqueness: { scope: [:tag_set_id], case_sensitive: false }
+  validates :name, uniqueness: {
+    scope: [:tag_set_id],
+    case_sensitive: false,
+    message: I18n.t('tags.errors.no_duplicate_names')
+  }
 
   # scopes
   scope :list_includes, -> { includes(:tag_synonyms) }

--- a/config/locales/strings/en.tags.yml
+++ b/config/locales/strings/en.tags.yml
@@ -1,5 +1,7 @@
 en:
   tags:
     errors:
+      rename_taken: >
+        A tag with that name already exists.
       rename_generic: >
         Failed to rename the tag.

--- a/config/locales/strings/en.tags.yml
+++ b/config/locales/strings/en.tags.yml
@@ -1,7 +1,11 @@
 en:
   tags:
     errors:
-      rename_taken: >
+      no_blank_name: >
+        Tag name should contain at least 1 character.
+      no_duplicate_names: >
         A tag with that name already exists.
+      no_spaces_in_name: >
+        Tag names may not contain spaces.
       rename_generic: >
         Failed to rename the tag.

--- a/config/locales/strings/en.tags.yml
+++ b/config/locales/strings/en.tags.yml
@@ -1,11 +1,13 @@
 en:
   tags:
+    validation:
+      errors:
+        no_blank_name: >
+          should contain at least 1 character
+        no_duplicate_names: >
+          cannot match an already existing tag
+        no_spaces_in_name: >
+          should not contain spaces
     errors:
-      no_blank_name: >
-        Tag name should contain at least 1 character.
-      no_duplicate_names: >
-        A tag with that name already exists.
-      no_spaces_in_name: >
-        Tag names may not contain spaces.
       rename_generic: >
-        Failed to rename the tag.
+        Failed to rename the tag

--- a/global.d.ts
+++ b/global.d.ts
@@ -12,6 +12,13 @@ interface PostValidatorMessage {
 
 type PostValidator = (postText: string) => [boolean, PostValidatorMessage[]];
 
+ interface ProcessedTag {
+  id: number | string
+  text: string
+  desc: string
+  synonyms?: string | QPixelTagSynonym[]
+ }
+
 interface UserPreferences {
   community: Record<string, string | null>;
   global: Record<string, string | null>;

--- a/test/controllers/tags_controller_test.rb
+++ b/test/controllers/tags_controller_test.rb
@@ -37,12 +37,14 @@ class TagsControllerTest < ActionController::TestCase
 
   test 'should get category tags list' do
     get :category, params: { id: categories(:main).id }
+
     assert_response(:success)
     assert_not_nil assigns(:tags)
     assert_not_nil assigns(:category)
 
     sign_in users(:standard_user)
     get :category, params: { id: categories(:main).id }
+
     assert_response(:success)
     assert_not_nil assigns(:tags)
     assert_not_nil assigns(:category)
@@ -50,12 +52,14 @@ class TagsControllerTest < ActionController::TestCase
 
   test 'should get children list' do
     get :children, params: { id: categories(:main).id, tag_id: tags(:topic).id }
+
     assert_response(:success)
     assert_not_nil assigns(:tags)
     assert_not_nil assigns(:category)
 
     sign_in users(:standard_user)
     get :children, params: { id: categories(:main).id, tag_id: tags(:topic).id }
+
     assert_response(:success)
     assert_not_nil assigns(:tags)
     assert_not_nil assigns(:category)
@@ -63,6 +67,7 @@ class TagsControllerTest < ActionController::TestCase
 
   test 'should get tag page and RSS' do
     get :show, params: { id: categories(:main).id, tag_id: tags(:topic).id }
+
     assert_response(:success)
     assert_not_nil assigns(:tag)
     assert_not_nil assigns(:category)
@@ -70,6 +75,7 @@ class TagsControllerTest < ActionController::TestCase
 
     sign_in users(:standard_user)
     get :show, params: { id: categories(:main).id, tag_id: tags(:topic).id }
+
     assert_response(:success)
     assert_not_nil assigns(:tag)
     assert_not_nil assigns(:category)
@@ -78,6 +84,7 @@ class TagsControllerTest < ActionController::TestCase
 
   test 'should get tag RSS feed' do
     get :show, params: { id: categories(:main).id, tag_id: tags(:topic).id, format: :rss }
+
     assert_response(:success)
     assert_not_nil assigns(:tag)
     assert_not_nil assigns(:category)
@@ -85,6 +92,7 @@ class TagsControllerTest < ActionController::TestCase
 
     sign_in users(:standard_user)
     get :show, params: { id: categories(:main).id, tag_id: tags(:topic).id, format: :rss }
+
     assert_response(:success)
     assert_not_nil assigns(:tag)
     assert_not_nil assigns(:category)
@@ -93,18 +101,21 @@ class TagsControllerTest < ActionController::TestCase
 
   test 'should deny edit to anonymous user' do
     get :edit, params: { id: categories(:main).id, tag_id: tags(:topic).id }
+
     assert_redirected_to_sign_in
   end
 
   test 'should deny edit to unprivileged user' do
     sign_in users(:standard_user)
     get :edit, params: { id: categories(:main).id, tag_id: tags(:topic).id }
+
     assert_response(:forbidden)
   end
 
   test 'should get edit' do
     sign_in users(:deleter)
     get :edit, params: { id: categories(:main).id, tag_id: tags(:topic).id }
+
     assert_response(:success)
     assert_not_nil assigns(:tag)
     assert_not_nil assigns(:category)
@@ -113,6 +124,7 @@ class TagsControllerTest < ActionController::TestCase
   test 'should deny update to anonymous user' do
     patch :update, params: { id: categories(:main).id, tag_id: tags(:topic).id,
                              tag: { parent_id: tags(:discussion).id, excerpt: 'things' } }
+
     assert_redirected_to_sign_in
   end
 
@@ -120,6 +132,7 @@ class TagsControllerTest < ActionController::TestCase
     sign_in users(:standard_user)
     patch :update, params: { id: categories(:main).id, tag_id: tags(:topic).id,
                              tag: { parent_id: tags(:discussion).id, excerpt: 'things' } }
+
     assert_response(:forbidden)
   end
 
@@ -127,6 +140,7 @@ class TagsControllerTest < ActionController::TestCase
     sign_in users(:deleter)
     patch :update, params: { id: categories(:main).id, tag_id: tags(:topic).id,
                              tag: { parent_id: tags(:discussion).id, excerpt: 'things' } }
+
     assert_response(:found)
     assert_redirected_to tag_path(id: categories(:main).id, tag_id: tags(:topic).id)
     assert_not_nil assigns(:tag)
@@ -138,6 +152,7 @@ class TagsControllerTest < ActionController::TestCase
     sign_in users(:deleter)
     patch :update, params: { id: categories(:main).id, tag_id: tags(:topic).id,
                              tag: { tag_synonyms_attributes: { '1': { name: 'conversation' } } } }
+
     assert_response(:found)
     assert_redirected_to tag_path(id: categories(:main).id, tag_id: tags(:topic).id)
     assert_not_nil assigns(:tag)
@@ -148,6 +163,7 @@ class TagsControllerTest < ActionController::TestCase
     sign_in users(:deleter)
     patch :update, params: { id: categories(:main).id, tag_id: tags(:base).id,
                              tag: { tag_synonyms_attributes: { '1': { id: tag_synonyms(:base_synonym).id, _destroy: 'true' } } } }
+
     assert_response(:found)
     assert_redirected_to tag_path(id: categories(:main).id, tag_id: tags(:base).id)
     assert_not_nil assigns(:tag)
@@ -158,6 +174,7 @@ class TagsControllerTest < ActionController::TestCase
     sign_in users(:deleter)
     patch :update, params: { id: categories(:main).id, tag_id: tags(:topic).id,
                              tag: { parent_id: tags(:topic).id, excerpt: 'things' } }
+
     assert_response(:bad_request)
     assert_not_nil assigns(:tag)
     assert_equal ['A tag cannot be its own parent.'], assigns(:tag).errors.full_messages
@@ -167,6 +184,7 @@ class TagsControllerTest < ActionController::TestCase
     sign_in users(:deleter)
     patch :update, params: { id: categories(:main).id, tag_id: tags(:topic).id,
                              tag: { parent_id: tags(:child).id, excerpt: 'things' } }
+
     assert_response(:bad_request)
     assert_not_nil assigns(:tag)
     assert_equal ["The #{tags(:child).name} tag is already a child of this tag."], assigns(:tag).errors.full_messages
@@ -180,12 +198,8 @@ class TagsControllerTest < ActionController::TestCase
 
     try_rename_tag(categories(:main), tag, new_tag_name)
 
-    assert_response(:success)
-    assert_valid_json_response
-
+    assert_json_success
     res_body = JSON.parse(response.body)
-
-    assert_equal 'success', res_body['status']
     assert_equal new_tag_name, res_body['tag']['name']
 
     log_entry = AuditLog.last
@@ -201,13 +215,9 @@ class TagsControllerTest < ActionController::TestCase
 
     try_rename_tag(categories(:main), tag, '')
 
-    assert_response(:bad_request)
-    assert_valid_json_response
-
+    assert_json_failure(:bad_request)
     res_body = JSON.parse(response.body)
-
-    assert_equal 'failed', res_body['status']
-    assert_equal I18n.t('tags.errors.rename_generic'), res_body['message']
+    assert_equal @controller.helpers.tag_rename_error_msg(tag), res_body['message']
     tag.reload
     assert_equal tag.name, old_tag_name
   end

--- a/test/controllers/tags_controller_test.rb
+++ b/test/controllers/tags_controller_test.rb
@@ -224,8 +224,6 @@ class TagsControllerTest < ActionController::TestCase
       res_body = JSON.parse(response.body)
       error_message = I18n.t("tags.validation.errors.#{error_key}")
 
-      Rails.logger.warn(res_body['errors'])
-
       assert res_body['errors'].any? { |msg| msg.include?(error_message) },
              "Expected '#{error_message}' to be among the errors"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -136,6 +136,15 @@ class ActiveSupport::TestCase
     end
   end
 
+  def assert_json_failure(code, status: 'failed')
+    assert_response(code)
+    assert_nothing_raised do
+      parsed = JSON.parse(response.body)
+      assert_not_nil(parsed)
+      assert_equal status, parsed['status']
+    end
+  end
+
   def assert_json_success(status: 'success')
     assert_response(:success)
     assert_nothing_raised do


### PR DESCRIPTION
closes #1851

Also fixes an old bug preventing validation for tags with spaces from taking effect.

Error notification when the new tag name contains spaces:

<img width="819" height="91" alt="Screenshot from 2025-09-29 14-21-04" src="https://github.com/user-attachments/assets/246b2283-269b-4293-a912-6f4f955a9eed" />

Error notification when the new tag name matches an already existing tag:

<img width="819" height="91" alt="Screenshot from 2025-09-29 14-21-14" src="https://github.com/user-attachments/assets/5a272d16-3afc-42b9-b4ed-3c23f22232e9" />

As a treat, it also ensures old tag names are quoted in the rename prompt (on a tangent, we should move from a prompt to a proper modal dialog, but this is outside of the scope of this PR):

<img width="408" height="48" alt="image" src="https://github.com/user-attachments/assets/0513b100-4bbf-48a1-9925-940b7e5d6d11" />

Compared to how it is now:

<img width="405" height="47" alt="Screenshot from 2025-09-28 12-52-15" src="https://github.com/user-attachments/assets/b6f423a5-6488-4886-99df-97a8e630b9d6" />

Finally, it also changes error handling for tag creation (see https://github.com/codidact/qpixel/pull/1852#issuecomment-3343951054) a bit:

- removes duplicate error flashes after failing to create tags;
- improves the combined error message shown upon failure to create a tag (no actual changes, just a nice side-effect of other changes):

    <img width="763" height="159" alt="Screenshot from 2025-09-29 14-52-59" src="https://github.com/user-attachments/assets/a5dbe395-1ffd-4245-ab9c-ce8e0f86fe2f" />

