### PR TITLE
show pending edits on deleted posts (and the indicator) IFF current user can handle them

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -47,9 +47,7 @@ class CategoriesController < ApplicationController
       AuditLog.admin_audit(event_type: 'category_create', related: @category, user: current_user,
                            comment: "<<Category #{before}>>")
       flash[:success] = 'Your category was created.'
-      Rails.cache.delete "#{RequestContext.community_id}/header_categories"
-      Rails.cache.delete 'categories/by_lowercase_name'
-      Rails.cache.delete 'categories/by_id'
+      clear_categories_cache
       redirect_to category_path(@category)
     else
       flash[:danger] = 'There were some errors while trying to save your category.'
@@ -69,9 +67,7 @@ class CategoriesController < ApplicationController
       AuditLog.admin_audit(event_type: 'category_update', related: @category, user: current_user,
                            comment: "from <<Category #{before}>>\nto <<Category #{after}>>")
       flash[:success] = 'Your category was updated.'
-      Rails.cache.delete "#{RequestContext.community_id}/header_categories"
-      Rails.cache.delete 'categories/by_lowercase_name'
-      Rails.cache.delete 'categories/by_id'
+      clear_categories_cache
       redirect_to category_path(@category)
     else
       flash[:danger] = 'There were some errors while trying to save your category.'
@@ -205,6 +201,12 @@ class CategoriesController < ApplicationController
     @posts = helpers.qualifiers_to_sql(filter_qualifiers, @posts, current_user)
     @filtered = filter_qualifiers.any?
     @posts = @posts.paginate(page: params[:page], per_page: 50).order(sort_param)
+  end
+
+  def clear_categories_cache
+    Rails.cache.delete 'header_categories'
+    Rails.cache.delete 'categories/by_lowercase_name'
+    Rails.cache.delete 'categories/by_id'
   end
 
   # Updates last visit cache for a given category

--- a/app/controllers/suggested_edit_controller.rb
+++ b/app/controllers/suggested_edit_controller.rb
@@ -14,13 +14,9 @@ class SuggestedEditController < ApplicationController
 
     @category = params[:category].present? ? Category.find(params[:category]) : nil
 
-    @edits = SuggestedEdit.where(post: Post.in(@category),
-                                 active: !@show_decided)
+    @edits = SuggestedEdit.accessible_to(current_user, @category)
+                          .where(active: !@show_decided)
                           .order(@sort_type => @sort_order)
-
-    @edits_undeleted = SuggestedEdit.where(post: Post.undeleted.in(@category),
-                                           active: !@show_decided)
-                                    .order(@sort_type => @sort_order)
   end
 
   def show

--- a/app/controllers/suggested_edit_controller.rb
+++ b/app/controllers/suggested_edit_controller.rb
@@ -19,9 +19,9 @@ class SuggestedEditController < ApplicationController
                           .order(@sort_type => @sort_order)
 
     @edits_undeleted = SuggestedEdit.where(post: Post.undeleted.in(@category),
-                                 active: !@show_decided)
-                          .order(@sort_type => @sort_order)
-end
+                                           active: !@show_decided)
+                                    .order(@sort_type => @sort_order)
+  end
 
   def show
     render layout: 'without_sidebar'

--- a/app/controllers/suggested_edit_controller.rb
+++ b/app/controllers/suggested_edit_controller.rb
@@ -14,10 +14,14 @@ class SuggestedEditController < ApplicationController
 
     @category = params[:category].present? ? Category.find(params[:category]) : nil
 
