### PR TITLE
flag history view should indicate that you are viewing another user's…

### DIFF
--- a/app/views/flags/history.html.erb
+++ b/app/views/flags/history.html.erb
@@ -9,14 +9,11 @@
 
 <%
   is_same_user = @user.same_as?(current_user)
+  title_prefix = is_same_user ? 'My Flag History' : 'Flag History for'
   translation_key = is_same_user ? 'history_self' : 'history_other'
 %>
 
-<% if is_same_user %>
-  <h1> My Flag History </h1>
-<% else %>
-  <h1> Flag History for <%= user_link(@user) %> </h1>
-<% end %>
+<h1><%= title_prefix %> <%= user_link(@user) unless is_same_user %></h1>
 <p><%= t("flags.descriptions.#{translation_key}") %></p>
 
 <h3>

--- a/app/views/flags/history.html.erb
+++ b/app/views/flags/history.html.erb
@@ -9,12 +9,12 @@
 
 <%
   is_same_user = @user.same_as?(current_user)
-  title_prefix = is_same_user ? 'My Flag History' : 'Flag History for'
-  translation_key = is_same_user ? 'history_self' : 'history_other'
+  title_key = "history_#{is_same_user ? 'self' : 'other'}_prefix"
+  description_key = "history_#{is_same_user ? 'self' : 'other'}"
 %>
 
-<h1><%= title_prefix %> <%= user_link(@user) unless is_same_user %></h1>
-<p><%= t("flags.descriptions.#{translation_key}") %></p>
+<h1><%= t("flags.headers.#{title_key}") %> <%= user_link(@user) unless is_same_user %></h1>
+<p><%= t("flags.descriptions.#{description_key}") %></p>
 
 <h3>
   <%= pluralize(@flags.count, 'flag') %>

--- a/app/views/flags/history.html.erb
+++ b/app/views/flags/history.html.erb
@@ -1,8 +1,20 @@
-<h1>Flag History</h1>
-<p>
-  Below is a list of all the flags you have cast and the outcome of each of them. Moderators handling your flags may also
-  have left you feedback.
-</p>
+<%#
+   "User's flag history view
+
+    Instance variables:
+      @flags    : ActiveRecord::Relation<Flag> collection of user's flags to display
+      @statuses : Hash{String => Integer} flag counts grouped by status
+      @user     : User to display flag history for
+"%>
+
+<%
+  is_same_user = @user.same_as?(current_user)
+  title_pfx = is_same_user ? 'My' : "#{@user.rtl_safe_username}'s"
+  translation_key = is_same_user ? 'history_self' : 'history_other'
+%>
+
+<h1><%= title_pfx %> Flag History</h1>
+<p><%= t("flags.descriptions.#{translation_key}") %></p>
 
 <h3>
   <%= pluralize(@flags.count, 'flag') %>

--- a/app/views/flags/history.html.erb
+++ b/app/views/flags/history.html.erb
@@ -9,11 +9,14 @@
 
 <%
   is_same_user = @user.same_as?(current_user)
-  title_pfx = is_same_user ? 'My' : "#{@user.rtl_safe_username}'s"
   translation_key = is_same_user ? 'history_self' : 'history_other'
 %>
 
-<h1><%= title_pfx %> Flag History</h1>
+<% if is_same_user %>
+  <h1> My Flag History </h1>
+<% else %>
+  <h1> Flag History for <%= user_link(@user) %> </h1>
+<% end %>
 <p><%= t("flags.descriptions.#{translation_key}") %></p>
 
 <h3>

--- a/config/locales/strings/en.flags.yml
+++ b/config/locales/strings/en.flags.yml
@@ -2,8 +2,8 @@ en:
   flags:
     descriptions:
       history_other: >
-        Below is a list of all the flags that the user have cast,
-        the outcome of each them, and handling moderators' feedback, if any.
+        Below is a list of all the flags this user has cast,
+        the outcome of each of them, and handling moderators' feedback, if any.
       history_self: >
         Below is a list of all the flags you have cast and the outcome of each of them.
         Moderators handling your flags may also have left you feedback.

--- a/config/locales/strings/en.flags.yml
+++ b/config/locales/strings/en.flags.yml
@@ -9,8 +9,7 @@ en:
       history_other: >
         Below is a list of all the flags this user has cast with their outcomes and any moderator feedback.
       history_self: >
-        Below is a list of all the flags you have cast and the outcome of each of them.
-        Moderators handling your flags may also have left you feedback.
+        Below is a list of all the flags you have cast with their outcomes and any moderator feedback.
     errors:
       create_generic: >
         Failed to raise the flag.

--- a/config/locales/strings/en.flags.yml
+++ b/config/locales/strings/en.flags.yml
@@ -1,5 +1,10 @@
 en:
   flags:
+    headers:
+      history_other_prefix: >
+        Flag History for
+      history_self_prefix: >
+        My Flag History
     descriptions:
       history_other: >
         Below is a list of all the flags this user has cast,

--- a/config/locales/strings/en.flags.yml
+++ b/config/locales/strings/en.flags.yml
@@ -7,8 +7,7 @@ en:
         My Flag History
     descriptions:
       history_other: >
-        Below is a list of all the flags this user has cast,
-        the outcome of each of them, and handling moderators' feedback, if any.
+        Below is a list of all the flags this user has cast with their outcomes and any moderator feedback.
       history_self: >
         Below is a list of all the flags you have cast and the outcome of each of them.
         Moderators handling your flags may also have left you feedback.

--- a/config/locales/strings/en.flags.yml
+++ b/config/locales/strings/en.flags.yml
@@ -1,5 +1,12 @@
 en:
   flags:
+    descriptions:
+      history_other: >
+        Below is a list of all the flags that the user have cast,
+        the outcome of each them, and handling moderators' feedback, if any.
+      history_self: >
+        Below is a list of all the flags you have cast and the outcome of each of them.
+        Moderators handling your flags may also have left you feedback.
     errors:
       create_generic: >
         Failed to raise the flag.


### PR DESCRIPTION
closes #1885 

Here's how current user's page header will look like:

<img width="774" height="184" alt="Screenshot from 2025-10-22 07-17-47" src="https://github.com/user-attachments/assets/4c3490b5-6c07-43f6-b085-16acb2ad350f" />


and here's how it will look like when viewing the same page for another user:

<img width="774" height="184" alt="Screenshot from 2025-10-22 07-17-42" src="https://github.com/user-attachments/assets/11235d78-8d99-48ac-ac2e-80a889ae5761" />

As a bonus, the PR makes the view's descriptions configurable via translation strings.
