### PR TITLE
Remove extremely high z-index for Select2 containers causing them to render over modal backgrounds

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -47,7 +47,6 @@ select.form-element {
 
 .select2-container {
   width: 100% !important;
-  z-index: 8999;
 }
 
 .select2-results__option {


### PR DESCRIPTION
closes #1546

This is necessary - `z-index` needs to be added only when there is _no other way,_ not the other way around, otherwise it always ends up in issues like this one (not to mention that Select2 already controls the property for its dropdowns, there's no need to interfere with it). I've checked what I could - do let me know if `z-index` now needs to be slightly increased in some places to avoid overlapping.