### PR TITLE
query_url helper should correctly rebuild merged query

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,7 +48,7 @@ module ApplicationHelper
   end
 
   ##
-  # Utility to add additional query parameters to a URI.
+  # Adds additional query parameters to a URI.
   # @param base_url [String, nil] A base URI to which to add parameters. If none is specified then the request URI for
   #   the current page will be used.
   # @param params [Hash{#to_s => #to_s}] A hash of query parameters to add to the URI.
@@ -65,7 +65,7 @@ module ApplicationHelper
     end
 
     query = query.merge(params.to_h { |k, v| [k.to_s, v.to_s] })
-    uri.query = query.map { |k, v| "#{k}=#{v}" }.join('&')
+    uri.query = Rack::Utils.build_nested_query(query)
     uri.to_s
   end
 


### PR DESCRIPTION
closes #1902 

The issue in question can be reproduced by (and should not be reproducible with the PR applied):
1. Creating a saved filter with a couple of included tags (doesn't matter which, but it's best to add at least 2).
2. Applying the filter from step 1 in a category view (doesn't matter which one).
3. Attempting to switch to a different sorting type / order - at this point, there should be a server error.
