### PR TITLE
fix incorrect count on tags page

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -47,6 +47,8 @@ class TagsController < ApplicationController
               @tag_set.tags
             end.list_includes
 
+    @count_all = @tags.length || 0
+
     table = params[:hierarchical].present? ? 'tags_paths' : 'tags'
 
     @tags = @tags.left_joins(:posts)

--- a/app/views/tags/category.html.erb
+++ b/app/views/tags/category.html.erb
@@ -28,7 +28,7 @@
 
 <% unless params[:q].present? %>
   <div class="category-meta">
-    <h3><%= pluralize(@count, 'tag') %></h3>
+    <h3><%= pluralize(@count_all, 'tag') %></h3>
     <div class="button-list is-gutterless has-margin-2">
       <%= link_to 'Usage', category_tags_path(@category),
                   class: "button is-muted is-outlined #{request.query_parameters.size == 0 ? 'is-active' : ''}",


### PR DESCRIPTION
Fixes https://github.com/codidact/qpixel/issues/1914. 

The count was set after pagination, meaning we never reported the total but only the number of tags on the current page.  I don't know if the `count` set in the controller was used somewhere else, so I added `count_all` rather than redefining it.