### PR TITLE
Follow / unfollow thread actions should bump its last activity date & time + minor general fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,7 +58,7 @@ Naming/BlockForwarding:
   EnforcedStyle: explicit
 Naming/PredicateMethod:
   Mode: conservative
-  AllowedPatterns: ['verify_.*', 'check_.*', 'enforce_.*', 'setup_.*']
+  AllowedPatterns: ['verify_.*', 'check_.*', 'enforce_.*', 'setup_.*','add_.*', 'remove_.*']
   AllowedMethods:
     - post_sign_in # returns a boolean but is a necessary after-sign-in method for both normal and SAML flows
     - comment_rate_limited? # returns a tuple with the boolean as the first value

--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -250,8 +250,11 @@ $(() => {
 
     QPixel.handleJSONResponse(data, () => {
       const wrapper = getCommentThreadWrapper($tgt);
-      const inline = isInlineCommentThread(wrapper);
-      openThread(wrapper, threadID, { inline });
+
+      if (wrapper) {
+        const inline = isInlineCommentThread(wrapper);
+        openThread(wrapper, threadID, { inline });
+      }
     });
   });
 
@@ -265,8 +268,11 @@ $(() => {
 
     QPixel.handleJSONResponse(data, () => {
       const wrapper = getCommentThreadWrapper($tgt);
-      const inline = isInlineCommentThread(wrapper);
-      openThread(wrapper, threadID, { inline });
+
+      if (wrapper) {
+        const inline = isInlineCommentThread(wrapper);
+        openThread(wrapper, threadID, { inline });
+      }
     });
   })
 

--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -255,6 +255,21 @@ $(() => {
     });
   });
 
+  $(document).on('click', '.js--unfollow-thread', async (ev) => {
+    ev.preventDefault();
+
+    const $tgt = $(ev.target);
+    const threadID = $tgt.data('thread');
+
+    const data = await QPixel.unfollowThread(threadID);
+
+    QPixel.handleJSONResponse(data, () => {
+      const wrapper = getCommentThreadWrapper($tgt);
+      const inline = isInlineCommentThread(wrapper);
+      openThread(wrapper, threadID, { inline });
+    });
+  })
+
   /**
    * @param {Element} target
    */

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -506,6 +506,14 @@ window.QPixel = {
     return QPixel.parseJSONResponse(resp, 'Failed to follow thread');
   },
 
