### PR TITLE
Assorted fixes for the Code Golf's leaderboard

### DIFF
--- a/app/views/posts/_expanded.html.erb
+++ b/app/views/posts/_expanded.html.erb
@@ -47,7 +47,7 @@
     </div>
   <% end %>
 
-  <div class="post--container <%= 'deleted-content' if post.deleted? %> grid is-nowrap">
+  <div class="post--container <%= 'deleted-content js-deleted-post' if post.deleted? %> grid is-nowrap">
     <% if post_type.has_votes || (user_signed_in? && post.post_type.has_reactions && post.post_type.reactions.any?) %>
       <%= render 'posts/votes', post: post %>
     <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -23,7 +23,7 @@
 
 <% if @post.post_type.has_answers %>
   <% if num_answers > 0 %>
-    <h2><%= pluralize(num_answers, 'answer') %></h2>
+    <h2 class="js-answers-header"><%= pluralize(num_answers, 'answer') %></h2>
   <% end %>
   <% if num_answers > 1 %>
     <div class="button-list is-gutterless has-float-right">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -23,7 +23,7 @@
 
 <% if @post.post_type.has_answers %>
   <% if num_answers > 0 %>
-    <h2 class="js-answers-header"><%= pluralize(num_answers, 'answer') %></h2>
+    <h2 id="answers" class="js-answers-header"><%= pluralize(num_answers, 'answer') %></h2>
   <% end %>
   <% if num_answers > 1 %>
     <div class="button-list is-gutterless has-float-right">

--- a/public/assets/community/codegolf.js
+++ b/public/assets/community/codegolf.js
@@ -330,9 +330,7 @@
       // If x were undefined, it would be automatically sorted to the end, but not so if x.score is undefined, so this needs to be stated explicitly.
       sort = (x, y) => typeof x.score === "undefined" ? 1 : x.score - y.score;
 
-      document
-        .querySelector(".post:first-child")
-        .nextElementSibling.insertAdjacentElement("afterend", embed);
+      document.querySelector(".js-answers-header")?.insertAdjacentElement('beforebegin', embed);
 
       refreshBoard(sort);
     } else if (
@@ -342,9 +340,7 @@
       // If x were undefined, it would be automatically sorted to the end, but not so if x.score is undefined, so this needs to be stated explicitly.
       sort = (x, y) => typeof x.score === "undefined" ? 1 : y.score - x.score;
 
-      document
-        .querySelector(".post:first-child")
-        .nextElementSibling.insertAdjacentElement("afterend", embed);
+      document.querySelector(".js-answers-header")?.insertAdjacentElement("beforebegin", embed);
 
       refreshBoard(sort);
     }

--- a/public/assets/community/codegolf.js
+++ b/public/assets/community/codegolf.js
@@ -261,14 +261,14 @@
     row.href = answer.answerURL;
 
     row.innerHTML = `
-    <div class="toc--badge"><span class="badge is-tag is-green">${answer.score}</span></div>
+    <div class="toc--badge"><span class="badge is-tag is-green">${answer.score ?? 'N/A'}</span></div>
     <div class="toc--full"><p class="row-summary"><span class='username has-padding-right-1'></span></p></div>
     ${answer.placement === 1 ? '<div class="toc--badge"><span class="badge is-tag is-yellow"><i class="fas fa-trophy"></i></span></div>'
       : (settings.showPlacements ? `<div class="toc--badge"><span class="badge is-tag">#${answer.placement}</span></div>` : '')}
     <div class="toc--badge"><span class="language-badge badge is-tag is-blue"></span></div>`;
 
     row.querySelector('.username').innerText = answer.username
-    row.querySelector('.language-badge').innerText = answer.full_language;
+    row.querySelector('.language-badge').innerText = answer.full_language ?? 'N/A';
     if (answer.code) {
       row.querySelector('.username').after(document.createElement('code'));
       row.querySelector('code').innerText = answer.code.split('\n')[0].substring(0, 200);

--- a/public/assets/community/codegolf.js
+++ b/public/assets/community/codegolf.js
@@ -106,10 +106,9 @@
       const text = await pagePromises[i];
       const doc = dom_parser.parseFromString(text.toString(), 'text/html');
       const [question, ...page_answers] = doc.querySelectorAll('.post');
-      const non_deleted_answers = page_answers.filter((answer) => answer.querySelector('.deleted-content') === null);
+      const non_deleted_answers = page_answers.filter((answer) => answer.querySelector('.js-deleted-post') === null);
 
       for (const answerPost of non_deleted_answers) {
-
         /** @type {HTMLElement | null} */
         const header = answerPost.querySelector('h1, h2, h3');
         const code = header?.parentElement.querySelector(':scope > pre > code');
@@ -128,8 +127,8 @@
           answerID: answerPost.id,
           answerURL: answerPost.querySelector('.js-permalink').href,
           page: i + 1, // +1 because pages are 1-indexed while arrays are 0-indexed
-          username: userlink.firstChild.data.trim(),
-          userid: userlink.href.match(/\d+/)[0],
+          username: userlink?.firstChild?.data?.trim() || 'deleted user',
+          userid: userlink?.href?.match(/\d+/)?.[0] || '',
           full_language,
           language,
           variant,


### PR DESCRIPTION
This PR fixes several issues with the dashboard:

1. Answers from deleted users now show up as expected:
     <img width="710" height="50" alt="image" src="https://github.com/user-attachments/assets/0e50c9bd-2d72-4a8a-8490-ede0a548a1bc" />
2. The leaderboard no longer shows `undefined` instead of username / language if either can't be determined (I chose "N/A" but not married to it - deferring to @trichoplax's judgment call):
    <img width="710" height="50" alt="image" src="https://github.com/user-attachments/assets/d667f2f4-b8cf-40b4-970a-95350c27c79a" />
3. The leaderboard now always renders in the correct place (before the number of answers header) - see the issue for details

closes #1911 

As a side-effect of these changes, we now have two more hooks that userscripts / community assets can rely on: `js-deleted-post` and `js-answers-header` (neither of these is likely to go away, so let's make sure layout changes don't screw up with user-built stuff).

