### PR TITLE
"Open" system filter & a bit of cleanup

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -94,7 +94,9 @@ class UsersController < ApplicationController
     end
   end
 
-  # Helper method to convert it to the form expected by the client
+  # Converts a given filter to JSON
+  # @param filter {Filter} filter to convert
+  # @return {Hash}
   def filter_json(filter)
     {
       min_score: filter.min_score,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -107,7 +107,7 @@ class UsersController < ApplicationController
       exclude_tags: Tag.where(id: filter.exclude_tags).map { |tag| [tag.name, tag.id] },
       source: filter.source,
       status: filter.status,
-      system: filter.user_id == -1
+      system: filter.system?
     }
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -109,16 +109,19 @@ class UsersController < ApplicationController
     }
   end
 
-  def filters_json
-    system_filters = Rails.cache.fetch 'default_system_filters', expires_in: 1.day do
+  # Gets system filters as JSON
+  # @return [Hash{String => Hash}]
+  def system_filters_json
+    Rails.cache.fetch 'default_system_filters', expires_in: 1.day do
       system_user.filters.to_h { |filter| [filter.name, filter_json(filter)] }
     end
+  end
 
+  def filters_json
     if user_signed_in?
-      current_user.filters.to_h { |filter| [filter.name, filter_json(filter)] }
-                  .merge(system_filters)
+      current_user.filters.to_h { |filter| [filter.name, filter_json(filter)] }.merge(system_filters_json)
     else
-      system_filters
+      system_filters_json
     end
   end
 

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -4,4 +4,8 @@ class Filter < ApplicationRecord
   validates :name, uniqueness: { scope: :user }
   serialize :include_tags, coder: YAML, type: Array
   serialize :exclude_tags, coder: YAML, type: Array
+
+  def system?
+    user_id == -1
+  end
 end

--- a/db/seeds/filters.yml
+++ b/db/seeds/filters.yml
@@ -12,3 +12,7 @@
   min_answers: 0
   max_answers: 0
   status: 'open'
+
+- name: Open
+  user_id: -1
+  status: 'open'

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -565,6 +565,19 @@ class UsersControllerTest < ActionController::TestCase
     assert_json_success
   end
 
+  test 'filters should only return system filters for anonymous users' do
+    try_filters
+
+    assert_response(:success)
+    assert_valid_json_response
+
+    parsed = JSON.parse(response.body)
+    assert parsed.any?
+    parsed.each do |name, filter|
+      assert filter['system'], "'#{name}' is not a system filter"
+    end
+  end
+
   private
 
   def create_other_user
@@ -573,6 +586,12 @@ class UsersControllerTest < ActionController::TestCase
     other_user = User.create!(email: 'other@example.com', password: 'abcdefghijklmnopqrstuvwxyz', username: 'other_user')
     other_user.community_users.create!(community: other_community)
     other_user
+  end
+
+  def try_filters
+    get :filters, params: {
+      format: :json
+    }
   end
 
   def try_default_filter(category)

--- a/test/fixtures/filters.yml
+++ b/test/fixtures/filters.yml
@@ -17,3 +17,8 @@ two:
   min_answers: 1
   max_answers: 1
   status: MyString
+
+system:
+  name: System filter
+  user: system
+  status: open

--- a/test/models/filter_test.rb
+++ b/test/models/filter_test.rb
@@ -1,7 +1,11 @@
 require 'test_helper'
 
 class FilterTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'system? should correctly determine if a filter is a system filter' do
+    sys_usr = users(:system)
+
+    filters.each do |filter|
+      assert_equal filter.system?, filter.user_id == sys_usr
+    end
+  end
 end


### PR DESCRIPTION
closes #1865

This is a minor PR that adds a new system filter to only show open posts (user request) + makes a couple of minor improvements to filter-related logic & docs:

<img width="800" height="430" alt="Screenshot from 2025-10-26 00-44-46" src="https://github.com/user-attachments/assets/c6248b90-f7e9-40f2-b524-2f1c505c2f3e" />

Note for reviewers: you need to run `rails db:seed` and clear Redis cache for the new filter to show up.
