### PR TITLE
Move 'native' sorting order option to filters

### DIFF
--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -4,6 +4,24 @@
   border-top: 1px solid $muted-graphic;
 }
 
+.search-filters-constraints {
+  display: grid;
+  column-gap: 0.5em;
+  grid-template-columns: repeat(4, 1fr);
+
+  @media screen and (max-width: $screen-lg) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  @media screen and (max-width: $screen-md) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media screen and (max-width: $screen-sm) {
+    grid-template-columns: repeat(1, 1fr);
+  }
+}
+
 .search-sorting {
   align-items: center;
   display: flex;

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -164,8 +164,7 @@ class CategoriesController < ApplicationController
   def set_list_posts
     sort_params = { activity: { last_activity: :desc }, age: { created_at: :desc }, score: { score: :desc },
                     lottery: [Arel.sql('(RAND() - ? * DATEDIFF(CURRENT_TIMESTAMP, posts.created_at)) DESC'),
-                              SiteSetting['LotteryAgeDeprecationSpeed']],
-                    native: Arel.sql('att_source IS NULL DESC, last_activity DESC') }
+                              SiteSetting['LotteryAgeDeprecationSpeed']] }
     sort_param = sort_params[params[:sort]&.to_sym] || { last_activity: :desc }
     @posts = @category.posts
                       .undeleted
@@ -197,7 +196,8 @@ class CategoriesController < ApplicationController
           max_answers: default_filter.max_answers,
           include_tags: default_filter.include_tags,
           exclude_tags: default_filter.exclude_tags,
-          status: default_filter.status
+          status: default_filter.status,
+          imports: default_filter.imports
         }
       end
     end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -186,7 +186,7 @@ class CategoriesController < ApplicationController
       end
 
       unless default_filter.nil?
-        filter_qualifiers = helpers.filter_to_qualifiers default_filter
+        filter_qualifiers = helpers.filter_to_qualifiers(default_filter)
         @active_filter = {
           default: default,
           name: default_filter.name,
@@ -197,7 +197,7 @@ class CategoriesController < ApplicationController
           include_tags: default_filter.include_tags,
           exclude_tags: default_filter.exclude_tags,
           status: default_filter.status,
-          imports: default_filter.imports
+          source: default_filter.source
         }
       end
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -103,6 +103,7 @@ class UsersController < ApplicationController
       max_answers: filter.max_answers,
       include_tags: Tag.where(id: filter.include_tags).map { |tag| [tag.name, tag.id] },
       exclude_tags: Tag.where(id: filter.exclude_tags).map { |tag| [tag.name, tag.id] },
+      imports: filter.imports,
       status: filter.status,
       system: filter.user_id == -1
     }
@@ -642,7 +643,9 @@ class UsersController < ApplicationController
   private
 
   def filter_params
-    params.permit(:min_score, :max_score, :min_answers, :max_answers, :status, :include_tags, :exclude_tags,
+    params.permit(:min_score, :max_score, :min_answers, :max_answers,
+                  :status, :imports,
+                  :include_tags, :exclude_tags,
                   include_tags: [], exclude_tags: [])
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -103,7 +103,7 @@ class UsersController < ApplicationController
       max_answers: filter.max_answers,
       include_tags: Tag.where(id: filter.include_tags).map { |tag| [tag.name, tag.id] },
       exclude_tags: Tag.where(id: filter.exclude_tags).map { |tag| [tag.name, tag.id] },
-      imports: filter.imports,
+      source: filter.source,
       status: filter.status,
       system: filter.user_id == -1
     }
@@ -644,7 +644,7 @@ class UsersController < ApplicationController
 
   def filter_params
     params.permit(:min_score, :max_score, :min_answers, :max_answers,
-                  :status, :imports,
+                  :status, :source,
                   :include_tags, :exclude_tags,
                   include_tags: [], exclude_tags: [])
   end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -54,7 +54,7 @@ module SearchHelper
     qualifiers.append({ param: :include_tags, tag_ids: filter.include_tags }) unless filter.include_tags.nil?
     qualifiers.append({ param: :exclude_tags, tag_ids: filter.exclude_tags }) unless filter.exclude_tags.nil?
     qualifiers.append({ param: :status, value: filter.status }) unless filter.status.nil?
-    qualifiers.append({ param: :imports, value: filter.imports }) unless filter.imports.nil?
+    qualifiers.append({ param: :source, value: filter.source }) unless filter.source.nil?
     qualifiers
   end
 
