### PR TITLE
Fix tag drafts not being deleted upon creation / update

### DIFF
--- a/app/controllers/concerns/draft_management.rb
+++ b/app/controllers/concerns/draft_management.rb
@@ -2,6 +2,42 @@ module DraftManagement
   extend ActiveSupport::Concern
 
   DRAFTABLE_FIELDS = [:body, :comment, :excerpt, :license, :saved_at, :tags, :tag_name, :title].freeze
+  NESTED_DRAFTABLE_FIELDS = [:body, :saved_at].freeze
+  TOP_LEVEL_DRAFTABLE_FIELDS = [:body, :comment, :excerpt, :license, :tag_name, :tags, :title].freeze
+  DRAFT_MAX_AGE = 86_400 * 7
+
+  # saving by-field is kept for backwards compatibility with old drafts
+  # @param path [String] draft path to save
+  # @return [String] top level field key
+  def do_save_draft(path)
+    base_key = "saved_post.#{current_user.id}.#{path}"
+
+    TOP_LEVEL_DRAFTABLE_FIELDS.each do |key|
+      next unless params.key?(key)
+
+      key_name = NESTED_DRAFTABLE_FIELDS.include?(key) ? base_key : "#{base_key}.#{key}"
+
+      if key == :tags
+        valid_tags = params[key]&.select(&:present?)
+
+        RequestContext.redis.del(key_name)
+
+        if valid_tags.present?
+          RequestContext.redis.sadd(key_name, valid_tags)
+        end
+      else
+        RequestContext.redis.set(key_name, params[key])
+      end
+
+      RequestContext.redis.expire(key_name, DRAFT_MAX_AGE)
+    end
+
+    saved_at_key = "saved_post_at.#{current_user.id}.#{path}"
+    RequestContext.redis.set(saved_at_key, DateTime.now.iso8601)
+    RequestContext.redis.expire(saved_at_key, DRAFT_MAX_AGE)
+
+    base_key
+  end
 
   # Attempts to delete a draft for a given path
   # @param path [String] draft path to delete
@@ -10,7 +46,7 @@ module DraftManagement
     keys = DRAFTABLE_FIELDS.map do |key|
       pfx = key == :saved_at ? 'saved_post_at' : 'saved_post'
       base = "#{pfx}.#{current_user.id}.#{path}"
-      [:body, :saved_at].include?(key) ? base : "#{base}.#{key}"
+      NESTED_DRAFTABLE_FIELDS.include?(key) ? base : "#{base}.#{key}"
     end
 
     RequestContext.redis.del(*keys)

--- a/app/controllers/concerns/draft_management.rb
+++ b/app/controllers/concerns/draft_management.rb
@@ -7,10 +7,11 @@ module DraftManagement
   DRAFT_MAX_AGE = 86_400 * 7
 
   # saving by-field is kept for backwards compatibility with old drafts
+  # @param user [User] user to save the draft for
   # @param path [String] draft path to save
   # @return [String] top level field key
-  def do_save_draft(path)
-    base_key = "saved_post.#{current_user.id}.#{path}"
+  def do_save_draft(user, path)
+    base_key = "saved_post.#{user.id}.#{path}"
 
     TOP_LEVEL_DRAFTABLE_FIELDS.each do |key|
       next unless params.key?(key)
@@ -32,7 +33,7 @@ module DraftManagement
       RequestContext.redis.expire(key_name, DRAFT_MAX_AGE)
     end
 
-    saved_at_key = "saved_post_at.#{current_user.id}.#{path}"
+    saved_at_key = "saved_post_at.#{user.id}.#{path}"
     RequestContext.redis.set(saved_at_key, DateTime.now.iso8601)
     RequestContext.redis.expire(saved_at_key, DRAFT_MAX_AGE)
 
@@ -40,12 +41,13 @@ module DraftManagement
   end
 
   # Attempts to delete a draft for a given path
+  # @param user [User] user to delete the draft for
   # @param path [String] draft path to delete
   # @return [Boolean] status of the operation
-  def do_draft_delete(path)
+  def do_delete_draft(user, path)
     keys = DRAFTABLE_FIELDS.map do |key|
       pfx = key == :saved_at ? 'saved_post_at' : 'saved_post'
-      base = "#{pfx}.#{current_user.id}.#{path}"
+      base = "#{pfx}.#{user.id}.#{path}"
       NESTED_DRAFTABLE_FIELDS.include?(key) ? base : "#{base}.#{key}"
     end
 