-    @edits = SuggestedEdit.where(post: Post.undeleted.in(@category),
+    @edits = SuggestedEdit.where(post: Post.in(@category),
                                  active: !@show_decided)
                           .order(@sort_type => @sort_order)
-  end
+
+    @edits_undeleted = SuggestedEdit.where(post: Post.undeleted.in(@category),
+                                 active: !@show_decided)
+                          .order(@sort_type => @sort_order)
+end
 
   def show
     render layout: 'without_sidebar'

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -46,4 +46,16 @@ module CategoriesHelper
       SuggestedEdit.where(post: Post.undeleted.in(current_category), active: true).any?
     end
   end
+
+  ##
+  # Checks if there are any pending edit suggestions in the current category,
+  # including on deleted posts (for viewers who can both edit and see deleted).
+  # @note Cached - cache is manually broken when new suggestions are created.
+  # @return [Boolean]
+  def pending_suggestions_with_deleted?
+    Rails.cache.fetch "pending_suggestions_with_deleted/#{current_category.id}" do
+      SuggestedEdit.where(post: Post.in(current_category), active: true).any?
+    end
+  end
+
 end

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -57,5 +57,4 @@ module CategoriesHelper
       SuggestedEdit.where(post: Post.in(current_category), active: true).any?
     end
   end
-
 end

--- a/app/models/suggested_edit.rb
+++ b/app/models/suggested_edit.rb
@@ -33,6 +33,7 @@ class SuggestedEdit < ApplicationRecord
 
   def clear_pending_cache
     Rails.cache.delete "pending_suggestions/#{post.category_id}"
+    Rails.cache.delete "pending_suggestions_with_deleted/#{post.category_id}"
   end
 
   def pending?

--- a/app/models/suggested_edit.rb
+++ b/app/models/suggested_edit.rb
@@ -22,6 +22,15 @@ class SuggestedEdit < ApplicationRecord
   scope :by, ->(user) { where(user: user) }
   scope :rejected, -> { where(active: false, accepted: false) }
 
+  # Gets suggested edits scoped for a given user and category
+  # @param user [User] user to check
+  # @param category [Category] category to check
+  # @return [ActiveRecord::Relation<SuggestedEdit>]
+  def self.accessible_to(user, category)
+    posts = user&.can_see_deleted_posts? ? Post.in(category) : Post.undeleted.in(category)
+    SuggestedEdit.where(post: posts)
+  end
+
   def clear_pending_cache
     Rails.cache.delete "pending_suggestions/#{post.category_id}"
   end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -280,7 +280,7 @@
                   <%= link_to suggested_edits_queue_path(current_cat),
                       class: "category-header--nav-item #{active?(current_cat) && controller_name == 'suggested_edit' ? 'is-active' : ''}" do %>
                     Edits
-                    <% if pending_suggestions?  && check_your_privilege('edit_posts') %>
+                    <% if check_your_privilege('edit_posts') && (pending_suggestions? || (pending_suggestions_with_deleted? && check_your_privilege('flag_curate'))) %>
                       <span class="badge is-status" title="Suggested edits pending"></span>
                     <% end %>
                   <% end %>

--- a/app/views/suggested_edit/category_index.html.erb
+++ b/app/views/suggested_edit/category_index.html.erb
@@ -35,11 +35,7 @@
     </tr>
     <% categories.each do |cat| %>
       <% next if (cat.min_view_trust_level || -1) > (current_user&.trust_level || 0) %>
-      <% if current_user&.can_see_deleted_posts? %>
-        <% sug_edits_count = SuggestedEdit.where(post: Post.in(cat), active: !@show_decided).count %>
-      <% else %>
-        <% sug_edits_count = SuggestedEdit.where(post: Post.undeleted.in(cat), active: !@show_decided).count %>
-      <% end %>
+      <% sug_edits_count = SuggestedEdit.accessible_to(current_user, cat).where(active: !@show_decided).count %>
       <% queue_url = suggested_edits_queue_url(cat, params.permit(:sort, :order, :show_decided)) %>
       <tr>
         <td>
@@ -53,7 +49,7 @@
           <% if cat == current_cat %>
             <%= sug_edits_count %>
           <% else %>
-<%= link_to sug_edits_count, queue_url %>
+            <%= link_to sug_edits_count, queue_url %>
           <% end %>
         </td>
       </tr>

--- a/app/views/suggested_edit/category_index.html.erb
+++ b/app/views/suggested_edit/category_index.html.erb
@@ -36,9 +36,9 @@
     <% categories.each do |cat| %>
       <% next if (cat.min_view_trust_level || -1) > (current_user&.trust_level || 0) %>
       <% if current_user&.can_see_deleted_posts? %>
-        <% sug_edits = SuggestedEdit.where(post: Post.in(cat), active: !@show_decided).count %>
+        <% sug_edits_count = SuggestedEdit.where(post: Post.in(cat), active: !@show_decided).count %>
       <% else %>
-        <% sug_edits = SuggestedEdit.where(post: Post.undeleted.in(cat), active: !@show_decided).count %>
+        <% sug_edits_count = SuggestedEdit.where(post: Post.undeleted.in(cat), active: !@show_decided).count %>
       <% end %>
       <% queue_url = suggested_edits_queue_url(cat, params.permit(:sort, :order, :show_decided)) %>
       <tr>
@@ -51,9 +51,9 @@
         </td>
         <td>
           <% if cat == current_cat %>
-            <%= sug_edits %>
+            <%= sug_edits_count %>
           <% else %>
-<%= link_to sug_edits, queue_url %>
+<%= link_to sug_edits_count, queue_url %>
           <% end %>
         </td>
       </tr>

--- a/app/views/suggested_edit/category_index.html.erb
+++ b/app/views/suggested_edit/category_index.html.erb
@@ -1,7 +1,9 @@
 <h1>Suggested Edits</h1>
 <p class="is-lead">Suggested edits for review.</p>
 
-<% categories = Category.unscoped.where(community: @community).order(sequence: :asc, id: :asc) %>
+<% categories = Category.unscoped.accessible_to(current_user)
+                                 .where(community: @community)
+                                 .order(sequence: :asc, id: :asc) %>
 <% current_cat = current_category %>
 
 <div class="suggested-edits-list-header">
@@ -34,7 +36,6 @@
       <th>pending edits</th>
     </tr>
     <% categories.each do |cat| %>
-      <% next if (cat.min_view_trust_level || -1) > (current_user&.trust_level || 0) %>
       <% sug_edits_count = SuggestedEdit.accessible_to(current_user, cat).where(active: !@show_decided).count %>
       <% queue_url = suggested_edits_queue_url(cat, params.permit(:sort, :order, :show_decided)) %>
       <tr>

--- a/app/views/suggested_edit/category_index.html.erb
+++ b/app/views/suggested_edit/category_index.html.erb
@@ -69,7 +69,7 @@
 
 <% if edits_list.any? %>
   <div class="widget">
-    <% @edits.each do |edit| %>
+    <% edits_list.each do |edit| %>
       <div class="widget--body h-p-b-0 <%= 'deleted-content' if edit.post.deleted? %>" data-ckb-list-item data-ckb-item-type="link">
         <div>
           <%= link_to suggested_edit_path(edit.id), class: 'has-font-size-larger', data: {'ckb-item-link' => ''} do %>

--- a/app/views/suggested_edit/category_index.html.erb
+++ b/app/views/suggested_edit/category_index.html.erb
@@ -58,15 +58,9 @@
   </table>
 </details>
 
-<% if current_user&.can_see_deleted_posts?
-     edits_list = @edits
-   else
-     edits_list = @edits_undeleted 
-   end %>
-
-<% if edits_list.any? %>
+<% if @edits.any? %>
   <div class="widget">
-    <% edits_list.each do |edit| %>
+    <% @edits.each do |edit| %>
       <div class="widget--body h-p-b-0 <%= 'deleted-content' if edit.post.deleted? %>" data-ckb-list-item data-ckb-item-type="link">
         <div>
           <%= link_to suggested_edit_path(edit.id), class: 'has-font-size-larger', data: {'ckb-item-link' => ''} do %>

--- a/app/views/suggested_edit/category_index.html.erb
+++ b/app/views/suggested_edit/category_index.html.erb
@@ -35,7 +35,11 @@
     </tr>
     <% categories.each do |cat| %>
       <% next if (cat.min_view_trust_level || -1) > (current_user&.trust_level || 0) %>
-      <% sug_edits = SuggestedEdit.where(post: Post.undeleted.in(cat), active: !@show_decided).count %>
+      <% if current_user&.can_see_deleted_posts? %>
+        <% sug_edits = SuggestedEdit.where(post: Post.in(cat), active: !@show_decided).count %>
+      <% else %>
+        <% sug_edits = SuggestedEdit.where(post: Post.undeleted.in(cat), active: !@show_decided).count %>
+      <% end %>
       <% queue_url = suggested_edits_queue_url(cat, params.permit(:sort, :order, :show_decided)) %>
       <tr>
         <td>
@@ -57,10 +61,16 @@
   </table>
 </details>
 
-<% if @edits.any? %>
+<% if current_user&.can_see_deleted_posts? %>
+<% edits_list = @edits %>
+<% else %>
+<% edits_list = @edits_undeleted %>
+<% end %>
+
+<% if edits_list.any? %>
   <div class="widget">
     <% @edits.each do |edit| %>
-      <div class="widget--body h-p-b-0" data-ckb-list-item data-ckb-item-type="link">
+      <div class="widget--body h-p-b-0 <%= 'deleted-content' if edit.post.deleted? %>" data-ckb-list-item data-ckb-item-type="link">
         <div>
           <%= link_to suggested_edit_path(edit.id), class: 'has-font-size-larger', data: {'ckb-item-link' => ''} do %>
             <%= edit.post.post_type.name %>: <strong><%= edit.post.post_type.is_top_level ? edit.post.title : edit.post.parent.title %></strong>

--- a/app/views/suggested_edit/category_index.html.erb
+++ b/app/views/suggested_edit/category_index.html.erb
@@ -61,11 +61,11 @@
   </table>
 </details>
 
-<% if current_user&.can_see_deleted_posts? %>
-<% edits_list = @edits %>
-<% else %>
-<% edits_list = @edits_undeleted %>
-<% end %>
+<% if current_user&.can_see_deleted_posts?
+     edits_list = @edits
+   else
+     edits_list = @edits_undeleted 
+   end %>
 
 <% if edits_list.any? %>
   <div class="widget">

--- a/test/fixtures/suggested_edits.yml
+++ b/test/fixtures/suggested_edits.yml
@@ -85,3 +85,14 @@ approved_edit_scorer:
   decided_at: 2000-01-01T00:00:00.000000Z
   decided_by: editor
   title: approved suggested edit by the user used for edit score tests
+
+on_deleted_post:
+  post: deleted
+  user: standard_user
+  community: sample
+  body: This suggested edit is on a deleted post
+  title: Edit on a deleted post
+  body_markdown: <p>This suggested edit is on a deleted post</p>
+  comment: for users with access only
+  active: true
+  accepted: false

--- a/test/models/suggested_edit_test.rb
+++ b/test/models/suggested_edit_test.rb
@@ -16,4 +16,27 @@ class SuggestedEditTest < ActiveSupport::TestCase
     assert suggested_edits(:accepted_suggested_edit).approved?
     assert suggested_edits(:rejected_suggested_edit).rejected?
   end
+
+  test 'accessible_to should correctly scope suggested edits' do
+    categories_with_edits_on_deleted_posts = suggested_edits
+                                             .select { |edit| edit.post.deleted? }
+                                             .map { |edit| edit.post.category.id }
+                                             .uniq
+
+    assert categories_with_edits_on_deleted_posts.any?
+
+    users.each do |user|
+      categories_with_edits_on_deleted_posts.each do |category|
+        edits = SuggestedEdit.accessible_to(user, category)
+
+        assert edits.any?
+
+        if user.can_see_deleted_posts?
+          assert(edits.any? { |edit| edit.post.deleted? })
+        else
+          assert(edits.none? { |edit| edit.post.deleted? })
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/codidact/qpixel/issues/1496.

Test 1: two pending edits, one on a deleted post.

Editor (who can't see deleted posts):

<img width="847" height="525" alt="one pending edit" src="https://github.com/user-attachments/assets/3ecf824c-3617-4d4d-bc59-aef884beaa9a" />

Editor-curator (can see deleted posts):

<img width="853" height="646" alt="two pending edits, one with deleted styling" src="https://github.com/user-attachments/assets/df563169-1578-4e98-912a-4847183078ba" />

----

Test 2: one pending edit, on a deleted post.

Editor sees nothing, and note that the indicator dot isn't there:

<img width="838" height="655" alt="no pending edits" src="https://github.com/user-attachments/assets/2e2b0160-f46b-4401-9b52-0b6f62da9115" />

Editor-curator sees the edit and the indicator dot:

<img width="843" height="540" alt="one pending edit" src="https://github.com/user-attachments/assets/c16abc1a-1d64-40bb-84ea-51fc27d9554e" />

----

No changes have been made to the suggested-edit page itself.  Post authors could always see those, so they were already visible without any special styling, but maybe now that we're broadening who can see them we should also do something there to indicate that the *edit* is still there but the underlying *post* is currently deleted.