@@ -72,7 +72,7 @@ module SearchHelper
       include_tags: params[:include_tags],
       exclude_tags: params[:exclude_tags],
       status: params[:status],
-      imports: params[:imports]
+      source: params[:source]
     }
   end
 
@@ -110,8 +110,8 @@ module SearchHelper
       filter_qualifiers.append({ param: :status, value: params[:status] })
     end
 
-    if SOURCE_TYPES.include?(params[:imports]&.to_sym)
-      filter_qualifiers.append({ param: :imports, value: params[:imports] })
+    if SOURCE_TYPES.include?(params[:source]&.to_sym)
+      filter_qualifiers.append({ param: :source, value: params[:source].to_sym })
     end
 
     if params[:include_tags]&.all? { |id| id.match? valid_value[:integer] }
@@ -145,9 +145,7 @@ module SearchHelper
   # @return [Array<Hash{Symbol => Object}>]
   def parse_qualifier_strings(qualifiers)
     qualifiers.map do |qualifier|
-      splat = qualifier.split ':'
-      parameter = splat[0]
-      value = splat[1]
+      parameter, value = qualifier.split(':')
 
       parsed = case parameter
                when 'score'
@@ -174,6 +172,8 @@ module SearchHelper
                  parse_answers_qualifier(value)
                when 'status'
                  parse_status_qualifier(value)
+               when 'source'
+                 parse_source_qualifier(value)
                end
 
       parsed
@@ -231,7 +231,7 @@ module SearchHelper
         when 'closed'
           query = query.where(closed: true)
         end
-      when :imports
+      when :source
         case qualifier[:value]
         when :native
           query = query.where(att_source: nil)

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -110,7 +110,7 @@ module SearchHelper
       filter_qualifiers.append({ param: :status, value: params[:status] })
     end
 
-    if SOURCE_TYPES.include?(params[:source]&.to_sym)
+    if valid_source_type?(params[:source])
       filter_qualifiers.append({ param: :source, value: params[:source].to_sym })
     end
 
@@ -242,5 +242,12 @@ module SearchHelper
     end
 
     query
+  end
+
+  # Is a given param a valid source type?
+  # @param param [String, Symbol, nil] parameter to check
+  # @return [Boolean] check result
+  def valid_source_type?(param)
+    SOURCE_TYPES.include?(param&.to_sym)
   end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -141,7 +141,7 @@ module SearchHelper
 
   ##
   # Parses a full qualifier string into an array of qualifier objects.
-  # @param qualifiers [String] A qualifier string as returned by {#parse_search}.
+  # @param qualifiers [Array<String>] Qualifier strings as returned by {#parse_search}.
   # @return [Array<Hash{Symbol => Object}>]
   def parse_qualifier_strings(qualifiers)
     qualifiers.map do |qualifier|

--- a/app/helpers/search_qualifier_helper.rb
+++ b/app/helpers/search_qualifier_helper.rb
@@ -23,6 +23,10 @@ module SearchQualifierHelper
     value.match?(/any|open|closed/)
   end
 
+  def matches_source?(value)
+    value.match?(/any|imported|native/)
+  end
+
   def parse_answers_qualifier(value)
     return unless matches_non_negative_int?(value)
 
@@ -79,6 +83,12 @@ module SearchQualifierHelper
     return unless matches_status?(value)
 
     { param: :status, value: value }
+  end
+
+  def parse_source_qualifier(value)
+    return unless matches_source?(value)
+
+    { param: :source, value: value }
   end
 
   def parse_include_tag_qualifier(value)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -246,6 +246,12 @@ class Post < ApplicationRecord
     ThreadFollower.where(post: self, user: user).any?
   end
 
+  # Is the post an imported post?
+  # @return [Boolean] check result
+  def imported?
+    att_source.present?
+  end
+
   # Does the post have any pending (not handled) spam flags?
   # A spam flag could be marked helpful but the post wouldn't be deleted, and
   # we don't want the post to be treated like it's spam risk if that happens.

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -37,9 +37,8 @@ class Subscription < ApplicationRecord
               .where(Question.arel_table[:created_at].gteq(last_sent_at || created_at))
               .where(user_id: qualifier)
     when 'interesting'
-      RequestContext.community = community # otherwise SiteSetting#[] doesn't work
       Question.unscoped.on(community).where(post_type_id: Question.post_type_id)