--- a/app/controllers/concerns/draft_management.rb
+++ b/app/controllers/concerns/draft_management.rb
@@ -1,0 +1,18 @@
+module DraftManagement
+  extend ActiveSupport::Concern
+
+  DRAFTABLE_FIELDS = [:body, :comment, :excerpt, :license, :saved_at, :tags, :tag_name, :title].freeze
+
+  # Attempts to delete a draft for a given path
+  # @param path [String] draft path to delete
+  # @return [Boolean] status of the operation
+  def do_draft_delete(path)
+    keys = DRAFTABLE_FIELDS.map do |key|
+      pfx = key == :saved_at ? 'saved_post_at' : 'saved_post'
+      base = "#{pfx}.#{current_user.id}.#{path}"
+      [:body, :saved_at].include?(key) ? base : "#{base}.#{key}"
+    end
+
+    RequestContext.redis.del(*keys)
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,8 @@
 # rubocop:disable Metrics/ClassLength
 # rubocop:disable Metrics/MethodLength
 class PostsController < ApplicationController
+  include DraftManagement
+
   before_action :authenticate_user!, except: [:document, :help_center, :show]
   before_action :set_post, only: [:toggle_comments, :feature, :lock, :unlock]
   before_action :set_scoped_post, only: [:change_category, :show, :edit, :update, :close, :reopen, :delete, :restore]
@@ -725,19 +727,6 @@ class PostsController < ApplicationController
 
   def unless_locked
     check_if_locked(@post)
-  end
-
-  # Attempts to actually delete a post draft
-  # @param path [String] draft path to delete
-  # @return [Boolean] status of the operation
-  def do_draft_delete(path)
-    keys = [:body, :comment, :excerpt, :license, :saved_at, :tags, :tag_name, :title].map do |key|
-      pfx = key == :saved_at ? 'saved_post_at' : 'saved_post'
-      base = "#{pfx}.#{current_user.id}.#{path}"
-      [:body, :saved_at].include?(key) ? base : "#{base}.#{key}"
-    end
-
-    RequestContext.redis.del(*keys)
   end
 end
 # rubocop:enable Metrics/MethodLength

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -113,7 +113,7 @@ class PostsController < ApplicationController
         Rails.cache.delete "community_user/#{current_user.community_user.id}/metric/#{key}"
       end
 
-      do_draft_delete(URI(request.referer || '').path)
+      do_delete_draft(current_user, URI(request.referer || '').path)
 
       redirect_to helpers.generic_show_link(@post)
     else
@@ -263,7 +263,7 @@ class PostsController < ApplicationController
               PostHistory.redact(@post, current_user)
             end
             Rails.cache.delete "community_user/#{current_user.community_user.id}/metric/E"
-            do_draft_delete(URI(request.referer || '').path)
+            do_delete_draft(current_user, URI(request.referer || '').path)
             redirect_to post_path(@post)
           end
 
@@ -302,7 +302,7 @@ class PostsController < ApplicationController
             message += " on '#{@post.parent.title}'"
           end
           @post.user.create_notification message, suggested_edit_url(edit, host: @post.community.host)
-          do_draft_delete(URI(request.referer || '').path)
+          do_delete_draft(current_user, URI(request.referer || '').path)
           redirect_to post_path(@post)
         else
           @post.errors.copy!(edit.errors)
@@ -634,12 +634,12 @@ class PostsController < ApplicationController
   end
 
   def save_draft
-    base_key = do_save_draft(params[:path])
+    base_key = do_save_draft(current_user, params[:path])
     render json: { status: 'success', success: true, key: base_key }
   end
 
   def delete_draft
-    do_draft_delete(params[:path])
+    do_delete_draft(current_user, params[:path])
     render json: { status: 'success', success: true }
   end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -272,8 +272,7 @@ class TagsController < ApplicationController
   end
 
   def verify_tag_editor
-    unless user_signed_in? && (current_user.privilege?(:edit_tags) ||
-      current_user.at_least_moderator?)
+    unless user_signed_in? && current_user.can_edit_tags?
       respond_to do |format|
         format.html do
           render 'errors/not_found', layout: 'without_sidebar', status: :not_found

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -98,7 +98,6 @@ class TagsController < ApplicationController
 
     @tag = Tag.new(create_params)
     if @tag.save
