### PR TITLE
0valt/1875/audit logs

### DIFF
--- a/app/assets/stylesheets/audit_logs.scss
+++ b/app/assets/stylesheets/audit_logs.scss
@@ -1,7 +1,9 @@
 @import 'variables';
 
 .audit-log-filters {
-  .form-group-horizontal .actions, .select2-container {
+
+  .form-group-horizontal .actions,
+  .select2-container {
     height: 37px;
     margin: 4px 0px;
   }
@@ -33,4 +35,23 @@
 
 .audit-log-table-wrapper {
   overflow: scroll;
+}
+
+.audit-log-summary {
+  display: flex;
+  align-items: center;
+  gap: 1em;
+  word-break: break-word;
+
+  &[open] {
+    margin: 0;
+  }
+
+  &::before {
+    top: unset;
+  }
+
+  .details {
+    flex: 1;
+  }
 }

--- a/app/assets/stylesheets/audit_logs.scss
+++ b/app/assets/stylesheets/audit_logs.scss
@@ -30,3 +30,7 @@
     }
   }
 }
+
+.audit-log-table-wrapper {
+  overflow: scroll;
+}

--- a/app/assets/stylesheets/audit_logs.scss
+++ b/app/assets/stylesheets/audit_logs.scss
@@ -33,10 +33,6 @@
   }
 }
 
