### PR TITLE
Improve and shorten wordings in right panel of profile

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -184,7 +184,7 @@
         <td class="overflow-ellipsis" title="<%= @user.metric 'E' %>"><%= @user.metric 'E' %></td>
       </tr>
       <% if current_user&.id == @user.id || current_user&.at_least_moderator? %>
-        <tr><td colspan="3">User since <%= @user.community_user.created_at %></td></tr>
+        <tr><td colspan="3">Joined <%= @user.community_user.created_at %></td></tr>
       <% end %>
     </table>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -204,13 +204,13 @@
         <% end %>
         <div class="widget--footer">
           <% if current_user&.id == @user.id %>
-           <%= link_to abilities_path, class: 'has-font-weight-bold', 'aria-label': 'View your abilities' do %>
-             Abilities &raquo;
-           <% end %>
+            <%= link_to abilities_path, class: 'has-font-weight-bold', 'aria-label': 'View your abilities' do %>
+              Abilities &raquo;
+            <% end %>
           <% else %>
-           <%= link_to abilities_path(for: @user.id), class: 'has-font-weight-bold', 'aria-label': "View abilities of #{rtl_safe_username(@user)}" do %>
-             Abilities &raquo;
-           <% end %>
+            <%= link_to abilities_path(for: @user.id), class: 'has-font-weight-bold', 'aria-label': "View abilities of #{rtl_safe_username(@user)}" do %>
+              Abilities &raquo;
+            <% end %>
           <% end %>
         </div>
       </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -275,11 +275,11 @@
       <tr>
         <td colspan="2">
           <% if current_user&.id == @user.id %>
-            <%= link_to search_path(search: "user:#{@user.id} post_type:3"), 'aria-label': 'View your articles' do %>
+            <%= link_to search_path(search: "user:#{@user.id} post_type:5"), 'aria-label': 'View your articles' do %>
               Articles
             <% end %>
           <% else %>
-            <%= link_to search_path(search: "user:#{@user.id} post_type:3"), 'aria-label': "View articles from #{rtl_safe_username(@user)}" do %>
+            <%= link_to search_path(search: "user:#{@user.id} post_type:5"), 'aria-label': "View articles from #{rtl_safe_username(@user)}" do %>
               Articles
             <% end %>
           <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -56,7 +56,7 @@
         </div>
         <% end %>
       <% end %>
-     
+
       <p>
         <% if @user.discord.present? %>
           <span class="h-m-r-4">
@@ -72,7 +72,7 @@
           <% end %>
         <% end %>
         <% if current_user&.at_least_moderator? %>
-          <a href="<%= mod_user_path(@user) %>" class="button is-danger is-outlined is-small" data-drop="#mod-tools-drop"><i class="fas fa-shield-alt"></i> Moderator Tools <% if @user.community_user.mod_warnings&.size.positive? %> (<%= pluralize(@user.community_user.mod_warnings.count, 'message') %>) <% end %></a> 
+          <a href="<%= mod_user_path(@user) %>" class="button is-danger is-outlined is-small" data-drop="#mod-tools-drop"><i class="fas fa-shield-alt"></i> Moderator Tools <% if @user.community_user.mod_warnings&.size.positive? %> (<%= pluralize(@user.community_user.mod_warnings.count, 'message') %>) <% end %></a>
           <div class="droppanel" id="mod-tools-drop">
             <div class="droppanel--header">quick actions</div>
             <div class="droppanel--menu">
@@ -146,26 +146,26 @@
         <td class="overflow-ellipsis" title="<%= @user.reputation %>"><%= @user.reputation %></td>
       </tr>
       <tr>
-        <td colspan="2"><i class="far fa-fw fa-comment-alt"></i> Number of top-level posts</td>
+        <td colspan="2"><i class="far fa-fw fa-comment-alt"></i> Top-level posts</td>
         <td class="overflow-ellipsis" title="<%= @user.metric '1' %>"><%= @user.metric '1' %></td>
       </tr>
       <tr>
-        <td colspan="2"><i class="fas fa-fw fa-reply-all"></i> Number of answers</td>
+        <td colspan="2"><i class="fas fa-fw fa-reply-all"></i> Answers</td>
         <td class="overflow-ellipsis" title="<%= @user.metric '2' %>"><%= @user.metric '2' %></td>
       </tr>
       <tr>