-      Rails.logger.warn(URI(request.referer || '').path)
       do_draft_delete(URI(request.referer || '').path)
       redirect_to tag_path(id: @category.id, tag_id: @tag.id)
     else

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,4 +1,6 @@
 class TagsController < ApplicationController
+  include DraftManagement
+
   before_action :authenticate_user!, only: [:new, :create, :edit, :update, :rename, :merge, :select_merge]
   before_action :set_category, except: [:index]
   before_action :set_tag, only: [:show, :edit, :update, :children, :rename, :merge, :select_merge, :nuke, :nuke_warning]
@@ -92,8 +94,12 @@ class TagsController < ApplicationController
   end
 
   def create
-    @tag = Tag.new(tag_params.merge(tag_set_id: @category.tag_set.id))
+    create_params = tag_params.merge(tag_set_id: @category.tag_set.id)
+
+    @tag = Tag.new(create_params)
     if @tag.save
+      Rails.logger.warn(URI(request.referer || '').path)
+      do_draft_delete(URI(request.referer || '').path)
       redirect_to tag_path(id: @category.id, tag_id: @tag.id)
     else
       render :new, status: :bad_request
@@ -109,7 +115,11 @@ class TagsController < ApplicationController
     return unless check_your_privilege('edit_tags', nil, true)
 
     wiki_md = params[:tag][:wiki_markdown]
-    if @tag.update(tag_params.merge(wiki: wiki_md.present? ? helpers.render_markdown(wiki_md) : nil).except(:name))
+    update_params = tag_params.merge(wiki: wiki_md.present? ? helpers.render_markdown(wiki_md) : nil)
+                              .except(:name)
+
+    if @tag.update(update_params)
+      do_draft_delete(URI(request.referer || '').path)
       redirect_to tag_path(id: @category.id, tag_id: @tag.id)
     else
       render :edit, status: :bad_request

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -98,7 +98,7 @@ class TagsController < ApplicationController
 
     @tag = Tag.new(create_params)
     if @tag.save
-      do_draft_delete(URI(request.referer || '').path)
+      do_delete_draft(current_user, URI(request.referer || '').path)
       redirect_to tag_path(id: @category.id, tag_id: @tag.id)
     else
       render :new, status: :bad_request
@@ -118,7 +118,7 @@ class TagsController < ApplicationController
                               .except(:name)
 
     if @tag.update(update_params)
-      do_draft_delete(URI(request.referer || '').path)
+      do_delete_draft(current_user, URI(request.referer || '').path)
       redirect_to tag_path(id: @category.id, tag_id: @tag.id)
     else
       render :edit, status: :bad_request

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -138,6 +138,12 @@ class User < ApplicationRecord
     privilege?('flag_curate') && !target.deleted?
   end
 
+  # Can the user edit tags?
+  # @return [Boolean] check result
+  def can_edit_tags?
+    privilege?('edit_tags') || false
+  end
+
   # Can the user handle flags?
   # @return [Boolean] check result
   def can_handle_flags?

--- a/test/controllers/tags_controller_test.rb
+++ b/test/controllers/tags_controller_test.rb
@@ -99,6 +99,45 @@ class TagsControllerTest < ActionController::TestCase
     assert_not_nil assigns(:posts)
   end
 
+  test ':create should require authentication' do
+    try_create_tag(categories(:main), tag_sets(:main))
+
+    assert_redirected_to_sign_in
+  end
+
+  test 'only users who can edit tags should be able to create them' do
+    category = categories(:main)
+    tag_set = tag_sets(:main)
+
+    users.each do |user|
+      sign_in(user)
+      try_create_tag(category, tag_set, name: "test-tag-#{user.id}")
+
+      if !@controller.helpers.user_signed_in?
+        assert_redirected_to_sign_in
+      elsif user.can_edit_tags?
+        assert_response(:found, "Expected user '#{user.name}' to be able to create tags")
+      else
+        assert_response(:not_found, "Expected user '#{user.name}' to not be able to create tags")
+      end
+    end
+  end
+
+  test ':create should correctly create tags' do
+    sign_in users(:editor)
+
+    category = categories(:main)
+    tag_set = tag_sets(:main)
+    tag_name = 'test-tag'
+
+    try_create_tag(category, tag_set, name: tag_name)
+
+    @tag = assigns(:tag)
+
+    assert_not_nil @tag
+    assert_redirected_to(tag_path(id: category.id, tag_id: @tag.id))
+  end
+
   test 'should deny edit to anonymous user' do
     get :edit, params: { id: categories(:main).id, tag_id: tags(:topic).id }
 