+  unfollowThread: async (id) => {
+    const resp = await QPixel.fetchJSON(`/comments/thread/${id}/unfollow`, {}, {
+      headers: { 'Accept': 'application/json' },
+    });
+
+    return QPixel.parseJSONResponse(resp, 'Failed to unfollow thread');
+  },
+
   lockThread: async (id, duration) => {
     const resp = await QPixel.fetchJSON(`/comments/thread/${id}/lock`, {
       duration,

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -266,7 +266,7 @@ class CommentsController < ApplicationController
   end
 
   def follow_thread
-    status = ThreadFollower.create(comment_thread: @comment_thread, user: current_user)
+    status = @comment_thread.add_follower(current_user)
     restrict_thread_response(@comment_thread, status)
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -188,14 +188,16 @@ class CommentsController < ApplicationController
   end
 
   def thread
-    respond_to do |format|
-      format.html { render 'comments/thread' }
-      format.json { render json: @comment_thread }
+    if stale?(last_modified: @comment_thread.last_activity.utc)
+      respond_to do |format|
+        format.html { render 'comments/thread' }
+        format.json { render json: @comment_thread }
+      end
     end
   end
 
   def thread_content
-    if stale?(last_modified: @comment_thread.last_activity_at.utc)
+    if stale?(last_modified: @comment_thread.last_activity.utc)
       render partial: 'comment_threads/expanded',
              locals: { inline: params[:inline] == 'true',
                        show_deleted: params[:show_deleted_comments] == '1',

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -295,7 +295,7 @@ class CommentsController < ApplicationController
   end
 
   def unfollow_thread
-    status = ThreadFollower.find_by(comment_thread: @comment_thread, user: current_user)&.destroy
+    status = @comment_thread.remove_follower(current_user)
     restrict_thread_response(@comment_thread, status)
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -12,6 +12,7 @@ class CommentsController < ApplicationController
                                     :archive_thread,
                                     :delete_thread,
                                     :follow_thread,
+                                    :unfollow_thread,
                                     :lock_thread,
                                     :thread_unrestrict,
                                     :thread_followers]
@@ -313,8 +314,6 @@ class CommentsController < ApplicationController
       unarchive_thread
     when 'delete'
       undelete_thread
-    when 'follow'
-      unfollow_thread
     else
       not_found!
     end

--- a/app/jobs/clean_up_thread_followers_job.rb
+++ b/app/jobs/clean_up_thread_followers_job.rb
@@ -1,0 +1,24 @@
+class CleanUpThreadFollowersJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    sql = File.read(Rails.root.join('db/scripts/threads_with_duplicate_followers.sql'))
+    threads = ActiveRecord::Base.connection.execute(sql).to_a
+
+    threads.each do |thread|
+      user_id, thread_id = thread
+
+      followers = ThreadFollower.where(comment_thread_id: thread_id, user_id: user_id)
+
+      next unless followers.many?
+
+      duplicate = followers.first
+      result = duplicate.destroy
+
+      unless result
+        puts "failed to destroy thread follower duplicate \"#{duplicate.id}\""
+        duplicate.errors.each { |e| puts e.full_message }
+      end
+    end
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -17,7 +17,7 @@ class Comment < ApplicationRecord
   after_create :create_follower
   after_update :delete_thread
 
-  before_save :bump_last_activity_at
+  before_save :bump_last_activity
 
   counter_culture :comment_thread, column_name: proc { |model| model.deleted? ? nil : 'reply_count' }, touch: true
 
@@ -49,7 +49,7 @@ class Comment < ApplicationRecord
     matches.flatten.select { |m| pingable.include?(m.to_i) }.map(&:to_i)
   end
 
-  def bump_last_activity_at
+  def bump_last_activity
     self.last_activity_at = DateTime.now
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -49,8 +49,14 @@ class Comment < ApplicationRecord
     matches.flatten.select { |m| pingable.include?(m.to_i) }.map(&:to_i)
   end
 
-  def bump_last_activity
+  # Directly bumps the comment's last activity date & time
+  # @param persist_changes [Boolean] if set to +true+, will persist the changes
+  def bump_last_activity(persist_changes: false)
     self.last_activity_at = DateTime.now
+
+    if persist_changes
+      save
+    end
   end
 
   private

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -37,6 +37,12 @@ class Comment < ApplicationRecord
     end
   end
 
+  # Gets last activity date and time on the comment
+  # @return [DateTime] last activity date and time
+  def last_activity
+    [created_at, updated_at, last_activity_at].compact.max
+  end
+
   def pings
     pingable = comment_thread.pingable
     matches = content.scan(USER_PING_REG_EXP)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -17,15 +17,11 @@ class Comment < ApplicationRecord
   after_create :create_follower
   after_update :delete_thread
 
+  before_save :bump_last_activity_at
+
   counter_culture :comment_thread, column_name: proc { |model| model.deleted? ? nil : 'reply_count' }, touch: true
 
   validate :content_length
-
-  # Gets last activity date and time on the comment
-  # @return [DateTime] last activity date and time
-  def last_activity_at
-    [created_at, updated_at].compact.max
-  end
 
   def root
     # If parent_question is nil, the comment is already on a question, so we can just return post.
@@ -48,6 +44,10 @@ class Comment < ApplicationRecord
   end
 
   private
+
+  def bump_last_activity_at
+    self.last_activity_at = DateTime.now
+  end
 
   def create_follower
     if user.preference('auto_follow_comment_threads') == 'true'

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -49,11 +49,11 @@ class Comment < ApplicationRecord
     matches.flatten.select { |m| pingable.include?(m.to_i) }.map(&:to_i)
   end
 
-  private
-
   def bump_last_activity_at
     self.last_activity_at = DateTime.now
   end
+
+  private
 
   def create_follower
     if user.preference('auto_follow_comment_threads') == 'true'

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -109,7 +109,7 @@ class CommentThread < ApplicationRecord
   # @param user [User] user to remove from followers
   # @return [Boolean] status of the operation
   def remove_follower(user)
-    ThreadFollower.find_by(comment_thread: self, user: user)&.destroy || false
+    ThreadFollower.where(comment_thread: self, user: user).destroy_all.any?
   end
 
   private

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -99,6 +99,13 @@ class CommentThread < ApplicationRecord
     self.last_activity_at = DateTime.now
   end
 
+  # Removes a given user from the thread's followers
+  # @param user [User] user to remove from followers
+  # @return [Boolean] status of the operation
+  def remove_follower(user)
+    ThreadFollower.find_by(comment_thread: self, user: user)&.destroy || false
+  end
+
   private
 
   # Comment author and post author are automatically followed to the thread. Question author is NOT

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -53,9 +53,9 @@ class CommentThread < ApplicationRecord
 
   # Gets last activity date and time on the thread
   # @return [DateTime] last activity date and time
-  def last_activity_at
-    last_comment_activity_at = comments.map(&:last_activity_at).compact.max
-    [created_at, locked_at, updated_at, last_comment_activity_at].compact.max
+  def last_activity
+    last_comment_activity = comments.map(&:last_activity).compact.max
+    [created_at, updated_at, last_activity_at, last_comment_activity].compact.max
   end
 
   # Gets a list of user IDs who should be pingable in the thread.

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -92,7 +92,9 @@ class CommentThread < ApplicationRecord
   # @param user [User] user to register as a follower
   # @return [Boolean] status of the operation
   def add_follower(user)
-    ThreadFollower.create(comment_thread: self, user: user)
+    if ThreadFollower.where(comment_thread: self, user: user).none?
+      ThreadFollower.create(comment_thread: self, user: user)
+    end
   end
 
   # Directly bumps the thread's last activity date & time

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -92,9 +92,9 @@ class CommentThread < ApplicationRecord
   # @param user [User] user to register as a follower
   # @return [Boolean] status of the operation
   def add_follower(user)
-    if ThreadFollower.where(comment_thread: self, user: user).none?
-      ThreadFollower.create(comment_thread: self, user: user)
-    end
+    return true if ThreadFollower.where(comment_thread: self, user: user).any?
+
+    ThreadFollower.create(comment_thread: self, user: user)
   end
 
   # Directly bumps the thread's last activity date & time
@@ -111,6 +111,8 @@ class CommentThread < ApplicationRecord
   # @param user [User] user to remove from followers
   # @return [Boolean] status of the operation
   def remove_follower(user)
+    return true if ThreadFollower.where(comment_thread: self, user: user).none?
+
     ThreadFollower.where(comment_thread: self, user: user).destroy_all.any?
   end
 

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -88,11 +88,11 @@ class CommentThread < ApplicationRecord
     end
   end
 
-  private
-
   def bump_last_activity_at
     self.last_activity_at = DateTime.now
   end
+
+  private
 
   # Comment author and post author are automatically followed to the thread. Question author is NOT
   # automatically followed on new answer comment threads. Comment author follower creation is done

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -16,7 +16,7 @@ class CommentThread < ApplicationRecord
 
   after_create :create_follower
 
-  before_save :bump_last_activity_at
+  before_save :bump_last_activity
 
   # Gets threads appropriately scoped for a given user & post
   # @param user [User, nil] user to check
@@ -88,7 +88,7 @@ class CommentThread < ApplicationRecord
     end
   end
 
-  def bump_last_activity_at
+  def bump_last_activity
     self.last_activity_at = DateTime.now
   end
 

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -92,7 +92,10 @@ class CommentThread < ApplicationRecord
   # @param user [User] user to register as a follower
   # @return [Boolean] status of the operation
   def add_follower(user)
-    return true if ThreadFollower.where(comment_thread: self, user: user).any?
+    if ThreadFollower.where(comment_thread: self, user: user).any?
+      bump_last_activity(persist_changes: true)
+      return true
+    end
 
     ThreadFollower.create(comment_thread: self, user: user)
   end
@@ -111,7 +114,10 @@ class CommentThread < ApplicationRecord
   # @param user [User] user to remove from followers
   # @return [Boolean] status of the operation
   def remove_follower(user)
-    return true if ThreadFollower.where(comment_thread: self, user: user).none?
+    if ThreadFollower.where(comment_thread: self, user: user).none?
+      bump_last_activity(persist_changes: true)
+      return true
+    end
 
     ThreadFollower.where(comment_thread: self, user: user).destroy_all.any?
   end

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -52,7 +52,7 @@ class CommentThread < ApplicationRecord
   # Gets last activity date and time on the thread
   # @return [DateTime] last activity date and time
   def last_activity_at
-    last_comment_activity_at = comments.map(&:last_activity_at).max
+    last_comment_activity_at = comments.map(&:last_activity_at).compact.max
     [created_at, locked_at, updated_at, last_comment_activity_at].compact.max
   end
 

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -16,6 +16,8 @@ class CommentThread < ApplicationRecord
 
   after_create :create_follower
 
+  before_save :bump_last_activity_at
+
   # Gets threads appropriately scoped for a given user & post
   # @param user [User, nil] user to check
   # @para post [Post] post to check
@@ -87,6 +89,10 @@ class CommentThread < ApplicationRecord
   end
 
   private
+
+  def bump_last_activity_at
+    self.last_activity_at = DateTime.now
+  end
 
   # Comment author and post author are automatically followed to the thread. Question author is NOT
   # automatically followed on new answer comment threads. Comment author follower creation is done

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -88,6 +88,13 @@ class CommentThread < ApplicationRecord
     end
   end
 
+  # Registers a given user as a follower of the thread
+  # @param user [User] user to register as a follower
+  # @return [Boolean] status of the operation
+  def add_follower(user)
+    ThreadFollower.create(comment_thread: self, user: user)
+  end
+
   def bump_last_activity
     self.last_activity_at = DateTime.now
   end

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -95,8 +95,14 @@ class CommentThread < ApplicationRecord
     ThreadFollower.create(comment_thread: self, user: user)
   end
 
-  def bump_last_activity
+  # Directly bumps the thread's last activity date & time
+  # @param persist_changes [Boolean] if set to +true+, will persist the changes
+  def bump_last_activity(persist_changes: false)
     self.last_activity_at = DateTime.now
+
+    if persist_changes
+      save
+    end
   end
 
   # Removes a given user from the thread's followers

--- a/app/models/thread_follower.rb
+++ b/app/models/thread_follower.rb
@@ -3,15 +3,15 @@ class ThreadFollower < ApplicationRecord
   belongs_to :post, optional: true
   belongs_to :user
 
-  after_create :bump_thread_last_activity_at
-  before_destroy :bump_thread_last_activity_at
+  after_create :bump_thread_last_activity
+  before_destroy :bump_thread_last_activity
 
   validate :thread_or_post
 
   private
 
-  def bump_thread_last_activity_at
-    comment_thread&.bump_last_activity_at
+  def bump_thread_last_activity
+    comment_thread&.bump_last_activity
     comment_thread&.save
   end
 

--- a/app/models/thread_follower.rb
+++ b/app/models/thread_follower.rb
@@ -11,8 +11,7 @@ class ThreadFollower < ApplicationRecord
   private
 
   def bump_thread_last_activity
-    comment_thread&.bump_last_activity
-    comment_thread&.save
+    comment_thread&.bump_last_activity(persist_changes: true)
   end
 
   def thread_or_post

--- a/app/models/thread_follower.rb
+++ b/app/models/thread_follower.rb
@@ -3,9 +3,17 @@ class ThreadFollower < ApplicationRecord
   belongs_to :post, optional: true
   belongs_to :user
 
+  after_create :bump_thread_last_activity_at
+  before_destroy :bump_thread_last_activity_at
+
   validate :thread_or_post
 
   private
+
+  def bump_thread_last_activity_at
+    comment_thread&.bump_last_activity_at
+    comment_thread&.save
+  end
 
   def thread_or_post
     if comment_thread.nil? && post.nil?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -483,13 +483,13 @@ class User < ApplicationRecord
   end
 
   # Anonymizes the user (f.e., for the purpose of soft deletion)
-  # @param persist_changes [Boolean] if set to +false+, will persist the changes
+  # @param persist_changes [Boolean] if set to +true+, will persist the changes
   def anonymize(persist_changes: false)
     assign_attributes(username: "user#{id}",
                       email: "#{id}@deleted.localhost",
                       password: SecureRandom.hex(32))
 
-    unless persist_changes
+    if persist_changes
       skip_reconfirmation!
       save
     end
@@ -505,7 +505,7 @@ class User < ApplicationRecord
                       deleted_by_id: attribute_to.id,
                       deleted_at: DateTime.now)
 
-    anonymize(persist_changes: true)
+    anonymize(persist_changes: false)
 
     skip_reconfirmation!
     save

--- a/app/views/comments/_thread_follow_link.html.erb
+++ b/app/views/comments/_thread_follow_link.html.erb
@@ -8,8 +8,7 @@
 
 <% if thread.followed_by?(user) %>
   <a href="#"
-     class="widget--header-link js--unrestrict-thread"
-     data-action="follow"
+     class="widget--header-link js--unfollow-thread"
      data-thread="<%= thread.id %>"
      title="You are following this thread and will be notified of every response. You can unfollow at any time."
      role="button"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -247,6 +247,7 @@ Rails.application.routes.draw do
     post   'thread/:id/archive',           to: 'comments#archive_thread', as: :archive_comment_thread
     post   'thread/:id/delete',            to: 'comments#delete_thread', as: :delete_comment_thread
     post   'thread/:id/follow',            to: 'comments#follow_thread', as: :follow_comment_thread
+    post   'thread/:id/unfollow',          to: 'comments#unfollow_thread', as: :unfollow_comment_thread
     post   'thread/:id/lock',              to: 'comments#lock_thread', as: :lock_comment_thread
 
     post   'thread/:id/unrestrict',        to: 'comments#thread_unrestrict', as: :unrestrict_comment_thread

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -26,6 +26,10 @@ every 1.day, at: '02:30' do
   runner 'scripts/run_complaints_closure.rb'
 end
 
+every 7.days, at: '02:35' do
+  runner 'scripts/run_thread_followers_cleanup.rb'
+end
+
 every 6.hours do
   runner 'scripts/recalc_abilities.rb'
 end

--- a/db/migrate/20251221140930_add_last_activity_at_to_comments.rb
+++ b/db/migrate/20251221140930_add_last_activity_at_to_comments.rb
@@ -1,0 +1,5 @@
+class AddLastActivityAtToComments < ActiveRecord::Migration[7.2]
+  def change
+    add_column :comments, :last_activity_at, :datetime
+  end
+end

--- a/db/migrate/20251221142105_add_last_activity_at_to_comment_threads.rb
+++ b/db/migrate/20251221142105_add_last_activity_at_to_comment_threads.rb
@@ -1,0 +1,5 @@
+class AddLastActivityAtToCommentThreads < ActiveRecord::Migration[7.2]
+  def change
+    add_column :comment_threads, :last_activity_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_15_121326) do
+ActiveRecord::Schema[7.2].define(version: 2025_12_21_140930) do
   create_table "abilities", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "community_id"
     t.string "name"
@@ -195,6 +195,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_15_121326) do
     t.boolean "has_reference", default: false, null: false
     t.text "reference_text"
     t.bigint "references_comment_id"