-        <td colspan="2"><i class="fas fa-fw fa-star-half-alt"></i> Sum of received votes (up minus down)</td>
+        <td colspan="2"><i class="fas fa-fw fa-star-half-alt"></i> Received votes (up minus down)</td>
         <td class="overflow-ellipsis" title="<%= @user.metric 's' %>"><%= @user.metric 's' %></td>
       </tr>
       <tr>
-        <td colspan="2"><i class="fas fa-fw fa-pen"></i> Number of edits made</td>
+        <td colspan="2"><i class="fas fa-fw fa-pen"></i> Edits made</td>
         <td class="overflow-ellipsis" title="<%= @user.metric 'E' %>"><%= @user.metric 'E' %></td>
       </tr>
       <% if current_user&.id == @user.id || current_user&.at_least_moderator? %>
         <tr><td colspan="3">User since <%= @user.community_user.created_at %></td></tr>
       <% end %>
     </table>
-  
+
     <% unless @abilities.empty? %>
       <h2>Earned Abilities</h2>
 
@@ -203,7 +203,7 @@
         <th colspan="3">Posts</th>
       </tr>
       <tr>
-        <td colspan="2">Count</td>
+        <td colspan="2">Total</td>
         <td class="overflow-ellipsis" title="<%= @user.posts.undeleted.count %>">
           <%= @user.posts.undeleted.count %>
         </td>
@@ -238,7 +238,7 @@
         <th colspan="3">Votes cast</th>
       </tr>
       <tr>
-        <td colspan="2">Count</td>
+        <td colspan="2">Total</td>
         <td class="overflow-ellipsis" title="<%= @user.votes.count %>"><%= @user.votes.count %></td>
       </tr>
       <% if @user.id == current_user&.id || current_user&.admin? %>
@@ -263,19 +263,19 @@
         <td class="overflow-ellipsis" title="<%= votes_by_type[-1] || 0 %>"><%= votes_by_type[-1] || 0 %></td>
       </tr>
       <tr>
-        <td colspan="2">on Question</td>
+        <td colspan="2">on Questions</td>
         <td class="overflow-ellipsis" title="<%= votes_for(votes_by_post_type, Question) %>">
           <%= votes_for(votes_by_post_type, Question) %>
         </td>
       </tr>
       <tr>
-        <td colspan="2">on Answer</td>
+        <td colspan="2">on Answers</td>
         <td class="overflow-ellipsis" title="<%= votes_for(votes_by_post_type, Answer) %>">
           <%= votes_for(votes_by_post_type, Answer) %>
         </td>
       </tr>
       <tr>
-        <td colspan="2">on Article</td>
+        <td colspan="2">on Articles</td>
         <td class="overflow-ellipsis" title="<%= votes_for(votes_by_post_type, Article) %>">
           <%= votes_for(votes_by_post_type, Article) %>
         </td>
@@ -288,7 +288,7 @@
         <th colspan="3">Flags raised</th>
       </tr>
       <tr>
-        <td colspan="2">Count</td>
+        <td colspan="2">Total</td>
         <td class="overflow-ellipsis" title="<%= @user.flags.count %>">
           <% if current_user&.id == @user.id || at_least_moderator? %>
             <%= link_to @user.flags.count, flag_history_path(@user.id), class: 'is-muted',

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -20,6 +20,7 @@
   </div>
 <% end %>
 
+<% is_me = @user.same_as?(current_user) %>
 <div class="grid <%= deleted_user?(@user) ? 'deleted-content' : '' %>">
   <div class="grid--cell is-9-lg is-12">
     <div class="h-p-0 h-p-t-0">
@@ -153,28 +154,19 @@
       <tr>
         <td colspan="2">
             <i class="fas fa-fw fa-reply-all"></i>