-              .where('score >= ?', SiteSetting['InterestingSubscriptionScoreThreshold'])
+              .where('score >= ?', interesting_threshold)
               .order(Arel.sql('RAND()'))
     when 'category'
       Question.unscoped.on(community).where(post_type_id: Question.post_type_id)
@@ -78,6 +77,10 @@ class Subscription < ApplicationRecord
   end
 
   private
+
+  def interesting_threshold
+    SiteSetting.applied_setting('InterestingSubscriptionScoreThreshold', community: community).typed
+  end
 
   def qualifier_presence
     return unless qualified?

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -36,11 +36,6 @@
     <%= link_to 'Score', query_url(sort: 'score'),
                 class: "button is-muted is-outlined #{params[:sort] == 'score' ? 'is-active' : ''}",
                 title: 'highest score first (not the same as net votes)' %>
-    <% if SiteSetting['AllowContentTransfer'] %>
-      <%= link_to 'Native', query_url(sort: 'native'),
-                  class: "button is-muted is-outlined #{params[:sort] == 'native' ? 'is-active' : ''}",
-                  title: 'exclude imported posts' %>
-    <% end %>
     <%= link_to 'Random', query_url(sort: 'lottery'),
         class: "button is-muted is-outlined #{params[:sort] == 'lottery' ? 'is-active' : ''}",
         title: 'random set of questions, usually older ones' %>

--- a/app/views/search/_filters.html.erb
+++ b/app/views/search/_filters.html.erb
@@ -26,37 +26,59 @@
     <%= label_tag :save_as_default, 'Is default for this category?' %>
     <%= check_box_tag :save_as_default, @category.id, false, { class: 'filter-is-default form-checkbox-element' } %>
   <% end %>
-  <div class="form-group-horizontal">
+  <div class="form-group-horizontal search-filters-constraints">
     <div class="form-group">
-      <%= label_tag :min_score, 'Min Score (0-1)', class: "form-element" %>
-      <%= number_field_tag :min_score, @active_filter[:min_score],
-          min: 0, max: 1, step: 0.01, class: 'form-element form--filter',
-          data: { name: 'min_score' } %>
+      <%= label_tag :min_score, 'Min Score (0-1)', class: "form-element nowrap" %>
+      <%= number_field_tag :min_score,
+                           @active_filter[:min_score],
+                           min: 0, max: 1, step: 0.01,
+                           class: 'form-element form--filter',
+                           data: { name: 'min_score' } %>
     </div>
     <div class="form-group">
-      <%= label_tag :max_score, 'Max Score (0-1)', class: "form-element" %>
-      <%= number_field_tag :max_score, @active_filter[:max_score],
-          min: 0, max: 1, step: 0.01, class: 'form-element form--filter',
-          data: { name: 'max_score' } %>
+      <%= label_tag :max_score, 'Max Score (0-1)', class: "form-element nowrap" %>
+      <%= number_field_tag :max_score,
+                           @active_filter[:max_score],
+                           min: 0, max: 1, step: 0.01,
+                           class: 'form-element form--filter',
+                           data: { name: 'max_score' } %>
     </div>
     <div class="form-group">
-      <%= label_tag :min_answers, 'Min Answers', class: "form-element" %>
-      <%= number_field_tag :min_answers, @active_filter[:min_answers],
-          min: 0, step: 1, class: 'form-element form--filter',
-          data: { name: 'min_answers' } %>
+      <%= label_tag :min_answers, 'Min Answers', class: "form-element nowrap" %>
+      <%= number_field_tag :min_answers,
+                           @active_filter[:min_answers],
+                           min: 0, step: 1,
+                           class: 'form-element form--filter',
+                           data: { name: 'min_answers' } %>
     </div>
     <div class="form-group">
-      <%= label_tag :max_answers, 'Max Answers', class: "form-element" %>
-      <%= number_field_tag :max_answers, @active_filter[:max_answers],
-          min: 0, step: 1, class: 'form-element form--filter',
-          data: { name: 'max_answers' } %>
+      <%= label_tag :max_answers, 'Max Answers', class: "form-element nowrap" %>
+      <%= number_field_tag :max_answers,
+                           @active_filter[:max_answers],
+                           min: 0, step: 1,
+                           class: 'form-element form--filter',
+                           data: { name: 'max_answers' } %>
     </div>
     <div class="form-group">
