### PR TITLE
Allow Markdown in post titles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -308,5 +308,4 @@ kbd {
     left: 0.25em;
     right: 0.25em;
   };
-  vertical-align: text-bottom;
 }

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -58,10 +58,6 @@ h1 .badge.is-tag.is-master-tag {
     width: 100%;
     overflow-wrap: break-word;
   }
-
-  code {
-    vertical-align: middle;
-  }
 }
 
 .post-list--content {
@@ -147,10 +143,6 @@ h1 .badge.is-tag.is-master-tag {
 
   .post--title-text {
     width: 100%;
-  }
-
-  code {
-    vertical-align: text-top;
   }
 
   @media screen and (min-width: $screen-md) {

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -58,6 +58,10 @@ h1 .badge.is-tag.is-master-tag {
     width: 100%;
     overflow-wrap: break-word;
   }
+
+  del {
+    background-color: transparent;
+  }
 }
 
 .post-list--content {
@@ -143,6 +147,10 @@ h1 .badge.is-tag.is-master-tag {
 
   .post--title-text {
     width: 100%;
+  }
+
+  del {
+    background-color: transparent;
   }
 
   @media screen and (min-width: $screen-md) {

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -58,6 +58,10 @@ h1 .badge.is-tag.is-master-tag {
     width: 100%;
     overflow-wrap: break-word;
   }
+
+  code {
+    vertical-align: middle;
+  }
 }
 
 .post-list--content {
@@ -143,6 +147,10 @@ h1 .badge.is-tag.is-master-tag {
 
   .post--title-text {
     width: 100%;
+  }
+
+  code {
+    vertical-align: text-top;
   }
 
   @media screen and (min-width: $screen-md) {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -117,9 +117,10 @@ module ApplicationHelper
   # @param markdown [String] The markdown string to render.
   # @return [String] The rendered HTML string.
   def render_markdown(markdown)
-    CommonMarker.render_doc(markdown,
-                            [:FOOTNOTES, :LIBERAL_HTML_TAG, :STRIKETHROUGH_DOUBLE_TILDE],
-                            [:table, :strikethrough, :autolink]).to_html(:UNSAFE)
+    extensions = [:table, :strikethrough, :autolink]
+    options = [:FOOTNOTES, :LIBERAL_HTML_TAG, :STRIKETHROUGH_DOUBLE_TILDE]
+
+    CommonMarker.render_doc(markdown, options, extensions).to_html(:UNSAFE)
   end
 
   ##

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -114,11 +114,27 @@ module ApplicationHelper
 
   ##
   # Render a markdown string to HTML with consistent options.
-  # @param markdown [String] The markdown string to render.
-  # @return [String] The rendered HTML string.
-  def render_markdown(markdown)
-    extensions = [:table, :strikethrough, :autolink]
-    options = [:FOOTNOTES, :LIBERAL_HTML_TAG, :STRIKETHROUGH_DOUBLE_TILDE]
+  # @param markdown [String] markdown string to render
+  # @option opts :footnotes [Boolean] render footnotes?
+  # @option opts :strikethrough [Boolean] render strikethrough?
+  # @option opts :tables [Boolean] render tables?
+  # @return [String] rendered HTML string
+  def render_markdown(markdown, **opts)
+    extensions = [:autolink]
+    options = [:LIBERAL_HTML_TAG]
+
+    unless opts[:footnotes] == false
+      options << :FOOTNOTES
+    end
+
+    unless opts[:strikethrough] == false
+      extensions << :strikethrough
+      options << :STRIKETHROUGH_DOUBLE_TILDE
+    end
+
+    unless opts[:tables] == false
+      extensions << :table
+    end
 
     CommonMarker.render_doc(markdown, options, extensions).to_html(:UNSAFE)
   end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -8,6 +8,14 @@ module PostsHelper
     user_link(user, { host: post.community.host })
   end
 
+  # Renders title for a given post
+  # @param post [Post] post to render the title for
+  # @return [ActiveSupport::SafeBuffer] rendered title
+  def rendered_title(post)
+    raw_title = post.top_level? ? post.title : post.parent.title
+    sanitize(render_markdown(raw_title))
+  end
+
   ##
   # Get HTML for a field - should only be used in Markdown create/edit requests. Prioritises using the client-side
   # rendered HTML over rendering server-side.

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -13,7 +13,7 @@ module PostsHelper
   # @return [ActiveSupport::SafeBuffer] rendered title
   def rendered_title(post)
     raw_title = post.top_level? ? post.title : post.parent.title
-    sanitize(render_markdown(raw_title))
+    sanitize(render_markdown(raw_title), scrubber: title_scrubber)
   end
 
   ##
@@ -84,6 +84,22 @@ module PostsHelper
     [SiteSetting['MaxTitleLength'] || 255, 255].min
   end
 
+  class PostTitleScrubber < Rails::HTML::PermitScrubber
+    ALLOWED_ATTRS = %w[].freeze
+
+    ALLOWED_TAGS = %w[code em strong strike del sup sub kbd].freeze
+
+    def initialize
+      super
+      self.tags = ALLOWED_TAGS
+      self.attributes = ALLOWED_ATTRS
+    end
+
+    def skip_node?(node)
+      node.text?
+    end
+  end
+
   class PostScrubber < Rails::Html::PermitScrubber
     ALLOWED_ATTRS = %w[id class href title src height width alt rowspan colspan lang start dir].freeze
 
@@ -107,5 +123,11 @@ module PostsHelper
   # @return [PostScrubber]
   def scrubber
     PostsHelper::PostScrubber.new
+  end
+
+  # Get a post title scrubber instance
+  # @return [PostTitleScrubber]
+  def title_scrubber
+    PostsHelper::PostTitleScrubber.new
   end
 end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -91,7 +91,7 @@ module PostsHelper
       attrs = []
       tags = []
 
-      allowed_types = SiteSetting['AllowedPostTitleFormattingTypes'] || []
+      allowed_types = SiteSetting['AllowedPostTitleFormattingTypes'] || ['code', 'italic', 'keyboard']
       tags.push('del', 'strike') if allowed_types.include?('strikethrough')
       tags << 'code' if allowed_types.include?('code')
       tags << 'kbd' if allowed_types.include?('keyboard')

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -85,14 +85,23 @@ module PostsHelper
   end
 
   class PostTitleScrubber < Rails::HTML::PermitScrubber
-    ALLOWED_ATTRS = %w[].freeze
-
-    ALLOWED_TAGS = %w[code em strong strike del sup sub kbd].freeze
-
     def initialize
       super
-      self.tags = ALLOWED_TAGS
-      self.attributes = ALLOWED_ATTRS
+
+      attrs = []
+      tags = []
+
+      allowed_types = SiteSetting['AllowedPostTitleFormattingTypes']
+      tags.push('del', 'strike') if allowed_types.include?('strikethrough')
+      tags << 'code' if allowed_types.include?('code')
+      tags << 'kbd' if allowed_types.include?('keyboard')
+      tags << 'em' if allowed_types.include?('italic')
+      tags << 'strong' if allowed_types.include?('bold')
+      tags << 'sub' if allowed_types.include?('subscript')
+      tags << 'sup' if allowed_types.include?('superscript')
+
+      self.tags = tags
+      self.attributes = attrs
     end
 
     def skip_node?(node)

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -91,7 +91,7 @@ module PostsHelper
       attrs = []
       tags = []
 
-      allowed_types = SiteSetting['AllowedPostTitleFormattingTypes']
+      allowed_types = SiteSetting['AllowedPostTitleFormattingTypes'] || []
       tags.push('del', 'strike') if allowed_types.include?('strikethrough')
       tags << 'code' if allowed_types.include?('code')
       tags << 'kbd' if allowed_types.include?('keyboard')

--- a/app/helpers/site_settings_helper.rb
+++ b/app/helpers/site_settings_helper.rb
@@ -1,5 +1,9 @@
 module SiteSettingsHelper
+  # Renders description for a given site setting
+  # @param setting [SiteSetting] setting to render the description for
+  # @return [ActiveSupport::SafeBuffer] rendered description
   def rendered_description(setting)
-    sanitize(render_markdown(setting.description))
+    raw_description = setting.description || ''
+    sanitize(render_markdown(raw_description))
   end
 end

--- a/app/helpers/site_settings_helper.rb
+++ b/app/helpers/site_settings_helper.rb
@@ -1,3 +1,5 @@
-# Provides helper methods for use by views under <tt>SiteSettingsController</tt>.
 module SiteSettingsHelper
+  def rendered_description(setting)
+    sanitize(render_markdown(setting.description))
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -246,12 +246,6 @@ class Post < ApplicationRecord
     ThreadFollower.where(post: self, user: user).any?
   end
 
-  # Is the post a Meta post?
-  # @return [Boolean] check result
-  def meta?
-    false
-  end
-
   # Does the post have a pending suggested edit?
   # @return [Boolean] check result
   def pending_suggested_edit?

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -198,6 +198,12 @@ class Post < ApplicationRecord
     SuggestedEdit.where(post_id: id, active: true).any?
   end
 
+  # Is the post a top level post?
+  # @return [Boolean] check result
+  def top_level?
+    post_type.is_top_level
+  end
+
   # @return [SuggestedEdit, Nil] the suggested edit pending for this post (if any)
   def pending_suggested_edit
     SuggestedEdit.where(post_id: id, active: true).last

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -246,6 +246,14 @@ class Post < ApplicationRecord
     ThreadFollower.where(post: self, user: user).any?
   end
 
+  # Does the post have any pending (not handled) spam flags?
+  # A spam flag could be marked helpful but the post wouldn't be deleted, and
+  # we don't want the post to be treated like it's spam risk if that happens.
+  # @return [Boolean] check result
+  def pending_spam_flag?
+    flags.any? { |flag| flag.post_flag_type&.name == "it's spam" && !flag.status }
+  end
+
   # Does the post have a pending suggested edit?
   # @return [Boolean] check result
   def pending_suggested_edit?
@@ -257,14 +265,6 @@ class Post < ApplicationRecord
   # @return [Boolean] check result
   def related_posts_for?(user)
     related_posts_for(user).any?
-  end
-
-  # Does the post have any pending (not handled) spam flags?
-  # A spam flag could be marked helpful but the post wouldn't be deleted, and
-  # we don't want the post to be treated like it's spam risk if that happens.
-  # @return [Boolean] check result
-  def spam_flag_pending?
-    flags.any? { |flag| flag.post_flag_type&.name == "it's spam" && !flag.status }
   end
 
   # Is the post a top level post?

--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -19,15 +19,12 @@
 <% category ||= defined?(@category) && @category.id == post.category_id ? @category : post.category %>
 <% post_type ||= defined?(@post_type) && @post_type.id == post.post_type_id ? @post_type : post.post_type %>
 
-<% is_question = post.post_type_id == Question.post_type_id %>
-<% is_top_level = post.parent_id.nil? %>
-
-<div class="post <%= is_top_level ? '' : 'has-border-bottom-style-solid has-border-bottom-width-1 has-border-color-tertiary-100' %>"
-     id="<%= (is_question ? 'question-' : 'answer-') + post.id.to_s %>"
+<div class="post <%= 'has-border-bottom-style-solid has-border-bottom-width-1 has-border-color-tertiary-100' unless post.top_level? %>"
+     id="<%= (post.question? ? 'question-' : 'answer-') + post.id.to_s %>"
      data-post-id="<%= post.id %>"
      data-ckb-list-item data-ckb-item-type="post"
      data-ckb-post-id="<%= post.id %>">
-  <% if is_top_level %>
+  <% if post.top_level? %>
     <h1 class="post--title has-margin-top-0 has-padding-2">
       <% title = post.title +
                  (post.closed && !post.duplicate_post ? " [closed]" : "") +
@@ -223,7 +220,7 @@
           <%= render 'posts/flags_modal', post: post, user: current_user %>
         <% end %>
 
-        <% if is_top_level && post.children.undeleted.length >= SiteSetting["TableOfContentsThreshold"] && SiteSetting["TableOfContentsThreshold"] != -1 %>
+        <% if post.top_level? && post.children.undeleted.length >= SiteSetting["TableOfContentsThreshold"] && SiteSetting["TableOfContentsThreshold"] != -1 %>
           <div class="toc has-margin-left-4" id="toc-toggle">
             <button class="toc--header"
                     data-toggle="#toc-toggle"

--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -26,7 +26,7 @@
      data-ckb-post-id="<%= post.id %>">
   <% if post.top_level? %>
     <h1 class="post--title has-margin-top-0 has-padding-2">
-      <% title = post.title +
+      <% title = rendered_title(post) +
                  (post.closed && !post.duplicate_post ? " [closed]" : "") +
                  (post.duplicate_post ? " [duplicate]" : "") %>
       <a href="<%= generic_share_link(post) %>" class="post--title-text"><%= title %></a>

--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -22,7 +22,7 @@
 <% is_question = post.post_type_id == Question.post_type_id %>
 <% is_top_level = post.parent_id.nil? %>
 
-<div class="post <%= post.meta? ? 'is-meta' : '' %> <%= is_top_level ? '' : 'has-border-bottom-style-solid has-border-bottom-width-1 has-border-color-tertiary-100' %>"
+<div class="post <%= is_top_level ? '' : 'has-border-bottom-style-solid has-border-bottom-width-1 has-border-color-tertiary-100' %>"
      id="<%= (is_question ? 'question-' : 'answer-') + post.id.to_s %>"
      data-post-id="<%= post.id %>"
      data-ckb-list-item data-ckb-item-type="post"

--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -72,7 +72,7 @@
         <%= render('posts/notices/locked', post: post) %>
       <% end %>
 
-      <% if post.spam_flag_pending? && user_signed_in? %>
+      <% if post.pending_spam_flag? && user_signed_in? %>
         <%= render('posts/notices/flagged', post: post, user: current_user) %>
       <% end %>
 
@@ -82,7 +82,7 @@
 
       <div class="post--body">
         <% effective_post = raw(sanitize(post.body, scrubber: scrubber)) %>
-        <% if post.spam_flag_pending? && !user_signed_in? %>
+        <% if post.pending_spam_flag? && !user_signed_in? %>
           <%= sanitize(effective_post, attributes: %w()) %>
         <% else %>
           <%= effective_post %>

--- a/app/views/posts/_list.html.erb
+++ b/app/views/posts/_list.html.erb
@@ -26,9 +26,9 @@
         <% if @show_category_tag && post.post_type.has_category %>
           <span class="badge is-tag is-filled"><%= post.category.name %></span>
         <% end %>
-        <%= post.post_type.is_top_level ? post.title : post.parent.title %>
+        <%= rendered_title(post) %>
         <%= post.post_type.is_closeable && post.closed && !post.duplicate_post  ? "[closed]" : "" %>
-      <%= post.duplicate_post && post.post_type.is_closeable && post.closed ? "[duplicate]" : "" %>
+        <%= post.duplicate_post && post.post_type.is_closeable && post.closed ? "[duplicate]" : "" %>
       <% end %>
     </div>
     <% if (SiteSetting['PostBodyListTruncateLength'] || 0) > 0 %>

--- a/app/views/site_settings/index.html.erb
+++ b/app/views/site_settings/index.html.erb
@@ -28,7 +28,7 @@
               </p>
               <h4 class="overflow-ellipsis"
                   title="<%= setting.name %>"><%= setting.name %></h4>
-              <div class="form-caption"><%= setting.description %></div>
+              <div class="form-caption"><%= rendered_description(setting) %></div>
             </td>
             <% nowrap = setting.boolean? || setting.numeric? %>
             <td class="site-setting--value js-setting-value<%= nowrap ? ' nowrap' : ' wrap-word' %>"

--- a/db/seeds/site_settings.yml
+++ b/db/seeds/site_settings.yml
@@ -784,6 +784,7 @@
     - code
     - italic
     - keyboard
+    - strikethrough
     - subscript
     - superscript
   value_type: array

--- a/db/seeds/site_settings.yml
+++ b/db/seeds/site_settings.yml
@@ -776,3 +776,18 @@
   community_id: ~
   description: >
     File types that users will be able to upload.
+
+- name: AllowedPostTitleFormattingTypes
+  value: code italic keyboard
+  options:
+    - bold
+    - code
+    - italic
+    - keyboard
+    - subscript
+    - superscript
+  value_type: array
+  category: Display
+  description: >
+    Formatting types allowed in post titles.
+    By default, only <code>code</code>, <kbd>keyboard</kbd>, and <em>italic</em> are enabled.

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -136,4 +136,12 @@ class PostTest < ActiveSupport::TestCase
       assert_not post.deleted_by_owner?
     end
   end
+
+  test 'top_level? should correctly determine if the post is top level' do
+    post_types.each do |type|
+      Post.where(post_type: type).each do |post|
+        assert_equal post.top_level?, type.is_top_level
+      end
+    end
+  end
 end


### PR DESCRIPTION
closes #1857

This PR enables Markdown rendering in post titles.
Allowed formatting types are configurable per community.

This is how posts will look like in lists with _all_ formatting types enabled:

<img width="757" height="216" alt="2025-10-01_12-24" src="https://github.com/user-attachments/assets/5655602b-e6fc-48c6-9cda-289796157ab1" />

and in the expanded view:

<img width="777" height="515" alt="2025-10-01_12-26" src="https://github.com/user-attachments/assets/3c42fb6c-a3ce-42b2-9cb7-52eb0564d03d" />

The new site setting is called `AllowedPostTitleFormattingTypes`:

<img width="750" height="164" alt="Screenshot from 2025-10-01 13-04-36" src="https://github.com/user-attachments/assets/311d8041-8ba5-4c50-86d1-78bb8e5b3830" />

As a side-effect, it also enables markdown rendering for site settings descriptions - this allows us to be more expressive in them (of course, descriptions are sanitized).