-            <% if current_user&.id == @user.id %>
-              <%= link_to search_path(search: "user:#{@user.id} post_type:2"), 'aria-label': 'View your answers' do %>
-                Answers
-              <% end %>
-            <% else %>
-              <%= link_to search_path(search: "user:#{@user.id} post_type:2"), 'aria-label': "View answers from #{rtl_safe_username(@user)}" do %>
-                Answers
-              <% end %>
+            <%= link_to search_path(search: "user:#{@user.id} post_type:2"),
+              'aria-label': is_me ? 'View your answers' : "View answers from #{rtl_safe_username(@user)}" do %>
+              Answers
             <% end %>
         </td>
         <td class="overflow-ellipsis" title="<%= @user.metric '2' %>"><%= @user.metric '2' %></td>
       </tr>
       <tr>
         <td colspan="2"><i class="fas fa-fw fa-star-half-alt"></i>
-          <% if current_user&.id == @user.id %>
-            <%= link_to my_vote_summary_path, 'aria-label': 'View your received votes' do %>
-              Received votes
-            <% end %>
-          <% else %>
-            <%= link_to vote_summary_path, 'aria-label': "View received votes for #{rtl_safe_username(@user)}" do %>
-              Received votes
-            <% end %>
+          <%= link_to is_me ? my_vote_summary_path : vote_summary_path,
+            'aria-label':
+              is_me ? 'View your received votes' : "View received votes for #{rtl_safe_username(@user)}" do %>
+            Received votes
           <% end %>
           <br>(up minus down)
         </td>
@@ -184,7 +176,7 @@
         <td colspan="2"><i class="fas fa-fw fa-pen"></i> Edits made</td>
         <td class="overflow-ellipsis" title="<%= @user.metric 'E' %>"><%= @user.metric 'E' %></td>
       </tr>
-      <% if current_user&.id == @user.id || current_user&.at_least_moderator? %>
+      <% if is_me || current_user&.at_least_moderator? %>
         <tr><td colspan="3">Joined <%= @user.community_user.created_at %></td></tr>
       <% end %>
     </table>
@@ -204,14 +196,10 @@
         <% end %>
         <% end %>
         <div class="widget--footer">
-          <% if current_user&.id == @user.id %>
-            <%= link_to abilities_path, class: 'has-font-weight-bold', 'aria-label': 'View your abilities' do %>
-              Abilities &raquo;
-            <% end %>
-          <% else %>
-            <%= link_to abilities_path(for: @user.id), class: 'has-font-weight-bold', 'aria-label': "View abilities of #{rtl_safe_username(@user)}" do %>
-              Abilities &raquo;
-            <% end %>
+          <%= link_to is_me ? abilities_path : abilities_path(for: @user.id),
+            class: 'has-font-weight-bold',
+            'aria-label': is_me ? 'View your abilities' : "View abilities of #{rtl_safe_username(@user)}" do %>
+            Abilities &raquo;
           <% end %>
         </div>
       </div>
@@ -227,14 +215,9 @@
       </tr>
       <tr>
         <td colspan="2">
-          <% if current_user&.id == @user.id %>
-            <%= link_to user_posts_path, 'aria-label': 'View your posts' do %>
-              Total
-            <% end %>
-          <% else %>
-            <%= link_to user_posts_path, 'aria-label': "View posts for #{rtl_safe_username(@user)}" do %>
-              Total
-            <% end %>
+          <%= link_to user_posts_path,
+            'aria-label': is_me ? 'View your posts' : "View posts for #{rtl_safe_username(@user)}" do %>
+            Total
           <% end %>
         </td>
         <td class="overflow-ellipsis" title="<%= @user.posts.undeleted.count %>">
@@ -243,14 +226,9 @@
       </tr>
       <tr>
         <td colspan="2">
-          <% if current_user&.id == @user.id %>
-            <%= link_to search_path(search: "user:#{@user.id} post_type:1"), 'aria-label': 'View your questions' do %>
-              Questions
-            <% end %>
-          <% else %>
-            <%= link_to search_path(search: "user:#{@user.id} post_type:1"), 'aria-label': "View questions from #{rtl_safe_username(@user)}" do %>
-              Questions
-            <% end %>
+          <%= link_to search_path(search: "user:#{@user.id} post_type:1"),
+            'aria-label': is_me ? 'View your questions' : "View questions from #{rtl_safe_username(@user)}" do %>
+            Questions
           <% end %>
         </td>
         <td class="overflow-ellipsis" title="<%= posts_for(posts_by_post_type, Question) %>">
