### PR TITLE
expand who can rename threads, with public log

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -228,7 +228,13 @@ class CommentsController < ApplicationController
       # Comment is owned by System so regular users can't delete it. Without
       # this record, the title would be attributed to the thread creator,
       # which can be abused.
-      log_msg = Comment.new(post: @post, content: 'Thread renamed from \"' + orig_title + '\" to \"' + title + '\" by ' + current_user.username, user: User.find(-1), comment_thread: @comment_thread, has_reference: false)
+      log_msg =
+        Comment.new(post: @post,
+                    content:
+                      "Thread renamed from \\\"#{orig_title}\\\" to \\\"#{title}\\\" by #{current_user.username}",
+                    user: User.find(-1),
+                    comment_thread: @comment_thread,
+                    has_reference: false)
       comment_status = log_msg.save
     end
 
@@ -239,7 +245,7 @@ class CommentsController < ApplicationController
     unless comment_status
       flash[:danger] = I18n.t('comments.errors.comment_not_posted')
     end
-      
+
     redirect_to comment_thread_path(@comment_thread.id)
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -231,7 +231,7 @@ class CommentsController < ApplicationController
       log_msg =
         Comment.new(post: @post,
                     content:
-                      "Thread renamed from \\\"#{orig_title}\\\" to \\\"#{title}\\\" by #{current_user.username}",
+                      "Thread renamed from \\\"#{orig_title}\\\" to \\\"#{title}\\\" by @##{current_user.id}",
                     user: User.find(-1),
                     comment_thread: @comment_thread,
                     has_reference: false)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -88,6 +88,13 @@ class User < ApplicationRecord
     post.user == self || privilege?(name)
   end
 
+  # Can the user rename a given comment thread?
+  # @param thread [CommentThread] thread to archive
+  # @return [Boolean] check result
+  def can_rename?(thread)
+    privilege?('flag_curate')
+  end
+  
   # Can the user archive a given comment thread?
   # @param thread [CommentThread] thread to archive
   # @return [Boolean] check result

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,7 +95,7 @@ class User < ApplicationRecord
     privilege?('flag_curate') ||
       Comment.where(user: self, comment_thread_id: thread.id).any?
   end
-  
+
   # Can the user archive a given comment thread?
   # @param thread [CommentThread] thread to archive
   # @return [Boolean] check result

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,10 +89,11 @@ class User < ApplicationRecord
   end
 
   # Can the user rename a given comment thread?
-  # @param thread [CommentThread] thread to archive
+  # @param thread [CommentThread] thread to rename
   # @return [Boolean] check result
   def can_rename?(thread)
-    privilege?('flag_curate')
+    privilege?('flag_curate') ||
+      Comment.where(user: self, comment_thread_id: thread.id).any?
   end
   
   # Can the user archive a given comment thread?

--- a/app/views/comment_threads/_expanded.html.erb
+++ b/app/views/comment_threads/_expanded.html.erb
@@ -38,6 +38,15 @@
         <a href="<%= comment_thread_path(thread.id) %>" class="widget--header-link">show thread</a>
         <a href="javascript:void(0)" class="js-collapse-thread widget--header-link">collapse</a>
       <% end %>
+      <% if current_user&.can_rename?(thread) && !current_user&.privilege?('flag_curate') %>
+      <a href="javascript:void(0)"
+	 class="widget--header-link"
+	 data-modal=".js--rename-thread-<%= thread.id %>"
+         role="button"
+         aria-label="Rename thread">
+        <i class="fas fa-pen fa-fw"></i> rename
+      </a>
+      <% end %>
       <% if current_user&.privilege?('flag_curate') %>
         <%= render 'comments/thread_tools_link', thread: thread %>
       <% end %>
@@ -105,6 +114,10 @@
       </div>
     <% end %>
   <% end %>
+<% end %>
+
+<% if current_user&.can_rename?(thread)  %>
+  <%= render 'comments/rename_thread_modal', thread: thread %>
 <% end %>
 
 <% if current_user&.privilege?('flag_curate') %>

