### PR TITLE
"Hot posts" sidebar widget should render Markdown in titles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -287,6 +287,16 @@ mjx-container {
     overflow-y: hidden;
 }
 
+code,
+kbd {
+  padding: {
+    top: 0.1em;
+    bottom: 0.1em;
+    left: 0.25em;
+    right: 0.25em;
+  };
+}
+
 kbd {
   border: {
     color: $muted-graphic;
@@ -301,11 +311,5 @@ kbd {
   margin: {
     left: 0.15em;
     right: 0.15em;
-  };
-  padding: {
-    top: 0.1em;
-    bottom: 0.1em;
-    left: 0.25em;
-    right: 0.25em;
   };
 }

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -64,6 +64,14 @@ h1 .badge.is-tag.is-master-tag {
   }
 }
 
+.post-widget--title {
+  line-height: 1.5em;
+
+  del {
+    background-color: transparent;
+  }
+}
+
 .post-list--content {
   font-size: 14px;
   width: 100%;

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -75,32 +75,7 @@
       <% end %>
     <% end %>
 
-    <%# Hot Posts widget %>
-    <% if Rails.env.development? || @hot_questions.to_a.size > 0 %>
-      <% collapse_hot = user_preference('collapse_hot_posts') == 'true' %>
-      <% cache @hot_questions do %>
-        <div class="widget has-margin-4 is-tertiary" data-collapsed="<%= user_preference('collapse_hot_posts') %>">
-          <div class="widget--header">
-            Hot Posts
-            <button type="button" class="widget--header-link button is-icon-only-button js-widget-hide"
-                    aria-label="Collapse Hot Posts">
-              <i class="fas <%= collapse_hot ? 'fa-chevron-down' : 'fa-chevron-up' %>"></i>
-            </button>
-          </div>
-          <% @hot_questions.each do |hq| %>
-            <div class="widget--body <%= 'hidden' if collapse_hot %>">
-              <% unless hq.category.nil? %>
-                <%= hq.category.name %>
-                &mdash;
-              <% end %>
-              <%= link_to generic_share_link(hq) do %>
-                <%= hq.title %>
-              <% end %>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
-    <% end %>
+    <%= render 'shared/hot_posts', posts: @hot_questions %>
   <% end %>
 
   <% if Rails.env.development? || rand(100) <= 10 %>

--- a/app/views/shared/_hot_posts.html.erb
+++ b/app/views/shared/_hot_posts.html.erb
@@ -18,14 +18,14 @@
           <i class="fas <%= collapse_hot ? 'fa-chevron-down' : 'fa-chevron-up' %>"></i>
         </button>
       </div>
-      <% posts.each do |hq| %>
+      <% posts.each do |post| %>
         <div class="widget--body <%= 'hidden' if collapse_hot %>">
-          <% unless hq.category.nil? %>
-            <%= hq.category.name %>
+          <% unless post.category.nil? %>
+            <%= post.category.name %>
             &mdash;
           <% end %>
-          <%= link_to generic_share_link(hq) do %>
-            <%= hq.title %>
+          <%= link_to generic_share_link(post), class: 'post-widget--title' do %>
+            <%= rendered_title(post) %>
           <% end %>
         </div>
       <% end %>

--- a/app/views/shared/_hot_posts.html.erb
+++ b/app/views/shared/_hot_posts.html.erb
@@ -1,0 +1,34 @@
+<%#
+   "Render s a Hot Posts widget
+
+    Variables:
+      posts : ActiveRecord::Relation<Post> to list in the widget
+"%>
+
+<% if Rails.env.development? || posts.to_a.size > 0 %>
+  <% collapse_hot = user_preference('collapse_hot_posts') == 'true' %>
+  <% cache posts do %>
+    <div class="widget has-margin-4 is-tertiary"
+         data-collapsed="<%= user_preference('collapse_hot_posts') %>">
+      <div class="widget--header">
+        Hot Posts
+        <button type="button"
+                class="widget--header-link button is-icon-only-button js-widget-hide"
+                aria-label="Collapse Hot Posts">
+          <i class="fas <%= collapse_hot ? 'fa-chevron-down' : 'fa-chevron-up' %>"></i>
+        </button>
+      </div>
+      <% posts.each do |hq| %>
+        <div class="widget--body <%= 'hidden' if collapse_hot %>">
+          <% unless hq.category.nil? %>
+            <%= hq.category.name %>
+            &mdash;
+          <% end %>
+          <%= link_to generic_share_link(hq) do %>
+            <%= hq.title %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>


### PR DESCRIPTION
A followup to #1860 - forgot to add title rendering to the widget. The PR also makes the widget itself a partial (reuse + code organization):

<img width="364" height="251" alt="Screenshot from 2025-10-12 18-35-18" src="https://github.com/user-attachments/assets/56e79d2a-a6e1-47f9-b705-459a79dd9f1c" />

Since the widget is cached, it is advised to clear cache when testing