### PR TITLE
Add error report filtering by type

### DIFF
--- a/app/assets/javascripts/error_reports.js
+++ b/app/assets/javascripts/error_reports.js
@@ -1,0 +1,5 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.js-error-type-select').forEach((el) => {
+    $(el).select2();
+  });
+});

--- a/app/assets/stylesheets/error_reports.scss
+++ b/app/assets/stylesheets/error_reports.scss
@@ -1,0 +1,33 @@
+@import 'variables';
+
+.error-reports-filters {
+
+  .form-group-horizontal .actions,
+  .select2-container {
+    height: 37px;
+    margin: 4px 0px;
+  }
+
+  .select2-container {
+    .selection {
+      .select2-selection {
+        border-color: $muted-graphic;
+        height: 100%;
+        padding: 4px 0;
+      }
+
+      .select2-selection__arrow {
+        top: 50%;
+        translate: 0 -50%;
+      }
+    }
+  }
+
+  .form-group-horizontal {
+    .actions {
+      .button {
+        margin: 0;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/utilities.scss
+++ b/app/assets/stylesheets/utilities.scss
@@ -38,6 +38,10 @@
   flex-direction: column;
   flex-wrap: wrap;
 
+  &.items-end {
+    align-items: end;
+  }
+
   &.space-between {
     justify-content: space-between;
   }

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -11,11 +11,15 @@ class AdminController < ApplicationController
   def index; end
 
   def error_reports
-    base_scope = if current_user.is_global_admin
+    base_scope = if current_user.global_admin?
                    ErrorLog.all
                  else
                    ErrorLog.where(community: RequestContext.community)
                  end
+
+    if params[:type].present?
+      base_scope = base_scope.where(klass: params[:type])
+    end
 
     if params[:uuid].present?
       base_scope = base_scope.where(uuid: params[:uuid])

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -17,6 +17,8 @@ class AdminController < ApplicationController
                    ErrorLog.where(community: RequestContext.community)
                  end
 
+    @error_types = base_scope.select(:klass).distinct.to_a.map(&:klass)
+
     if params[:type].present?
       base_scope = base_scope.where(klass: params[:type])
     end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -86,8 +86,8 @@ module UsersHelper
   end
 
   ##
-  # Is the specified user deleted, either globally or on the current community?
-  # @param user [User]
+  # Is a gven user deleted (globally or on the current community)?
+  # @param user [User, nil] user to check
   # @return [Boolean] check result - true if the user is +nil+.
   def deleted_user?(user)
     return true if user.nil?
@@ -97,7 +97,7 @@ module UsersHelper
 
   ##
   # Get a RTL-safe string of the specified user's username. Appends an RTL terminator to the username.
-  # @param user [User]
+  # @param user [User, nil] user to get RTL-safe username for
   # @return [String]
   def rtl_safe_username(user)
     deleted_user?(user) ? 'deleted user' : user&.rtl_safe_username

--- a/app/views/admin/_error_report.html.erb
+++ b/app/views/admin/_error_report.html.erb
@@ -27,7 +27,7 @@
 
     <% if report.version? %>
       <br/>
-      <strong>Version:</strong>
+      <strong><%= t('g.version').capitalize %>:</strong>
       <%= link_to report.version, query_url(version: report.version) %>
     <% end %>
   </p>

--- a/app/views/admin/error_reports.html.erb
+++ b/app/views/admin/error_reports.html.erb
@@ -1,30 +1,31 @@
 <h1><%= t 'admin.tools.error_reports' %></h1>
-<p class="is-lead"><%= pluralize(@reports.count, t('g.error')) %> <%= t 'g.logged' %></p>
+<p class="is-lead"><%= pluralize(@reports.count, t('g.error')) %> <%= t('g.logged') %></p>
 
-<div class="flex-row">
+<div class="error-reports-filters flex-row items-end">
   <%= form_tag admin_error_reports_path, method: :get, class: 'has-margin-bottom-4 primary' do %>
     <div class="form-group-horizontal">
       <div class="form-group">
-        <%= label_tag :uuid, t('admin.error_search_uuid') %>
-        <%= text_field_tag :uuid, params[:uuid], class: 'form-element', placeholder: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' %>
+        <%= label_tag :type, 'Error type' %>
+        <%= select_tag :type,
+                       options_for_select(@error_types.map { |et| [et, et] }, selected: params[:type]),
+                       include_blank: true, class: 'form-element js-error-type-select' %>
       </div>
-      <div class="actions">
-        <%= submit_tag t('g.search').capitalize, class: 'button is-filled' %>
-      </div>
-    </div>
-  <% end %>
 
-  <%= form_tag admin_error_reports_path, method: :get, class: 'has-margin-bottom-4 primary' do %>
-    <div class="form-group-horizontal">
+      <div class="form-group">
+        <%= label_tag :uuid, 'Error UUID' %>
+        <%= text_field_tag :uuid, params[:uuid],
+                                  class: 'form-element',
+                                  placeholder: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' %>
+      </div>
+
       <div class="form-group">
         <%= label_tag :version, t('admin.error_search_version') %>
         <%= text_field_tag :version, params[:version], class: 'form-element', placeholder: '(full SHA)' %>
       </div>
-      <div class="actions">
-        <div class="button-list">
-          <button type="submit" class="button is-filled"><%= t('g.search').capitalize %></button>
-          <%= link_to 'Current', query_url(version: 'current'), class: 'button is-outlined' %>
-        </div>
+
+      <div class="actions gap-sm">
+        <button type="submit" class="button is-filled is-medium"><%= t('g.search').capitalize %></button>
+        <%= link_to 'Current', query_url(version: 'current'), class: 'button is-outlined is-medium' %>
       </div>
     </div>
   <% end %>

--- a/config/locales/strings/en.g.yml
+++ b/config/locales/strings/en.g.yml
@@ -23,6 +23,7 @@ en:
     threshold: 'threshold'
     type: 'type'
     user: 'user'
+    version: 'version'
 
   platform:
     network_name: 'Codidact'


### PR DESCRIPTION
The PR allows error reports to be filtered by type and simplifies the panel - we don't need 2 forms with the same action here, while "error type", "uuid", and "version" are just filters (also this aligns the header with how it works for audit logs and allows us to easily add even more filters):

<img width="1184" height="269" alt="Screenshot from 2025-09-28 15-37-53" src="https://github.com/user-attachments/assets/4f3887bf-d3e4-47d9-a5ce-6ef168acea9d" />