--- a/app/views/comment_threads/_expanded.html.erb
+++ b/app/views/comment_threads/_expanded.html.erb
@@ -8,6 +8,7 @@
       thread       : CommentThread to display
 %>
 
+<% can_only_rename = current_user&.can_rename?(thread) && !current_user&.privilege?('flag_curate') %>
 <% max_shown_comments = 5 %>
 <% comment_id ||= defined?(comment_id) ? comment_id : nil %>
 <% pingable = thread.pingable %>
@@ -38,10 +39,10 @@
         <a href="<%= comment_thread_path(thread.id) %>" class="widget--header-link">show thread</a>
         <a href="javascript:void(0)" class="js-collapse-thread widget--header-link">collapse</a>
       <% end %>
-      <% if current_user&.can_rename?(thread) && !current_user&.privilege?('flag_curate') %>
+      <% if can_only_rename %>
       <a href="javascript:void(0)"
-	 class="widget--header-link"
-	 data-modal=".js--rename-thread-<%= thread.id %>"
+	       class="widget--header-link"
+	       data-modal=".js--rename-thread-<%= thread.id %>"
          role="button"
          aria-label="Rename thread">
         <i class="fas fa-pen fa-fw"></i> rename
@@ -116,7 +117,7 @@
   <% end %>
 <% end %>
 
-<% if current_user&.can_rename?(thread)  %>
+<% if can_only_rename %>
   <%= render 'comments/rename_thread_modal', thread: thread %>
 <% end %>
 

--- a/app/views/comment_threads/_expanded.html.erb
+++ b/app/views/comment_threads/_expanded.html.erb
@@ -1,12 +1,12 @@
 <%#
-    Full thread view with all the details & actions
+   "Full thread view with all the details & actions
 
     Variables:
     ? comment_id   : Comment ID to show even if it would be hidden otherwise
       inline       : whether the thread is diplayed inline with the parent post
       show_deleted : whether to display deleted comments for those who can see them
       thread       : CommentThread to display
-%>
+"%>
 
 <% can_only_rename = current_user&.can_rename?(thread) && !current_user&.privilege?('flag_curate') %>
 <% max_shown_comments = 5 %>
@@ -41,8 +41,8 @@
       <% end %>
       <% if can_only_rename %>
       <a href="javascript:void(0)"
-	       class="widget--header-link"
-	       data-modal=".js--rename-thread-<%= thread.id %>"
+         class="widget--header-link"
+         data-modal=".js--rename-thread-<%= thread.id %>"
          role="button"
          aria-label="Rename thread">
         <i class="fas fa-pen fa-fw"></i> rename

--- a/config/locales/strings/en.comments.yml
+++ b/config/locales/strings/en.comments.yml
@@ -33,6 +33,8 @@ en:
         Failed to rename the thread.
       title_presence: >
         can't be empty after Markdown is removed.
+      comment_not_posted: >
+        Failed to create comment.
     labels:
       create_new_thread: >
         Start new comment thread


### PR DESCRIPTION
Currently, only curators can rename comment threads.  We've had many requests over the years from authors who didn't like the auto-generated title or wanted to fix a typo, but renames were also silent, so we wanted to restrict this to mitigate against abuse.  (After all, a silently-renamed thread puts that name in the mouth of the person who created that thread.)

This change adds attribution for renamed threads, like this:

<img width="813" height="304" alt="comments showing who renamed from what to what" src="https://github.com/user-attachments/assets/ae01cd05-79ed-43e1-a6a6-01a6aebde6c6" />

The comment is owned by System, not the renamer, so that regular users can't delete the comments.  These comments are created directly and do not ping followers (just as we do not notify followers for other state changes like lock and archive).

Non-curator users can only rename threads they've participated in, like this:

<img width="834" height="888" alt="two threads, one showing the rename control and one not" src="https://github.com/user-attachments/assets/90c76588-ae99-428f-8c3f-d44326e41343" />


Fixes https://github.com/codidact/qpixel/issues/714.