@@ -259,14 +237,9 @@
       </tr>
       <tr>
         <td colspan="2">
-          <% if current_user&.id == @user.id %>
-            <%= link_to search_path(search: "user:#{@user.id} post_type:2"), 'aria-label': 'View your answers' do %>
-              Answers
-            <% end %>
-          <% else %>
-            <%= link_to search_path(search: "user:#{@user.id} post_type:2"), 'aria-label': "View answers from #{rtl_safe_username(@user)}" do %>
-              Answers
-            <% end %>
+          <%= link_to search_path(search: "user:#{@user.id} post_type:2"),
+            'aria-label': is_me ? 'View your answers' : "View answers from #{rtl_safe_username(@user)}" do %>
+            Answers
           <% end %>
         </td>
         <td class="overflow-ellipsis" title="<%= posts_for(posts_by_post_type, Answer) %>">
@@ -275,14 +248,9 @@
       </tr>
       <tr>
         <td colspan="2">
-          <% if current_user&.id == @user.id %>
-            <%= link_to search_path(search: "user:#{@user.id} post_type:5"), 'aria-label': 'View your articles' do %>
-              Articles
-            <% end %>
-          <% else %>
-            <%= link_to search_path(search: "user:#{@user.id} post_type:5"), 'aria-label': "View articles from #{rtl_safe_username(@user)}" do %>
-              Articles
-            <% end %>
+          <%= link_to search_path(search: "user:#{@user.id} post_type:5"),
+            'aria-label': is_me ? 'View your articles' : "View articles from #{rtl_safe_username(@user)}" do %>
+            Articles
           <% end %>
         </td>
         <td class="overflow-ellipsis" title="<%= posts_for(posts_by_post_type, Article) %>">
@@ -304,45 +272,45 @@
         <td colspan="2">Total</td>
         <td class="overflow-ellipsis" title="<%= @user.votes.count %>"><%= @user.votes.count %></td>
       </tr>
-      <% if @user.id == current_user&.id || current_user&.admin? %>
-      <tr>
-        <td colspan="2">
-          <div class="flex items-center gap-sm">
-            <svg class="has-color-tertiary-600" width="1em" height="0.67em" viewbox="0 0 100 50">
-              <path d="M50,0 L100,50 L0,50 Z" fill="currentColor" />
-            </svg>Upvotes
-          </div>
-        </td>
-        <td class="overflow-ellipsis" title="<%= votes_by_type[1] || 0 %>"><%= votes_by_type[1] || 0 %></td>
-      </tr>
-      <tr>
-        <td colspan="2">
-          <div class="flex items-center gap-sm">
-            <svg class="has-color-tertiary-600" width="1em" height="0.67em" viewbox="0 0 100 50">
-              <path d="M0,0 L100,0 L50,50 Z" fill="currentColor" />
-            </svg>Downvotes
-          </div>
-        </td>
-        <td class="overflow-ellipsis" title="<%= votes_by_type[-1] || 0 %>"><%= votes_by_type[-1] || 0 %></td>
-      </tr>
-      <tr>
-        <td colspan="2">on Questions</td>
-        <td class="overflow-ellipsis" title="<%= votes_for(votes_by_post_type, Question) %>">
-          <%= votes_for(votes_by_post_type, Question) %>
-        </td>
-      </tr>
-      <tr>
-        <td colspan="2">on Answers</td>
-        <td class="overflow-ellipsis" title="<%= votes_for(votes_by_post_type, Answer) %>">
-          <%= votes_for(votes_by_post_type, Answer) %>
-        </td>
-      </tr>
-      <tr>
-        <td colspan="2">on Articles</td>
-        <td class="overflow-ellipsis" title="<%= votes_for(votes_by_post_type, Article) %>">
-          <%= votes_for(votes_by_post_type, Article) %>
-        </td>
-      </tr>
+      <% if is_me || current_user&.admin? %>
+        <tr>
+          <td colspan="2">
+            <div class="flex items-center gap-sm">
+              <svg class="has-color-tertiary-600" width="1em" height="0.67em" viewbox="0 0 100 50">
+                <path d="M50,0 L100,50 L0,50 Z" fill="currentColor" />
+              </svg>Upvotes
+            </div>
+          </td>
+          <td class="overflow-ellipsis" title="<%= votes_by_type[1] || 0 %>"><%= votes_by_type[1] || 0 %></td>
+        </tr>
+        <tr>
+          <td colspan="2">
+            <div class="flex items-center gap-sm">
+              <svg class="has-color-tertiary-600" width="1em" height="0.67em" viewbox="0 0 100 50">
+                <path d="M0,0 L100,0 L50,50 Z" fill="currentColor" />
+              </svg>Downvotes
+            </div>
+          </td>
+          <td class="overflow-ellipsis" title="<%= votes_by_type[-1] || 0 %>"><%= votes_by_type[-1] || 0 %></td>
+        </tr>
+        <tr>
+          <td colspan="2">on Questions</td>
+          <td class="overflow-ellipsis" title="<%= votes_for(votes_by_post_type, Question) %>">
+            <%= votes_for(votes_by_post_type, Question) %>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="2">on Answers</td>
+          <td class="overflow-ellipsis" title="<%= votes_for(votes_by_post_type, Answer) %>">
+            <%= votes_for(votes_by_post_type, Answer) %>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="2">on Articles</td>
+          <td class="overflow-ellipsis" title="<%= votes_for(votes_by_post_type, Article) %>">
+            <%= votes_for(votes_by_post_type, Article) %>
+          </td>
+        </tr>
       <% end %>
     </table>
     <br>