-.audit-log-table-wrapper {
-  overflow: scroll;
-}
-
 .audit-log-summary {
   display: flex;
   align-items: center;

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -100,7 +100,7 @@ class AdminController < ApplicationController
     redirect_to admin_path
   end
 
-  def audit_log
+  def audit_logs
     @page = helpers.safe_page(params)
     @per_page = helpers.safe_per_page(params)
 

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,3 +1,20 @@
-# Provides helper methods for use by views under <tt>AdminController</tt>.
 module AdminHelper
+  # Renders related model for a given log
+  # @param log [AuditLog] log to render related model for
+  # @return [String] rendered related model
+  def rendered_related(log)
+    return '' unless log.related.present?
+
+    if log.related.is_a?(User)
+      return user_link(log.related)
+    end
+
+    base = "#{log.related_type} ##{log.related_id}"
+
+    if log.related.respond_to?(:name)
+      "#{base} (#{log.related.name})"
+    else
+      base
+    end
+  end
 end

--- a/app/views/admin/_audit_log.html.erb
+++ b/app/views/admin/_audit_log.html.erb
@@ -1,0 +1,41 @@
+<%#
+   "Renders an audit log item
+
+    Variables:
+      log : AuditLog to render
+"%>
+
+<details class="audit-log">
+  <summary class="audit-log-summary">
+    <span class="details">
+      <strong><%= log.event_type.humanize %></strong>
+      <br/>
+      <span class="has-font-size-caption has-color-tertiary-600">
+        by <%= user_link(log.user) %><% if log.related.present? %>
+          for <%= rendered_related(log) %>
+        <% end %>
+      </span>
+    </span>
+    <span class="has-padding-right-2 has-float-right has-color-tertiary-600"
+          title="<%= log.created_at.iso8601 %>">
+      <%= time_ago_in_words(log.created_at.iso8601) %> ago
+    </span>
+  </summary>
+
+  <p>
+    <strong><%= t('g.type').capitalize %>:</strong>
+    <%= log.log_type.humanize %><br/>
+
+    <strong><%= t('g.user').capitalize %>:</strong>
+    <%= user_link(log.user) %><br/>
+
+    <% if log.related.present? %>
+      <strong><%= t('g.related').capitalize %>:</strong>
+      <%= rendered_related(log) %><br/>
+    <% end %>
+  </p>
+
+  <% if log.comment.present? %>
+    <pre><%= log.comment %></pre>
+  <% end %>
+</details>

--- a/app/views/admin/audit_log.html.erb
+++ b/app/views/admin/audit_log.html.erb
@@ -48,7 +48,9 @@
   </div>
 </div>
 
-<%= render 'log_table' %>
+<div class="audit-log-table-wrapper">
+  <%= render 'log_table' %>
+</div>
 
 <div class="has-padding-top-4">
   <%= will_paginate @logs, renderer: BootstrapPagination::Rails %>

--- a/app/views/admin/audit_logs.html.erb
+++ b/app/views/admin/audit_logs.html.erb
@@ -1,8 +1,8 @@
-<h1><%= t 'admin.tools.audit_log' %></h1>
+<h1><%= t 'admin.tools.audit_logs' %></h1>
 
 <div>
   <h3>Filters</h3>
-  <%= form_tag audit_log_path, method: :get, class: 'form-inline audit-log-filters' do %>
+  <%= form_tag audit_logs_path, method: :get, class: 'form-inline audit-log-filters' do %>
     <div class="form-group-horizontal">
       <div class="form-group">
         <%= label_tag :log_type, 'Log category', class: 'form-element' %>

--- a/app/views/admin/audit_logs.html.erb
+++ b/app/views/admin/audit_logs.html.erb
@@ -48,9 +48,9 @@
   </div>
 </div>
 
-<div class="audit-log-table-wrapper">
-  <%= render 'log_table' %>
-</div>
+<% @logs.each do |log| %>
+  <%= render 'admin/audit_log', log: log %>
+<% end %>
 
 <div class="has-padding-top-4">
   <%= will_paginate @logs, renderer: BootstrapPagination::Rails %>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -115,7 +115,7 @@
     <div class="widget">
       <div class="widget--body">
         <i class="fas fa-user-secret"></i>
-        <%= link_to t('admin.tools.audit_log'), audit_log_path, 'data-ckb-item-link' => '' %>
+        <%= link_to t('admin.tools.audit_logs'), audit_logs_path, 'data-ckb-item-link' => '' %>
       </div>
     </div>
   </div>

--- a/config/locales/strings/en.admin.yml
+++ b/config/locales/strings/en.admin.yml
@@ -33,7 +33,7 @@ en:
       privileges: 'Privileges'
       close_reasons: 'Close Reasons'
       licenses: 'Licenses'
-      audit_log: 'Audit Log'
+      audit_logs: 'Audit Log'
       post_types: 'Post Types'
       email_query: 'User Lookup by Email'
     user_fed_stat: 'User fed to STAT.'

--- a/config/locales/strings/es.admin.yml
+++ b/config/locales/strings/es.admin.yml
@@ -30,6 +30,6 @@ es:
       privileges: 'Privilegios'
       close_reasons: 'Razones para Cerrar'
       licenses: 'Licencias'
-      audit_log: 'Registro de Auditoría'
+      audit_logs: 'Registro de Auditoría'
       post_types: 'Tipos de Publicación'
     user_fed_stat: 'STAT alimentado con usuario/a.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,7 @@ Rails.application.routes.draw do
     get    'email-all',                    to: 'admin#all_email', as: :email_all
     post   'email-all',                    to: 'admin#send_all_email', as: :send_all_email
 
-    get    'audits',                       to: 'admin#audit_log', as: :audit_log
+    get    'audits',                       to: 'admin#audit_logs', as: :audit_logs
 
     get    'new-site',                     to: 'admin#new_site', as: :new_site
     post   'new-site',                     to: 'admin#create_site', as: :create_site

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class AdminControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
-  PARAM_LESS_ACTIONS = [:index, :error_reports, :privileges, :audit_log, :email_query, :admin_email, :all_email].freeze
+  PARAM_LESS_ACTIONS = [:index, :error_reports, :privileges, :audit_logs, :email_query, :admin_email, :all_email].freeze
 
   test 'should get index' do
     sign_in users(:admin)
@@ -127,7 +127,7 @@ class AdminControllerTest < ActionController::TestCase
 
   test 'should get audit log' do
     sign_in users(:admin)
-    get :audit_log
+    get :audit_logs
     assert_response(:success)
     assert_not_nil assigns(:logs)
   end
@@ -174,7 +174,7 @@ class AdminControllerTest < ActionController::TestCase
 
   test 'audit log should work with filter params' do
     sign_in users(:admin)
-    get :audit_log, params: { log_type: 'admin_audit', event_type: 'setting_update', from: '2025-04-13',
+    get :audit_logs, params: { log_type: 'admin_audit', event_type: 'setting_update', from: '2025-04-13',
                               to: '2025-04-13' }
     assert_response(:success)
     assert_not_nil assigns(:logs)

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -174,10 +174,26 @@ class AdminControllerTest < ActionController::TestCase
 
   test 'audit log should work with filter params' do
     sign_in users(:admin)
-    get :audit_logs, params: { log_type: 'admin_audit', event_type: 'setting_update', from: '2025-04-13',
-                              to: '2025-04-13' }
-    assert_response(:success)
-    assert_not_nil assigns(:logs)
+
+    log_types = audit_logs.map(&:log_type)
+
+    log_types.each do |type|
+      try_audit_logs(log_type: type)
+      @logs = assigns(:logs)
+      assert_response(:success)
+      assert_not_nil @logs
+      assert(@logs.all? { |l| l.log_type == type })
+    end
+
+    event_types = audit_logs.map(&:event_type)
+
+    event_types.each do |type|
+      try_audit_logs(event_type: type)
+      @logs = assigns(:logs)
+      assert_response(:success)
+      assert_not_nil @logs
+      assert(@logs.all? { |l| l.event_type == type })
+    end
   end
 
   test 'hellban should correctly block the user' do
@@ -202,6 +218,10 @@ class AdminControllerTest < ActionController::TestCase
   end
 
   private
+
+  def try_audit_logs(**params)
+    get :audit_logs, params: params
+  end
 
   def try_hellban_user(user)
     post :hellban, params: { id: user.id }

--- a/test/fixtures/audit_logs.yml
+++ b/test/fixtures/audit_logs.yml
@@ -1,6 +1,6 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-admin_log:
+site_setting_update_log:
   community: sample
   log_type: admin_audit
   event_type: setting_update
@@ -8,3 +8,14 @@ admin_log:
   related: one
   user: admin
   comment: some words
+
+vote_rate_limit_log:
+  community: sample
+  log_type: rate_limit_log
+  event_type: vote
+  related_type: Post
+  related: question_one
+  user: standard_user
+  comment: >
+    limit: 10
+    vote: 1

--- a/test/fixtures/audit_logs.yml
+++ b/test/fixtures/audit_logs.yml
@@ -1,5 +1,22 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
+impersonation_start_log:
+  community: sample
+  log_type: admin_audit
+  event_type: impersonation_start
+  related_type: User
+  related: moderator
+  user: admin
+  comment: For science!
+
+impersonation_end_log:
+  community: sample
+  log_type: admin_audit
+  event_type: impersonation_end
+  related_type: User
+  related: moderator
+  user: admin
+
 site_setting_update_log:
   community: sample
   log_type: admin_audit


### PR DESCRIPTION
closes #1875

This PR reworks the audit log table to align with how our error reports look like:

<img width="1142" height="336" alt="Screenshot from 2025-10-15 02-13-12" src="https://github.com/user-attachments/assets/514234ec-ff2c-4177-81c8-7cf24dfe7d16" />

<img width="1143" height="253" alt="Screenshot from 2025-10-15 02-23-57" src="https://github.com/user-attachments/assets/4107bd83-eb77-446d-94a2-b9a37c7150e8" />

This makes the logs easier to parse at a glance, solves wrapping and overflow issues, and allows us to make the logs as verbose as we want.

It also makes any `related` object that is a `User` a proper link (we should do that for all other types too, but that's a bit out of scope for this PR).