@@ -233,6 +272,20 @@ class TagsControllerTest < ActionController::TestCase
   end
 
   private
+
+  # @param category [Category] category to create the tag in
+  # @param tag_set [TagSet] tag set the tag belongs to
+  def try_create_tag(tag_set, category, **opts)
+    post :create, params: {
+      id: category.id,
+      tag: {
+        excerpt: 'Usage guidance goes here',
+        name: 'test-tag',
+        tag_set_id: tag_set.id,
+        wiki_markdown: 'Extended tag description goes here'
+      }.merge(opts)
+    }
+  end
 
   # @param category [Category] category to rename the tag in
   # @param tag [Tag] tag to rename

--- a/test/controllers/tags_controller_test.rb
+++ b/test/controllers/tags_controller_test.rb
@@ -124,7 +124,7 @@ class TagsControllerTest < ActionController::TestCase
   end
 
   test ':create should correctly create tags' do
-    sign_in users(:editor)
+    sign_in users(:tags_editor)
 
     category = categories(:main)
     tag_set = tag_sets(:main)

--- a/test/fixtures/community_users.yml
+++ b/test/fixtures/community_users.yml
@@ -26,6 +26,13 @@ sample_editor:
   is_moderator: false
   reputation: 501
 
+sample_tags_editor:
+  user: tags_editor
+  community: sample
+  is_admin: false
+  is_moderator: false
+  reputation: 42
+
 sample_deleter:
   user: deleter
   community: sample

--- a/test/fixtures/user_abilities.yml
+++ b/test/fixtures/user_abilities.yml
@@ -10,6 +10,10 @@ e_eo:
   community_user: sample_editor
   ability: everyone
 
+et_eo:
+  community_user: sample_tags_editor
+  ability: everyone
+
 d_eo:
   community_user: sample_deleter
   ability: everyone
@@ -36,6 +40,10 @@ c_ur:
 
 e_ur:
   community_user: sample_editor
+  ability: unrestricted
+
+et_ur:
+  community_user: sample_tags_editor
   ability: unrestricted
 
 d_ur:

--- a/test/fixtures/user_abilities.yml
+++ b/test/fixtures/user_abilities.yml
@@ -78,6 +78,10 @@ d_et:
   community_user: sample_deleter
   ability: edit_tags
 
+te_et:
+  community_user: sample_tags_editor
+  ability: edit_tags
+
 b_eo:
   community_user: sample_basic_user
   ability: everyone

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -40,6 +40,15 @@ editor:
   login_token_expires_at: 2000-01-01T00:00:00.000000Z
   confirmed_at: 2020-01-01T00:00:00.000000Z
 
+tags_editor:
+  email: editor@example.com
+  encrypted_password: '$2a$11$roUHXKxecjyQ72Qn7DWs3.9eRCCoRn176kX/UNb/xiue3aGqf7xEW'
+  sign_in_count: 1337
+  username: tags-editor
+  is_global_admin: false
+  is_global_moderator: false
+  confirmed_at: 2020-01-01T00:00:00.000000Z
+
 deleter:
   email: delete@qpixel-test.net
   encrypted_password: '$2a$11$roUHXKxecjyQ72Qn7DWs3.9eRCCoRn176kX/UNb/xiue3aGqf7xEW'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -129,6 +129,16 @@ class ActiveSupport::TestCase
     end
   end
 
+  def assert_draft_deleted(user, path, *fields)
+    base_key = "saved_post.#{user.id}.#{path}"
+
+    fields.each do |key|
+      key_name = DraftManagement::NESTED_DRAFTABLE_FIELDS.include?(key) ? base_key : "#{base_key}.#{key}"
+      assert_not(RequestContext.redis.exists?(key_name),
+                 "Expected '#{key_name}' draft to be deleted")
+    end
+  end
+
   def assert_valid_json_response
     assert_nothing_raised do
       parsed = JSON.parse(response.body)


### PR DESCRIPTION
closes #1859

This PR adds a `DraftManagement` concern to both facilitate the fix and avoid duplication (all our controllers share the same draft saving & deletion logic). The concern is named this way to match Rails's convention of naming such controller concerns (see, for example, `RequestForgeryProtection`)