@@ -353,7 +321,7 @@
       <tr>
         <td colspan="2">Total</td>
         <td class="overflow-ellipsis" title="<%= @user.flags.count %>">
-          <% if current_user&.id == @user.id || at_least_moderator? %>
+          <% if is_me || at_least_moderator? %>
             <%= link_to @user.flags.count, flag_history_path(@user.id), class: 'is-muted',
                         'aria-label': "View flag history for #{@user.flags.count} flags" %>
           <% else %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -150,11 +150,33 @@
         <td class="overflow-ellipsis" title="<%= @user.metric '1' %>"><%= @user.metric '1' %></td>
       </tr>
       <tr>
-        <td colspan="2"><i class="fas fa-fw fa-reply-all"></i> Answers</td>
+        <td colspan="2">
+            <i class="fas fa-fw fa-reply-all"></i>
+            <% if current_user&.id == @user.id %>
+              <%= link_to search_path(search: "user:#{@user.id} post_type:2"), 'aria-label': 'View your answers' do %>
+                Answers
+              <% end %>
+            <% else %>
+              <%= link_to search_path(search: "user:#{@user.id} post_type:2"), 'aria-label': "View answers from #{rtl_safe_username(@user)}" do %>
+                Answers
+              <% end %>
+            <% end %>
+        </td>
         <td class="overflow-ellipsis" title="<%= @user.metric '2' %>"><%= @user.metric '2' %></td>
       </tr>
       <tr>
-        <td colspan="2"><i class="fas fa-fw fa-star-half-alt"></i> Received votes (up minus down)</td>
+        <td colspan="2"><i class="fas fa-fw fa-star-half-alt"></i>
+          <% if current_user&.id == @user.id %>
+            <%= link_to my_vote_summary_path, 'aria-label': 'View your received votes' do %>
+              Received votes
+            <% end %>
+          <% else %>
+            <%= link_to vote_summary_path, 'aria-label': "View received votes for #{rtl_safe_username(@user)}" do %>
+              Received votes
+            <% end %>
+          <% end %>
+          <br>(up minus down)
+        </td>
         <td class="overflow-ellipsis" title="<%= @user.metric 's' %>"><%= @user.metric 's' %></td>
       </tr>
       <tr>
@@ -203,25 +225,65 @@
         <th colspan="3">Posts</th>
       </tr>
       <tr>
-        <td colspan="2">Total</td>
+        <td colspan="2">
+          <% if current_user&.id == @user.id %>
+            <%= link_to user_posts_path, 'aria-label': 'View your posts' do %>
+              Total
+            <% end %>
+          <% else %>
+            <%= link_to user_posts_path, 'aria-label': "View posts for #{rtl_safe_username(@user)}" do %>
+              Total
+            <% end %>
+          <% end %>
+        </td>
         <td class="overflow-ellipsis" title="<%= @user.posts.undeleted.count %>">
           <%= @user.posts.undeleted.count %>
         </td>
       </tr>
       <tr>