+    t.datetime "last_activity_at"
     t.index ["comment_thread_id"], name: "index_comments_on_comment_thread_id"
     t.index ["community_id"], name: "index_comments_on_community_id"
     t.index ["post_id"], name: "index_comments_on_post_type_and_post_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_21_140930) do
+ActiveRecord::Schema[7.2].define(version: 2025_12_21_142105) do
   create_table "abilities", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "community_id"
     t.string "name"
@@ -176,6 +176,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_21_140930) do
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "community_id", null: false
     t.datetime "locked_at", precision: nil
+    t.datetime "last_activity_at"
     t.index ["archived_by_id"], name: "index_comment_threads_on_archived_by_id"
     t.index ["community_id"], name: "index_comment_threads_on_community_id"
     t.index ["deleted_by_id"], name: "index_comment_threads_on_deleted_by_id"

--- a/db/scripts/threads_with_duplicate_followers.sql
+++ b/db/scripts/threads_with_duplicate_followers.sql
@@ -1,0 +1,13 @@
+select
+  user_id,
+  comment_thread_id,
+  count(*) as count
+from
+  thread_followers
+where
+  post_id is null
+group by
+  user_id,
+  comment_thread_id
+having
+  count > 1;

--- a/global.d.ts
+++ b/global.d.ts
@@ -588,6 +588,13 @@ interface QPixel {
   followThread?: (id: string) => Promise<QPixelResponseJSON>
 
   /**
+   * Attempts to unfollow a comment thread
+   * @param id id of the thread to unfollow
+   * @returns result of the operation
+   */
+  unfollowThread?: (id: string) => Promise<QPixelResponseJSON>
+
+  /**
    * Attempts to start following comments on a given post
    * @param postId id of the post to follow comments on
    * @returns result of the operation

--- a/scripts/run_thread_followers_cleanup.rb
+++ b/scripts/run_thread_followers_cleanup.rb
@@ -1,0 +1,1 @@
+CleanUpThreadFollowersJob.perform_later

--- a/test/comments_test_helpers.rb
+++ b/test/comments_test_helpers.rb
@@ -68,7 +68,7 @@ module CommentsControllerTestHelpers
   # Attempts to unfollow a given comment thread
   # @param thread [CommentThread] thread to unfollow
   def try_unfollow_thread(thread)
-    post :thread_unrestrict, params: { id: thread.id, type: 'follow' }
+    post :unfollow_thread, params: { id: thread.id }
   end
 
   # Attempts to follow new threads on a given post

--- a/test/fixtures/comment_threads.yml
+++ b/test/fixtures/comment_threads.yml
@@ -82,3 +82,10 @@ without_activity:
   community: sample
   created_at: 2020-01-01T00:00:00.000000Z
   updated_at: 2020-01-01T00:00:00.000000Z
+
+without_followers:
+  title: Comment thread without any followers
+  title: Comment thread without activity
+  reply_count: 0
+  post: question_one
+  community: sample

--- a/test/fixtures/comment_threads.yml
+++ b/test/fixtures/comment_threads.yml
@@ -74,3 +74,11 @@ with_user_pings:
   reply_count: 1
   post: question_one
   community: sample
+
+without_activity:
+  title: Comment thread without activity
+  reply_count: 0
+  post: question_one
+  community: sample
+  created_at: 2020-01-01T00:00:00.000000Z
+  updated_at: 2020-01-01T00:00:00.000000Z

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -81,3 +81,12 @@ with_user_pings:
   comment_thread: with_user_pings
   created_at: 2020-01-01T00:00:00.000000Z
   updated_at: 2021-01-01T00:00:00.000000Z
+
+without_activity:
+  user: standard_user
+  post: question_one
+  content: This comment must be without any initial activity
+  community: sample
+  comment_thread: normal
+  created_at: 2020-01-01T00:00:00.000000Z
+  updated_at: 2020-01-01T00:00:00.000000Z

--- a/test/jobs/clean_up_thread_followers_job_test.rb
+++ b/test/jobs/clean_up_thread_followers_job_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class CleanUpThreadFollowersJobTest < ActiveJob::TestCase
+  test 'should correctly clean up thread followers' do
+    thread = comment_threads(:without_followers)
+    std_usr = users(:standard_user)
+
+    ThreadFollower.create(comment_thread: thread, user: std_usr)
+    ThreadFollower.create(comment_thread: thread, user: std_usr)
+    assert_equal 2, ThreadFollower.where(comment_thread: thread, user: std_usr).size
+
+    perform_enqueued_jobs do
+      CleanUpThreadFollowersJob.perform_later
+    end
+
+    assert_performed_jobs 1
+    assert_equal 1, ThreadFollower.where(comment_thread: thread, user: std_usr).size
+  end
+end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -52,9 +52,10 @@ class CommentTest < ActiveSupport::TestCase
     comment.update!(content: 'this should bump last_activity')
     comment.reload
     last_activity_after_update = comment.last_activity
-    assert_operator comment.updated_at, '<=', last_activity_after_update
+    assert_operator comment.updated_at, '<', last_activity_after_update
 
-    comment.bump_last_activity
-    assert_operator last_activity_after_update, '<=', comment.last_activity
+    comment.bump_last_activity(persist_changes: true)
+    comment.reload
+    assert_operator last_activity_after_update, '<', comment.last_activity
   end
 end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -43,4 +43,18 @@ class CommentTest < ActiveSupport::TestCase
     assert pings.include?(std_user.id)
     assert_not pings.include?(User.system.id)
   end
+
+  test 'last_activity should correctly get the comment\'s last activity date & time' do
+    comment = comments(:without_activity)
+
+    assert_equal comment.created_at, comment.last_activity
+
+    comment.update!(content: 'this should bump last_activity')
+    comment.reload
+    last_activity_after_update = comment.last_activity
+    assert_operator comment.updated_at, '<=', last_activity_after_update
+
+    comment.bump_last_activity
+    assert_operator last_activity_after_update, '<=', comment.last_activity
+  end
 end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -34,7 +34,7 @@ class CommentTest < ActiveSupport::TestCase
     end
   end
 
-  test 'pings should correctly' do
+  test 'pings should correctly get pinged user ids' do
     std_user = users(:standard_user)
     with_pings = comments(:with_user_pings)
 

--- a/test/models/comment_thread_test.rb
+++ b/test/models/comment_thread_test.rb
@@ -27,6 +27,11 @@ class CommentThreadTest < ActiveSupport::TestCase
     assert_operator thread.updated_at, '<=', last_activity_after_update
 
     thread.bump_last_activity
-    assert_operator last_activity_after_update, '<=', thread.last_activity
+    last_activity_after_bump = thread.last_activity
+    assert_operator last_activity_after_update, '<=', last_activity_after_bump
+
+    thread.add_follower(users(:editor))
+    thread.reload
+    assert_operator last_activity_after_bump, '<=', thread.last_activity
   end
 end

--- a/test/models/comment_thread_test.rb
+++ b/test/models/comment_thread_test.rb
@@ -16,9 +16,28 @@ class CommentThreadTest < ActiveSupport::TestCase
     end
   end
 
+  test 'remove_follower should correctly bump last_activity' do
+    std_usr = users(:standard_user)
+    thread = comment_threads(:without_activity)
+    assert_equal thread.created_at, thread.last_activity
+
+    thread.add_follower(std_usr)
+    thread.reload
+    last_activity_after_follow = thread.last_activity
+
+    thread.remove_follower(std_usr)
+    thread.reload
+    last_activity_after_unfollow = thread.last_activity
+    assert_operator last_activity_after_follow, '<', last_activity_after_unfollow
+
+    thread.remove_follower(std_usr)
+    thread.reload
+    last_activity_after_noop = thread.last_activity
+    assert_operator last_activity_after_unfollow, '<', last_activity_after_noop
+  end
+
   test 'last_activity should correctly get the thread\'s last activity date & time' do
     thread = comment_threads(:without_activity)
-
     assert_equal thread.created_at, thread.last_activity
 
     thread.update!(title: 'this should bump last_activity')

--- a/test/models/comment_thread_test.rb
+++ b/test/models/comment_thread_test.rb
@@ -28,10 +28,15 @@ class CommentThreadTest < ActiveSupport::TestCase
 
     thread.bump_last_activity
     last_activity_after_bump = thread.last_activity
-    assert_operator last_activity_after_update, '<=', last_activity_after_bump
+    assert_operator last_activity_after_update, '<', last_activity_after_bump
 
     thread.add_follower(users(:editor))
     thread.reload
-    assert_operator last_activity_after_bump, '<=', thread.last_activity
+    last_activity_after_follow = thread.last_activity
+    assert_operator last_activity_after_bump, '<', last_activity_after_follow
+
+    thread.remove_follower(users(:editor))
+    thread.reload
+    assert_operator last_activity_after_follow, '<', thread.last_activity
   end
 end

--- a/test/models/comment_thread_test.rb
+++ b/test/models/comment_thread_test.rb
@@ -16,16 +16,17 @@ class CommentThreadTest < ActiveSupport::TestCase
     end
   end
 
-  test 'last_activity_at should correctly get last activity' do
-    normal = comment_threads(:normal)
-    normal_two = comment_threads(:normal_two)
-    locked = comment_threads(:locked)
+  test 'last_activity should correctly get the thread\'s last activity date & time' do
+    thread = comment_threads(:without_activity)
 
-    assert_not_equal locked.last_activity_at, locked.created_at
-    assert_not_equal normal_two.last_activity_at, normal_two.created_at
+    assert_equal thread.created_at, thread.last_activity
 
-    assert_equal locked.last_activity_at, locked.locked_at
-    assert_equal normal.last_activity_at, normal.created_at
-    assert_equal normal_two.last_activity_at, normal_two.updated_at
+    thread.update!(title: 'this should bump last_activity')
+    thread.reload
+    last_activity_after_update = thread.last_activity
+    assert_operator thread.updated_at, '<=', last_activity_after_update
+
+    thread.bump_last_activity
+    assert_operator last_activity_after_update, '<=', thread.last_activity
   end
 end

--- a/test/models/comment_thread_test.rb
+++ b/test/models/comment_thread_test.rb
@@ -26,7 +26,8 @@ class CommentThreadTest < ActiveSupport::TestCase
     last_activity_after_update = thread.last_activity
     assert_operator thread.updated_at, '<=', last_activity_after_update
 
-    thread.bump_last_activity
+    thread.bump_last_activity(persist_changes: true)
+    thread.reload
     last_activity_after_bump = thread.last_activity
     assert_operator last_activity_after_update, '<', last_activity_after_bump
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -321,7 +321,7 @@ class UserTest < ActiveSupport::TestCase
     anonymized_name = "user#{std.id}"
     anonymized_email = "#{std.id}@deleted.localhost"
 
-    [true, false].each do |persist|
+    [false, true].each do |persist|
       std.anonymize(persist_changes: persist)
 
       assert_equal std.username, anonymized_name
@@ -330,11 +330,11 @@ class UserTest < ActiveSupport::TestCase
       std.reload
 
       if persist
-        assert_not_equal std.username, anonymized_name
-        assert_not_equal std.email, anonymized_email
-      else
         assert_equal std.username, anonymized_name
         assert_equal std.email, anonymized_email
+      else
+        assert_not_equal std.username, anonymized_name
+        assert_not_equal std.email, anonymized_email
       end
     end
   end


### PR DESCRIPTION
closes #1930
closes #1932
closes #1933

This PR makes sure following / unfollowing a comment thread bumps the thread's last activity date & time and thus prevents stale content from being served afterwards.

It also fixes confusing inversion of the `User#anonymize` method's `persist_changes` parameter (turns out it wasn't the best idea to rename `dirty` to `persist_changes` while tired - thankfully, the logic was sound, this change is just a matter of making it not confusing).

Additionally, it ensures attempting to make the same action multiple times does not create duplicate entries (as well as automatically cleans up any duplicate entry on unfollow).

Finally, it also makes sure we don't need to reload the whole page upon successfully unfollowing a thread (and gets us closer to removing `thread_unrestrict` entirely).

Note for reviewers: to be able to test this change, you need to [enable caching in development](<https://guides.rubyonrails.org/v7.2/caching_with_rails.html#caching-in-development>) (should be on by default, but it doesn't hurt to check) *and* set the `PERFORM_CACHING` env variable to `true`. 