### PR TITLE
Add audit logs for mod warning creations

### DIFF
--- a/app/controllers/mod_warning_controller.rb
+++ b/app/controllers/mod_warning_controller.rb
@@ -70,7 +70,11 @@ class ModWarningController < ApplicationController
     @warning.update(active: false, read: false)
     @user.community_user.update is_suspended: false, suspension_public_comment: nil, suspension_end: nil
 
-    audit_warning('suspension_lift', @warning)
+    audit_warning('warning_lift', @warning)
+
+    if @warning.suspension?
+      audit_warning('suspension_lift', @warning)
+    end
 
     flash[:success] = 'The warning or suspension has been lifted. Please consider adding an annotation ' \
                       'explaining your reasons.'

--- a/app/controllers/mod_warning_controller.rb
+++ b/app/controllers/mod_warning_controller.rb
@@ -46,12 +46,15 @@ class ModWarningController < ApplicationController
     @warning = ModWarning.new(author: current_user, community_user: @user.community_user,
                               body: params[:mod_warning][:body], is_suspension: is_suspension,
                               suspension_end: suspension_end, active: true, read: false)
+
     if @warning.save
       audit_warning('warning_create', @warning)
 
       if is_suspension
         @user.community_user.update(is_suspended: is_suspension, suspension_end: suspension_end,
                                     suspension_public_comment: params[:mod_warning][:suspension_public_notice])
+
+        audit_warning('suspension_create', @warning)
       end
 
       redirect_to user_path(@user)
@@ -67,7 +70,7 @@ class ModWarningController < ApplicationController
     @warning.update(active: false, read: false)
     @user.community_user.update is_suspended: false, suspension_public_comment: nil, suspension_end: nil
 
-    audit_warning('warning_lift', @warning)
+    audit_warning('suspension_lift', @warning)
 
     flash[:success] = 'The warning or suspension has been lifted. Please consider adding an annotation ' \
                       'explaining your reasons.'

--- a/app/controllers/mod_warning_controller.rb
+++ b/app/controllers/mod_warning_controller.rb
@@ -47,6 +47,8 @@ class ModWarningController < ApplicationController
                               body: params[:mod_warning][:body], is_suspension: is_suspension,
                               suspension_end: suspension_end, active: true, read: false)
     if @warning.save
+      audit_warning('warning_create', @warning)
+
       if is_suspension
         @user.community_user.update(is_suspended: is_suspension, suspension_end: suspension_end,
                                     suspension_public_comment: params[:mod_warning][:suspension_public_notice])
@@ -65,8 +67,7 @@ class ModWarningController < ApplicationController
     @warning.update(active: false, read: false)
     @user.community_user.update is_suspended: false, suspension_public_comment: nil, suspension_end: nil
 
-    AuditLog.moderator_audit(event_type: 'warning_lift', related: @warning, user: current_user,
-                             comment: "<<Warning #{@warning.attributes_print} >>")
+    audit_warning('warning_lift', @warning)
 
     flash[:success] = 'The warning or suspension has been lifted. Please consider adding an annotation ' \
                       'explaining your reasons.'
@@ -87,5 +88,14 @@ class ModWarningController < ApplicationController
 
   def user_scope
     User.joins(:community_user).includes(:community_user, :avatar_attachment)
+  end
+
+  # Adds an audit log for a given mod warning
+  # @param event_type [String] type of the event
+  # @param warning [ModWarning] warning to audit
+  def audit_warning(event_type, warning)
+    AuditLog.moderator_audit(event_type: event_type,
+                             related: warning, user: current_user,
+                             comment: "<<Warning #{warning.attributes_print} >>")
   end
 end

--- a/app/models/mod_warning.rb
+++ b/app/models/mod_warning.rb
@@ -10,8 +10,16 @@ class ModWarning < ApplicationRecord
   scope :active, -> { where(active: true) }
   scope :to, ->(user) { where(community_user: user.community_user) }
 
+  # Was the warning issued with a suspension?
+  # @return [Boolean] check result
+  def suspension?
+    is_suspension
+  end
+
+  # Is the suspension issued with the warning still active?
+  # @return [Boolean] check result
   def suspension_active?
-    active && is_suspension && !suspension_end.past?
+    active && suspension? && !suspension_end.past?
   end
 
   def body_as_html

--- a/app/views/admin/_log_table.html.erb
+++ b/app/views/admin/_log_table.html.erb
@@ -1,31 +1,33 @@
 <table class="table is-full-width is-with-hover">
   <thead>
-  <tr>
-    <th><%= t('g.type').capitalize %></th>
-    <th><%= t('g.event').capitalize %></th>
-    <th><%= t('g.user').capitalize %></th>
-    <th><%= t('g.related').capitalize %></th>
-    <th><%= t('g.comment').capitalize %></th>
-    <th><%= t('g.created').capitalize %></th>
-  </tr>
+    <tr>
+      <th><%= t('g.type').capitalize %></th>
+      <th><%= t('g.event').capitalize %></th>
+      <th><%= t('g.user').capitalize %></th>
+      <th><%= t('g.related').capitalize %></th>
+      <th><%= t('g.comment').capitalize %></th>
+      <th><%= t('g.created').capitalize %></th>
+    </tr>
   </thead>
   <tbody>
