### PR TITLE
Fix misbehaving /me subroutes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -387,16 +387,20 @@ class ApplicationController < ActionController::Base
     helpers.devise_sign_in_enabled?
   end
 
+  def redirect_to_sign_in
+    if devise_sign_in_enabled?
+      redirect_to new_user_session_path
+    else
+      redirect_to new_saml_user_session_path
+    end
+  end
+
   def authenticate_user!(_fav = nil, **_opts)
     unless user_signed_in?
       respond_to do |format|
         format.html do
           flash[:error] = 'You need to sign in or sign up to continue.'
-          if devise_sign_in_enabled?
-            redirect_to new_user_session_path
-          else
-            redirect_to new_saml_user_session_path
-          end
+          redirect_to_sign_in
         end
         format.json do
           render json: { error: 'You need to sign in or sign up to continue.' }, status: 401

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -144,6 +144,14 @@ class ApplicationController < ActionController::Base
     helpers.post_type_ids(is_top_level: false, has_parent: true)
   end
 
+  [:json, :html, :xml].each do |format|
+    define_method "#{format}_request?" do
+      return false unless request.format.respond_to?("#{format}?")
+
+      request.format.send("#{format}?")
+    end
+  end
+
   private
 
   def distinguish_fake_community

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,6 +9,9 @@ class UsersController < ApplicationController
                                             :me, :my_network, :my_vote_summary,
                                             :preferences, :set_preference,
                                             :disconnect_sso, :confirm_disconnect_sso]