-      <%= label_tag :status, 'Status', class: "form-element" %>
-      <%= select_tag :status, options_for_select(['any', 'open', 'closed'], selected: @active_filter[:status] || 'any'),
-        min: 0, step: 1, class: 'form-element form--filter',
-        data: { name: 'status' } %>
+      <%= label_tag :status, 'Status', class: "form-element nowrap" %>
+      <%= select_tag :status,
+                     options_for_select(['any', 'open', 'closed'],
+                     selected: @active_filter[:status] || 'any'),
+                     class: 'form-element form--filter',
+                     data: { name: 'status' } %>
     </div>
+
+    <% if SiteSetting['AllowContentTransfer'] %>
+      <div class="form-group">
+        <%= label_tag :imports, 'Source', class: "form-element nowrap" %>
+        <%= select_tag :imports,
+                       options_for_select(SearchHelper::SOURCE_TYPES,
+                       selected: @active_filter[:imports] || :any),
+                       class: 'form-element form--filter',
+                       data: { name: 'imports' } %>
+      </div>
+    <% end %>
+
   </div>
   <div>
     <a href="/help/scoring">How scores are computed</a>

--- a/app/views/search/_filters.html.erb
+++ b/app/views/search/_filters.html.erb
@@ -70,12 +70,12 @@
 
     <% if SiteSetting['AllowContentTransfer'] %>
       <div class="form-group">
-        <%= label_tag :imports, 'Source', class: "form-element nowrap" %>
-        <%= select_tag :imports,
+        <%= label_tag :source, 'Source', class: "form-element nowrap" %>
+        <%= select_tag :source,
                        options_for_select(SearchHelper::SOURCE_TYPES,
-                       selected: @active_filter[:imports] || :any),
+                       selected: @active_filter[:source] || :any),
                        class: 'form-element form--filter',
-                       data: { name: 'imports' } %>
+                       data: { name: 'source' } %>
       </div>
     <% end %>
 

--- a/db/migrate/20251002164957_add_imports_to_filters.rb
+++ b/db/migrate/20251002164957_add_imports_to_filters.rb
@@ -1,5 +1,0 @@
-class AddImportsToFilters < ActiveRecord::Migration[7.2]
-  def change
-    add_column :filters, :imports, :string, null: false, default: :any
-  end
-end

--- a/db/migrate/20251002164957_add_imports_to_filters.rb
+++ b/db/migrate/20251002164957_add_imports_to_filters.rb
@@ -1,0 +1,5 @@
+class AddImportsToFilters < ActiveRecord::Migration[7.2]
+  def change
+    add_column :filters, :imports, :string, null: false, default: :any
+  end
+end

--- a/db/migrate/20251002164957_add_source_to_filters.rb
+++ b/db/migrate/20251002164957_add_source_to_filters.rb
@@ -1,0 +1,5 @@
+class AddSourceToFilters < ActiveRecord::Migration[7.2]
+  def change
+    add_column :filters, :source, :string, null: false, default: :any
+  end
+end

--- a/db/migrate/20251002220027_fix_interesting_subscription_score_threshold_site_setting.rb
+++ b/db/migrate/20251002220027_fix_interesting_subscription_score_threshold_site_setting.rb
@@ -1,0 +1,12 @@
+class FixInterestingSubscriptionScoreThresholdSiteSetting < ActiveRecord::Migration[7.2]
+  def up
+    SiteSetting.unscoped
+               .where(name: 'FixInterestingSubscriptionSiteSetting', value_type: 'integer')
+               .update_all(value_type: 'float')
+  end
+
+  def down
+    # noop, this is intentionally not idempotent
+    # the setting should've never been an integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_20_103432) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_02_164957) do
   create_table "abilities", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "community_id"
     t.string "name"
@@ -270,6 +270,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_20_103432) do
     t.string "exclude_tags"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "imports", default: "any", null: false
     t.index ["user_id"], name: "index_filters_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -270,7 +270,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_02_164957) do
     t.string "exclude_tags"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "imports", default: "any", null: false
+    t.string "source", default: "any", null: false
     t.index ["user_id"], name: "index_filters_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_02_164957) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_02_220027) do
   create_table "abilities", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "community_id"
     t.string "name"

--- a/db/seeds/site_settings.yml
+++ b/db/seeds/site_settings.yml
@@ -198,7 +198,7 @@
 
 - name: InterestingSubscriptionScoreThreshold
   value: 1