-        <td colspan="2">Questions</td>
+        <td colspan="2">
+          <% if current_user&.id == @user.id %>
+            <%= link_to search_path(search: "user:#{@user.id} post_type:1"), 'aria-label': 'View your questions' do %>
+              Questions
+            <% end %>
+          <% else %>
+            <%= link_to search_path(search: "user:#{@user.id} post_type:1"), 'aria-label': "View questions from #{rtl_safe_username(@user)}" do %>
+              Questions
+            <% end %>
+          <% end %>
+        </td>
         <td class="overflow-ellipsis" title="<%= posts_for(posts_by_post_type, Question) %>">
           <%= posts_for(posts_by_post_type, Question) %>
         </td>
       </tr>
       <tr>
-        <td colspan="2">Answers</td>
+        <td colspan="2">
+          <% if current_user&.id == @user.id %>
+            <%= link_to search_path(search: "user:#{@user.id} post_type:2"), 'aria-label': 'View your answers' do %>
+              Answers
+            <% end %>
+          <% else %>
+            <%= link_to search_path(search: "user:#{@user.id} post_type:2"), 'aria-label': "View answers from #{rtl_safe_username(@user)}" do %>
+              Answers
+            <% end %>
+          <% end %>
+        </td>
         <td class="overflow-ellipsis" title="<%= posts_for(posts_by_post_type, Answer) %>">
           <%= posts_for(posts_by_post_type, Answer) %>
         </td>
       </tr>
       <tr>
-        <td colspan="2">Articles</td>
+        <td colspan="2">
+          <% if current_user&.id == @user.id %>
+            <%= link_to search_path(search: "user:#{@user.id} post_type:3"), 'aria-label': 'View your articles' do %>
+              Articles
+            <% end %>
+          <% else %>
+            <%= link_to search_path(search: "user:#{@user.id} post_type:3"), 'aria-label': "View articles from #{rtl_safe_username(@user)}" do %>
+              Articles
+            <% end %>
+          <% end %>
+        </td>
         <td class="overflow-ellipsis" title="<%= posts_for(posts_by_post_type, Article) %>">
           <%= posts_for(posts_by_post_type, Article) %>
         </td>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -80,10 +80,11 @@
               <a href="/users/<%= @user.id %>/mod/annotations">annotations on user</a>
               <a href="/users/<%= @user.id %>/mod/privileges">privileges</a>
               <a href="/warning/log/<%= @user.id %>">warnings and suspensions sent to user
-		<% if @user.community_user.suspended? %><em>(includes lifting the suspension)</em>
-		<% elsif @user.community_user.mod_warnings&.size.positive? %>
-		(latest <%= time_ago_in_words(@user.community_user.latest_warning) %> ago)
-		<% end %></a>
+              <% if @user.community_user.suspended? %>
+                <em>(includes lifting the suspension)</em>
+              <% elsif @user.community_user.mod_warnings&.size.positive? %>
+                (latest <%= time_ago_in_words(@user.community_user.latest_warning) %> ago)
+              <% end %></a>
               <a href="/warning/new/<%= @user.id %>">warn or suspend user</a>
             </div>
             <div class="h-m-t-6">


### PR DESCRIPTION
The changes suggested in meta:287189:
- Remove redundancy in wordings.
- Make some wordings links to relevant pages.
- Change the 3 usages of "Count" to "Total".

Also:
- Change "User since" to "Joined" to avoid the time zone wrapping onto the next line.

Notice that the height of the panel is now significantly reduced.

## Appearance before (left) and after (right)
<img width="282" height="1364" alt="Screenshot 2026-01-04 at 06-24-47 DEV User user - QPixel" src="https://github.com/user-attachments/assets/12a6eb5b-8af9-49c0-b639-9821161bf5d1" />

<img width="282" height="1269" alt="Screenshot 2026-01-04 at 06-25-08 DEV User user - QPixel" src="https://github.com/user-attachments/assets/b9ff4481-62cf-4604-9daf-aba5000c84cf" />