+
+  before_action :authenticate_user!, only: [:filters], if: [:html_request?]
+
   before_action :verify_moderator, only: [:mod, :destroy, :soft_delete, :role_toggle, :full_log,
                                           :annotate, :annotations, :mod_privileges, :mod_privilege_action]
   before_action :set_user, only: [:show, :mod, :destroy, :soft_delete, :posts, :role_toggle, :full_log, :activity,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,8 +4,10 @@ require 'net/http'
 class UsersController < ApplicationController
   include Devise::Controllers::Rememberable
 
-  before_action :authenticate_user!, only: [:edit_profile, :update_profile, :stack_redirect, :transfer_se_content,
-                                            :qr_login_code, :me, :preferences, :set_preference, :my_vote_summary,
+  before_action :authenticate_user!, only: [:edit_profile, :update_profile, :stack_redirect,
+                                            :transfer_se_content, :qr_login_code,
+                                            :me, :my_network, :my_vote_summary,
+                                            :preferences, :set_preference,
                                             :disconnect_sso, :confirm_disconnect_sso]
   before_action :verify_moderator, only: [:mod, :destroy, :soft_delete, :role_toggle, :full_log,
                                           :annotate, :annotations, :mod_privileges, :mod_privilege_action]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,11 +6,11 @@ class UsersController < ApplicationController
 
   before_action :authenticate_user!, only: [:edit_profile, :update_profile, :stack_redirect,
                                             :transfer_se_content, :qr_login_code,
-                                            :me, :my_network, :my_vote_summary,
+                                            :me, :my_activity, :my_network, :my_vote_summary,
                                             :preferences, :set_preference,
                                             :disconnect_sso, :confirm_disconnect_sso]
 
-  before_action :authenticate_user!, only: [:filters], if: [:html_request?]
+  before_action :redirect_to_sign_in, only: [:filters], unless: [:user_signed_in?, :json_request?]
 
   before_action :verify_moderator, only: [:mod, :destroy, :soft_delete, :role_toggle, :full_log,
                                           :annotate, :annotations, :mod_privileges, :mod_privilege_action]
@@ -243,6 +243,10 @@ class UsersController < ApplicationController
   def network
     @communities = Community.all
     render layout: 'without_sidebar'
+  end
+
+  def my_activity
+    redirect_to user_activity_path(current_user)
   end
 
   def activity

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -194,6 +194,7 @@ Rails.application.routes.draw do
     get    '/mobile-login',             to: 'users#qr_login_code', as: :qr_login_code
     get    '/mobile-login/:token',      to: 'users#do_qr_login', as: :qr_login
     get    '/me',                       to: 'users#me', as: :users_me
+    get    '/me/activity',              to: 'users#my_activity', as: :my_activity
     get    '/me/preferences',           to: 'users#preferences', as: :user_preferences
     post   '/me/preferences',           to: 'users#set_preference', as: :set_user_preference
     get    '/me/filters',               to: 'users#filters', as: :user_filters

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -300,29 +300,19 @@ class UsersControllerTest < ActionController::TestCase
     assert_not_nil assigns(:user)
   end
 
-  # We can only test for one user per test block, hence there are
-  # three test blocks of users with different permission models to
-  # have a more unbiased check.
+  test 'my_vote_summary should redirect to the current user summary' do
+    users.each do |user|
+      sign_in user
+      get :my_vote_summary
 
-  test 'my vote summary redirects to current user summary (#1 deleter)' do
-    sign_in users(:deleter)
-    get :my_vote_summary
-    assert_redirected_to vote_summary_path(users(:deleter))
-    sign_out :user
-  end
+      if user.deleted? || user.community_user.deleted?
+        assert_redirected_to_sign_in
+      else
+        assert_redirected_to vote_summary_path(user)
+      end
 
-  test 'my vote summary redirects to current user summary (#2 std user)' do
-    sign_in users(:standard_user)
-    get :my_vote_summary
-    assert_redirected_to vote_summary_path(users(:standard_user))
-    sign_out :user
-  end
-
-  test 'my vote summary redirects to current user summary (#3 global_admin)' do
-    sign_in users(:global_admin)
-    get :my_vote_summary
-    assert_redirected_to vote_summary_path(users(:global_admin))
-    sign_out :user
+      sign_out :user
+    end
   end
 
   test 'vote summary rendered for all users, signed in or out, own or others' do
@@ -606,8 +596,13 @@ class UsersControllerTest < ActionController::TestCase
     assert_json_success
   end
 
-  test 'filters should only return system filters for anonymous users' do
-    try_filters
+  test 'HTML filters should redirect to sign in for anonymous users' do
+    try_filters(format: :html)
+    assert_redirected_to_sign_in
+  end
+
+  test 'JSON filters should return system filters for anonymous users' do
+    try_filters(format: :json)
 
     assert_response(:success)
     assert_valid_json_response
@@ -629,10 +624,8 @@ class UsersControllerTest < ActionController::TestCase
     other_user
   end
 
-  def try_filters
-    get :filters, params: {
-      format: :json
-    }
+  def try_filters(format: :json)
+    get :filters, params: { format: format }
   end
 
   def try_default_filter(category)

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -300,7 +300,22 @@ class UsersControllerTest < ActionController::TestCase
     assert_not_nil assigns(:user)
   end
 
-  test 'my_vote_summary should redirect to the current user summary' do
+  test 'my_network should redirect to current user network profile or to sign in otherwise' do
+    users.each do |user|
+      sign_in user
+      get :my_network
+
+      if user.deleted? || user.community_user.deleted?
+        assert_redirected_to_sign_in
+      else
+        assert_redirected_to network_path(user), "user #{user.name} is incorrectly redirected"
+      end
+
+      sign_out :user
+    end
+  end
+
+  test 'my_vote_summary should redirect to current user summary or to sign in otherwise' do
     users.each do |user|
       sign_in user
       get :my_vote_summary
@@ -308,7 +323,7 @@ class UsersControllerTest < ActionController::TestCase
       if user.deleted? || user.community_user.deleted?
         assert_redirected_to_sign_in
       else
-        assert_redirected_to vote_summary_path(user)
+        assert_redirected_to vote_summary_path(user), "user #{user.name} is incorrectly redirected"
       end
 
       sign_out :user

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -300,7 +300,22 @@ class UsersControllerTest < ActionController::TestCase
     assert_not_nil assigns(:user)
   end
 
-  test 'my_network should redirect to current user network profile or to sign in otherwise' do
+  test 'my_activity should redirect to user activity or to sign in for anonymous access' do
+    users.each do |user|
+      sign_in user
+      get :my_activity
+
+      if user.deleted? || user.community_user.deleted?
+        assert_redirected_to_sign_in
+      else
+        assert_redirected_to user_activity_path(user), "user #{user.name} is incorrectly redirected"
+      end
+
+      sign_out :user
+    end
+  end
+
+  test 'my_network should redirect to user network profile or to sign in for anonymous access' do
     users.each do |user|
       sign_in user
       get :my_network
@@ -315,7 +330,7 @@ class UsersControllerTest < ActionController::TestCase
     end
   end
 
-  test 'my_vote_summary should redirect to current user summary or to sign in otherwise' do
+  test 'my_vote_summary should redirect to user summary or to sign in for anonymous access' do
     users.each do |user|
       sign_in user
       get :my_vote_summary


### PR DESCRIPTION
closes #1903 

Fixes routes listed in the linked issue that either result in 404s or server errors instead of redirecting to sign in.