-  <% @logs.each do |log| %>
-    <tr>
-      <td><%= log.log_type.humanize %></td>
-      <td><%= log.event_type.humanize %></td>
-      <td><%= user_link log.user %></td>
-      <td>
-        <% if log.related.present? %>
-          <%= log.related_type %> #<%= log.related_id %>
-          <% if log.related.respond_to? :name %>
-            (<%= log.related.name %>)
+    <% @logs.each do |log| %>
+      <tr>
+        <td class="wrap-word"><%= log.log_type.humanize %></td>
+        <td class="wrap-word"><%= log.event_type.humanize %></td>
+        <td><%= user_link log.user %></td>
+        <td class="wrap-word">
+          <% if log.related.present? %>
+            <%= log.related_type %> #<%= log.related_id %>
+            <% if log.related.respond_to? :name %>
+              (<%= log.related.name %>)
+            <% end %>
           <% end %>
-        <% end %>
-      </td>
-      <td><pre class="pre-wrap"><%= log.comment %></pre></td>
-      <td title="<%= log.created_at.iso8601 %>"><%= time_ago_in_words(log.created_at) %> ago</td>
-    </tr>
-  <% end %>
+        </td>
+        <td>
+          <pre class="pre-wrap"><%= log.comment %></pre>
+        </td>
+        <td title="<%= log.created_at.iso8601 %>"><%= time_ago_in_words(log.created_at) %> ago</td>
+      </tr>
+    <% end %>
   </tbody>
 </table>

--- a/app/views/mod_warning/log.html.erb
+++ b/app/views/mod_warning/log.html.erb
@@ -14,19 +14,15 @@
         <span title="<%= w.created_at.iso8601 %>"><%= time_ago_in_words(w.created_at) %> ago</span>
       </td>
       <td>
-        <% if w.is_suspension %>
+        <% if w.suspension? %>
           <% diff = ((w.suspension_end - w.created_at) / (3600 * 24)).to_i %>
           <span class="badge is-tag is-red is-filled nowrap">Suspension</span> (<%= diff %>d)
         <% else %>
           <span class="badge is-tag is-muted nowrap">Warning</span>
         <% end %>
       </td>
-      <td>
-        <%= user_link w.author %>
-      </td>
-      <td>
-        <%= raw(sanitize(render_markdown(w.body), scrubber: scrubber)) %>
-      </td>
+      <td><%= user_link w.author %></td>
+      <td><%= raw(sanitize(render_markdown(w.body), scrubber: scrubber)) %></td>
       <td class="wrap-word">
         <% if w.suspension_active? %>
           <strong>Current</strong>

--- a/app/views/mod_warning/log.html.erb
+++ b/app/views/mod_warning/log.html.erb
@@ -16,9 +16,9 @@
       <td>
         <% if w.is_suspension %>
           <% diff = ((w.suspension_end - w.created_at) / (3600 * 24)).to_i %>
-          <span class="badge is-tag is-red is-filled">Suspension</span> (<%= diff %>d)
+          <span class="badge is-tag is-red is-filled nowrap">Suspension</span> (<%= diff %>d)
         <% else %>
-          <span class="badge is-tag is-muted">Warning</span>
+          <span class="badge is-tag is-muted nowrap">Warning</span>
         <% end %>
       </td>
       <td>

--- a/app/views/mod_warning/log.html.erb
+++ b/app/views/mod_warning/log.html.erb
@@ -27,7 +27,7 @@
       <td>
         <%= raw(sanitize(render_markdown(w.body), scrubber: scrubber)) %>
       </td>
-      <td>
+      <td class="wrap-word">
         <% if w.suspension_active? %>
           <strong>Current</strong>
           <%= form_tag lift_mod_warning_url(@user.id), method: :post do %>

--- a/app/views/mod_warning/log.html.erb
+++ b/app/views/mod_warning/log.html.erb
@@ -1,46 +1,46 @@
 <h1>Warnings sent to <%= user_link @user %></h1>
 
 <table class="table is-full-width is-with-hover">
+  <tr>
+    <th>Date</th>
+    <th>Type</th>
+    <th>From</th>
+    <th>Excerpt</th>
+    <th>Status</th>
+  </tr>
+  <% @warnings.each do |w| %>
     <tr>
-        <th>Date</th>
-        <th>Type</th>
-        <th>From</th>
-        <th>Excerpt</th>
-        <th>Status</th>
+      <td>
+        <span title="<%= w.created_at.iso8601 %>"><%= time_ago_in_words(w.created_at) %> ago</span>
+      </td>
+      <td>
+        <% if w.is_suspension %>
+          <% diff = ((w.suspension_end - w.created_at) / (3600 * 24)).to_i %>
+          <span class="badge is-tag is-red is-filled">Suspension</span> (<%= diff %>d)
+        <% else %>
+          <span class="badge is-tag is-muted">Warning</span>
+        <% end %>
+      </td>
+      <td>
+        <%= user_link w.author %>
+      </td>
+      <td>
+        <%= raw(sanitize(render_markdown(w.body), scrubber: scrubber)) %>
+      </td>
+      <td>
+        <% if w.suspension_active? %>
+          <strong>Current</strong>
+          <%= form_tag lift_mod_warning_url(@user.id), method: :post do %>
+            <%= submit_tag '(lift)', class: 'link is-red' %>
+          <% end %>
+        <% elsif w.active %>
+          <strong>Unread</strong>
+        <% elsif w.read %>
+          Read
+        <% else %>
+          <strong>Lifted</strong>
+        <% end %>
+      </td>
     </tr>
