### PR TITLE
Fix for QPixel#user race conditions

### DIFF
--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -110,9 +110,9 @@ window.QPixel = {
 
   /**
    * Used to prevent launching multiple requests to /users/me
-   * @type {Promise<Response>|null}
+   * @type {Promise<QPixelUser>|null}
    */
-  _pendingUserResponse: null,
+  _pendingUser: null,
 
   /**
    * @type {QPixelUser|null}
@@ -120,18 +120,24 @@ window.QPixel = {
   _user: null,
 
   _fetchUser () {
-    if (QPixel._pendingUserResponse) {
-      return QPixel._pendingUserResponse;
+    if (QPixel._pendingUser) {
+      return QPixel._pendingUser;
     }
 
-    const myselfPromise = QPixel.fetch('/users/me', {
-      headers: {
-        'Accept': 'application/json',
-        'Cache-Control': 'no-cache',
-      }
-    });
+    const myselfPromise = QPixel
+      .fetch('/users/me', {
+        headers: {
+          'Accept': 'application/json',
+          'Cache-Control': 'no-cache',
+        }
+      })
+      .then((resp) => resp.json())
+      .catch(() => null)
+      .finally(() => {
+        QPixel._pendingUser = null;
+      });
 
-    QPixel._pendingUserResponse = myselfPromise;
+    QPixel._pendingUser = myselfPromise;
 
     return myselfPromise;
   },
@@ -141,17 +147,7 @@ window.QPixel = {
       return QPixel._user;
     }
 
-    try {
-      const resp = await QPixel._fetchUser();
-
-      if (!resp.bodyUsed) {
-        QPixel._user = await resp.json();
-      }
-    }
-    finally {
-      // ensures pending user is cleared regardless of network errors
-      QPixel._pendingUserResponse = null;
-    }
+    QPixel._user = await QPixel._fetchUser();
 
     return QPixel._user;
   },

--- a/global.d.ts
+++ b/global.d.ts
@@ -364,7 +364,7 @@ interface QPixel {
 
   // private properties
   _filters?: QPixelFilter[] | null;
-  _pendingUserResponse?: Promise<Response> | null;
+  _pendingUser?: Promise<QPixelUser> | null;
   _popups?: Record<string, QPixelPopup>;
   _preferences?: UserPreferences | null;
   _user?: QPixelUser | null;
@@ -384,7 +384,7 @@ interface QPixel {
   /**
    * FIFO-style fetch wrapper for /users/me requests
    */
-  _fetchUser?: () => Promise<Response>;
+  _fetchUser?: () => Promise<QPixelUser | null>;
 
   /**
    * Get an object containing the current user's preferences. Loads, in order of precedence, from local variable,


### PR DESCRIPTION
Our current approach to fetching the user has an additional flaw that I overlooked in #1120 a couple years ago.
We have code that can (specifically, keyboard shortcuts on category index pages) resolve _before_ `QPixel._user` is cached (because `_pendingUserResponse` only stores the `fetch` promise). This PR ensures that is no longer possible