-  value_type: integer
+  value_type: float
   category: Email
   description: >
     The minimum score a question must have to qualify for selection for the Interesting email subscription.

--- a/global.d.ts
+++ b/global.d.ts
@@ -252,6 +252,7 @@ type QPixelFilter = {
   max_score: number | null
   min_answers: number | null
   min_score: number | null
+  imports: 'any' | 'native' | 'imported'
   status: 'any' | 'closed' | 'open'
   system: boolean
 }

--- a/global.d.ts
+++ b/global.d.ts
@@ -245,6 +245,10 @@ type QPixelComment = {
   references_comment_id: string | null
 }
 
+type QPixelFilterSource = 'any' | 'native' | 'imported'
+
+type QPixelFilterStatus = 'any' | 'closed' | 'open'
+
 type QPixelFilter = {
   exclude_tags: [string, number][]
   include_tags: [string, number][]
@@ -252,8 +256,8 @@ type QPixelFilter = {
   max_score: number | null
   min_answers: number | null
   min_score: number | null
-  imports: 'any' | 'native' | 'imported'
-  status: 'any' | 'closed' | 'open'
+  source: QPixelFilterSource
+  status: QPixelFilterStatus
   system: boolean
 }
 

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -495,3 +495,18 @@ post_scorer_question:
   community: sample
   category: main
   license: cc_by_sa
+
+imported_question:
+  post_type: question
+  title: This is a question imported from an external source
+  body: This is the body of the question imported from an external source
+  body_markdown: <p>This is the body of the question imported from an external source</p>
+  att_source: https://example.com/posts/42
+  tags_cache:
+    - support
+  tags:
+    - support
+  user: standard_user
+  community: sample
+  category: main
+  license: cc_by_sa

--- a/test/helpers/search_helper_test.rb
+++ b/test/helpers/search_helper_test.rb
@@ -13,6 +13,43 @@ class SearchHelperTest < ActionView::TestCase
     end
   end
 
+  test 'parse_qualifier_strings should correctly parse qualifiers' do
+    exclude_tag = tags(:bug)
+    include_tag = tags(:support)
+
+    {
+      'answers:>42' => { param: :answers, operator: '>', value: 42 },
+      'category:1' => { param: :category, operator: '=', category_id: 1 },
+      'downvotes:>10' => { param: :downvotes, operator: '>', value: 10 },
+      'post_type:2' => { param: :post_type, operator: '=', post_type_id: 2 },
+      'score:0.5' => { param: :score, operator: '=', value: 0.5 },
+      'status:any' => { param: :status, value: 'any' },
+      "tag:#{include_tag.name}" => { param: :include_tag, tag_id: include_tag },
+      "-tag:#{exclude_tag.name}" => { param: :exclude_tag, tag_id: exclude_tag },
+      'source:native' => { param: :source, value: 'native' },
+      'upvotes:<3' => { param: :upvotes, operator: '<', value: 3 },
+      'user:-1' => { param: :user, operator: '=', user_id: -1 },
+      'votes:0' => { param: :net_votes, operator: '=', value: 0 }
+    }.each do |input, expect|
+      parsed = parse_qualifier_strings([input])
+      assert_equal expect[:param], parsed[0][:param]
+
+      # TODO: make return types of parse_*_qualifier helpers consistent
+      if [:category, :post_type, :user].include?(expect[:param])
+        value_key = :"#{expect[:param]}_id"
+        assert_equal expect[value_key], parsed[0][value_key]
+      elsif [:include_tag, :exclude_tag].include?(expect[:param])
+        assert_equal expect[:tag_id].id, parsed[0][:tag_id].first&.id
+      else
+        assert_equal expect[:value], parsed[0][:value]
+      end
+
+      if expect[:operator].present?
+        assert_equal expect[:operator], parsed[0][:operator]
+      end
+    end
+  end
+
   test 'qualifiers_to_sql should correctly narrow by :category qualifier' do
     main = categories(:main)
     admin_only = categories(:admin_only)

--- a/test/helpers/search_helper_test.rb
+++ b/test/helpers/search_helper_test.rb
@@ -235,4 +235,14 @@ class SearchHelperTest < ActionView::TestCase
 
     assert_not(posts.any? { |p| p.category.id == admin_category.id })
   end
+
+  test 'valid_source_type? should correctly determine if the param is valid' do
+    SearchHelper::SOURCE_TYPES.each do |type|
+      assert valid_source_type?(type)
+    end
+
+    ['external', :source, nil].each do |invalid|
+      assert_not valid_source_type?(invalid)
+    end
+  end
 end

--- a/test/helpers/search_helper_test.rb
+++ b/test/helpers/search_helper_test.rb
@@ -83,6 +83,28 @@ class SearchHelperTest < ActionView::TestCase
     assert only_neut_posts
   end
 
+  test 'qualifiers_to_sql should correctly narrow by :source qualifier' do
+    std_user = users(:standard_user)
+
+    posts_query = Post.accessible_to(std_user)
+    native_post = [{ param: :source, value: :native }]
+    imported_post = [{ param: :source, value: :imported }]
+
+    native_query = qualifiers_to_sql(native_post, posts_query, std_user)
+    imported_query = qualifiers_to_sql(imported_post, posts_query, std_user)
+
+    only_native_posts = native_query.to_a.none?(&:imported?)
+    only_imported_posts = imported_query.to_a.all?(&:imported?)
+
+    assert_not_equal posts_query.size, native_query.size
+    assert_not_equal native_query.size, 0
+    assert only_native_posts
+
+    assert_not_equal posts_query.size, imported_query.size
+    assert_not_equal imported_query.size, 0
+    assert only_imported_posts
+  end
+
   test 'qualifiers_to_sql should correctly narrow by :status qualifier' do
     std_user = users(:standard_user)
 

--- a/test/helpers/search_qualifier_helper_test.rb
+++ b/test/helpers/search_qualifier_helper_test.rb
@@ -41,6 +41,16 @@ class SearchQualifierHelperTest < ActionView::TestCase
     end
   end
 
+  test 'matches_source? should correctly match status' do
+    [:any, :imported, :native].each do |value|
+      assert matches_source?(value)
+    end
+
+    [:from_somewhere, :source, '42'].each do |value|
+      assert_not matches_source?(value)
+    end
+  end
+
   test 'matches_status? should correctly match status' do
     ['any', 'closed', 'open'].each do |value|
       assert matches_status?(value)
@@ -144,6 +154,14 @@ class SearchQualifierHelperTest < ActionView::TestCase
       assert_equal :upvotes, parsed[:param]
       assert_equal expected_op, parsed[:operator]
       assert_equal expected_val, parsed[:value]
+    end
+  end
+
+  test 'parse_source_qualifier should correctly parse status:' do
+    [:any, :imported, :native].each do |value|
+      parsed = parse_source_qualifier(value)
+      assert_equal :source, parsed[:param]
+      assert_equal value, parsed[:value]
     end
   end
 


### PR DESCRIPTION
closes #1253

This PR implements a new filter governing whether imported content are included in post lists. It also removes the sorting option as per discussion in [Discord](https://discord.com/channels/634104110131445811/634104110131445815/1423338179506733187) and in [Native sorting button blocks other sorting orders](https://meta.codidact.com/posts/289141). It also starts work on making our filters widget responsive.

Available options are:
- "any" (returns both native and imported);
- "native" (excludes imported);
- "imported" (returns only imported);

Coincidentally, it also fixes the `InterestingSubscriptionScoreThreshold` site setting's value type - it does not work with our score system as it's of type `integer`, whereas it should be a `float`. I opted to fix it up with a data migration to be really sure everyone gets the fixed value - but open to moving it to a maintenance task if necessary.

Note for reviewers: there are 2 new migrations.

---

Very large width and wider - 4 column layout:

<img width="758" height="531" alt="Screenshot from 2025-10-02 21-38-15" src="https://github.com/user-attachments/assets/2d36d957-4336-4e85-a60e-b683597b8e5e" />

Large width - 3 column layout:

<img width="602" height="530" alt="Screenshot from 2025-10-02 21-38-34" src="https://github.com/user-attachments/assets/026e55e8-ad1d-40e3-9462-7546cdd15ea9" />

Medium width - 2 column layout:

<img width="497" height="732" alt="Screenshot from 2025-10-02 21-38-45" src="https://github.com/user-attachments/assets/ebd4fa20-2434-415a-b41e-40c6d5947017" />

Small width and narrower - 1 column layout (note that fixing the remaining parts of the filters widget is outside the scope of this PR):

<img width="439" height="972" alt="Screenshot from 2025-10-02 21-38-55" src="https://github.com/user-attachments/assets/afce5bc6-a6d5-4725-a2c4-3877ff9badb0" />