-    <% @warnings.each do |w| %>
-        <tr>
-            <td>
-                <span title="<%= w.created_at.iso8601 %>"><%= time_ago_in_words(w.created_at) %> ago</span>
-            </td>
-            <td>
-                <% if w.is_suspension %>
-                <% diff = ((w.suspension_end - w.created_at) / (3600 * 24)).to_i %>
-                <span class="badge is-tag is-red is-filled">Suspension</span> (<%= diff %>d)
-                <% else %>
-                <span class="badge is-tag is-muted">Warning</span>
-                <% end %>
-            </td>
-            <td>
-                <%= user_link w.author %>
-            </td>
-            <td>
-                <%= raw(sanitize(render_markdown(w.body), scrubber: scrubber)) %>
-            </td>
-            <td>
-                <% if w.suspension_active? %>
-                <strong>Current</strong>
-                <%= form_tag lift_mod_warning_url(@user.id), method: :post do %>
-                    <%= submit_tag '(lift)', class: 'link is-red' %>
-                <% end %>
-                <% elsif w.active %>
-                <strong>Unread</strong>
-                <% elsif w.read %>
-                Read
-                <% else %>
-                <strong>Lifted</strong>
-                <% end %>
-            </td>
-        </tr>
-    <% end %>
+  <% end %>
 </table>

--- a/test/controllers/mod_warning_controller_test.rb
+++ b/test/controllers/mod_warning_controller_test.rb
@@ -90,9 +90,9 @@ class ModWarningControllerTest < ActionController::TestCase
 
     std = users(:standard_user)
     warning = mod_warnings(:third_warning)
-
     warning.update(active: true)
-    post :lift, params: { user_id: std.id }
+
+    try_lift_suspension(std)
 
     assert_response(:found)
     warning.reload
@@ -116,5 +116,10 @@ class ModWarningControllerTest < ActionController::TestCase
         suspension_duration: 365
       }.merge(opts)
     }
+  end
+
+  # @param subject [User] for whome to lift the suspension
+  def try_lift_suspension(subject)
+    post :lift, params: { user_id: subject.id }
   end
 end

--- a/test/controllers/mod_warning_controller_test.rb
+++ b/test/controllers/mod_warning_controller_test.rb
@@ -30,7 +30,7 @@ class ModWarningControllerTest < ActionController::TestCase
     end
   end
 
-  test ':create should correclty create mod warnings' do
+  test ':create should correctly create mod warnings' do
     user = users(:moderator)
     subject = users(:standard_user)
 
@@ -42,6 +42,7 @@ class ModWarningControllerTest < ActionController::TestCase
     warning = assigns(:warning)
     assert_not_nil warning
     assert_audit_log('warning_create', related: warning)
+    assert_audit_log('suspension_create', related: warning)
   end
 
   test 'suspended user should redirect to current warning page' do

--- a/test/controllers/mod_warning_controller_test.rb
+++ b/test/controllers/mod_warning_controller_test.rb
@@ -97,6 +97,9 @@ class ModWarningControllerTest < ActionController::TestCase
     assert_response(:found)
     warning.reload
     assert_not warning.active
+
+    assert_audit_log('warning_lift', related: warning)
+    assert_audit_log('suspension_lift', related: warning)
   end
 
   private

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -129,6 +129,20 @@ class ActiveSupport::TestCase
     end
   end
 
+  def assert_audit_log(event_type, related: nil)
+    log_entry = AuditLog.where(event_type: event_type)
+                        .order(created_at: :desc)
+                        .last
+    assert_not_nil(log_entry)
+    assert_equal event_type, log_entry['event_type']
+
+    if related.present?
+      assert_equal related.id, log_entry['related_id']
+    else
+      assert_nil(log_entry['related_id'])
+    end
+  end
+
   def assert_valid_json_response
     assert_nothing_raised do
       parsed = JSON.parse(response.body)


### PR DESCRIPTION
As per [discussion in Discord](https://discord.com/channels/634104110131445811/668890340199235613/1424214885104881714) - this minor PR adds an audit log for when someone creates a mod warning:

<img width="1346" height="209" alt="Screenshot from 2025-10-05 14-12-49" src="https://github.com/user-attachments/assets/6c984b16-0484-4df4-a62b-65fb82fe0c91" />

We already audit mod warning _lifts_ - warning creation is just as important for accountability.

Tangentially, this PR also adds a small fix for audit log category, type, and subject column wrapping (`overflow-wrap: anywhere` is way too liberal for those).