### PR TITLE
Fix for accidental insertions of "[]()" into fields upon hitting Enter in various post fields + general cleanup

### DIFF
--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -380,7 +380,7 @@ $(() => {
       const id = $item.data('user-id');
       $tgt[0].selectionStart = caretPos - posInWord;
       $tgt[0].selectionEnd = caretPos - posInWord + currentWord.length;
-      QPixel.replaceSelection($tgt, `@#${id}`);
+      QPixel.MD.replaceSelection($tgt, `@#${id}`);
       popup.destroy();
       $tgt.focus();
     };

--- a/app/assets/javascripts/markdown.js
+++ b/app/assets/javascripts/markdown.js
@@ -1,11 +1,9 @@
 $(() => {
-  const stringInsert = (str, idx, insert) => str.slice(0, idx) + insert + str.slice(idx);
-
   const insertIntoField = ($field, start, end) => {
     let value = $field.val();
-    value = stringInsert(value, $field[0].selectionStart, start);
+    value = QPixel.MD.stringInsert(value, $field[0].selectionStart, start);
     if (end) {
-      value = stringInsert(value, $field[0].selectionEnd + start.length, end);
+      value = QPixel.MD.stringInsert(value, $field[0].selectionEnd + start.length, end);
     }
     $field.val(value).trigger('markdown');
   };

--- a/app/assets/javascripts/markdown.js
+++ b/app/assets/javascripts/markdown.js
@@ -1,9 +1,4 @@
 $(() => {
-  const replaceSelection = ($field, text) => {
-    const prev = $field.val();
-    $field.val(prev.substring(0, $field[0].selectionStart) + text + prev.substring($field[0].selectionEnd));
-  };
-
   $(document).on('click', '.js-markdown-tool', (ev) => {
     const $tgt = $(ev.target);
     const $button = $tgt.is('a') ? $tgt : $tgt.parents('a');
@@ -88,7 +83,7 @@ $(() => {
     const $field = $('.js-post-field');
 
     if ($field[0].selectionStart != null && $field[0].selectionStart !== $field[0].selectionEnd) {
-      replaceSelection($field, markdown);
+      QPixel.replaceSelection($field, markdown);
     }
     else {
       QPixel.MD.insertIntoField($field, markdown);

--- a/app/assets/javascripts/markdown.js
+++ b/app/assets/javascripts/markdown.js
@@ -83,7 +83,7 @@ $(() => {
     const $field = $('.js-post-field');
 
     if ($field[0].selectionStart != null && $field[0].selectionStart !== $field[0].selectionEnd) {
-      QPixel.replaceSelection($field, markdown);
+      QPixel.MD.replaceSelection($field, markdown);
     }
     else {
       QPixel.MD.insertIntoField($field, markdown);

--- a/app/assets/javascripts/markdown.js
+++ b/app/assets/javascripts/markdown.js
@@ -1,13 +1,4 @@
 $(() => {
-  const insertIntoField = ($field, start, end) => {
-    let value = $field.val();
-    value = QPixel.MD.stringInsert(value, $field[0].selectionStart, start);
-    if (end) {
-      value = QPixel.MD.stringInsert(value, $field[0].selectionEnd + start.length, end);
-    }
-    $field.val(value).trigger('markdown');
-  };
-
   const replaceSelection = ($field, text) => {
     const prev = $field.val();
     $field.val(prev.substring(0, $field[0].selectionStart) + text + prev.substring($field[0].selectionEnd));
@@ -36,7 +27,7 @@ $(() => {
 
     if (Object.keys(actions).indexOf(action) !== -1) {
       const preSelection = [$field[0].selectionStart, $field[0].selectionEnd];
-      insertIntoField($field, actions[action][0], actions[action][1]);
+      QPixel.MD.insertIntoField($field, actions[action][0], actions[action][1]);
       $field.focus();
       $field[0].selectionStart = preSelection[0] + actions[action][0].length;
       $field[0].selectionEnd = preSelection[1] + actions[action][0].length;
@@ -100,7 +91,7 @@ $(() => {
       replaceSelection($field, markdown);
     }
     else {
-      insertIntoField($field, markdown);
+      QPixel.MD.insertIntoField($field, markdown);
     }
 
     $field.trigger('markdown');

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -20,15 +20,6 @@ $(() => {
   /** @type {JQuery<HTMLFormElement>} */
   const $uploadForm = $('.js-upload-form');
 
-  /**
-   * Inserts text at a given {@link idx} in a given {@link str}
-   * @param {string} str text to insert into
-   * @param {number} idx position to insert at
-   * @param {string} insert text to insert
-   * @returns {string}
-   */
-  const stringInsert = (str, idx, insert) => str.slice(0, idx) + insert + str.slice(idx);
-
   const placeholder = '![Uploading, please wait...]()';
 
   $uploadForm.find('input[type="file"]').on('change', async (evt) => {
@@ -37,7 +28,7 @@ $(() => {
     const postText = postField.value;
     const cursorPos = postField.selectionStart;
 
-    postField.value = stringInsert(postText, cursorPos, placeholder);
+    postField.value = QPixel.MD.stringInsert(postText, cursorPos, placeholder);
 
     $uploadForm.trigger('submit');
   });

--- a/app/assets/javascripts/qpixel_api.js
+++ b/app/assets/javascripts/qpixel_api.js
@@ -98,11 +98,6 @@ window.QPixel = {
     }
   },
 
-  replaceSelection: ($field, text) => {
-    const prev = $field.val()?.toString();
-    $field.val(prev.substring(0, $field[0].selectionStart) + text + prev.substring($field[0].selectionEnd));
-  },
-
   /**
    * @type {QPixelFilter[]|null}
    */

--- a/app/assets/javascripts/qpixel_markdown.js
+++ b/app/assets/javascripts/qpixel_markdown.js
@@ -1,7 +1,7 @@
 window.QPixel = window.QPixel || {};
 
 QPixel.MD = {
-  insertIntoField($field, start, end) {
+  insertIntoField: ($field, start, end) => {
     let value = $field.val();
 
     value = QPixel.MD.stringInsert(value, $field[0].selectionStart, start);
@@ -13,7 +13,7 @@ QPixel.MD = {
     $field.val(value).trigger('markdown');
   },
 
-  replaceSelection($field, text) {
+  replaceSelection: ($field, text) => {
     const prev = $field.val()?.toString();
     $field.val(prev.substring(0, $field[0].selectionStart) + text + prev.substring($field[0].selectionEnd));
   },

--- a/app/assets/javascripts/qpixel_markdown.js
+++ b/app/assets/javascripts/qpixel_markdown.js
@@ -13,6 +13,11 @@ QPixel.MD = {
     $field.val(value).trigger('markdown');
   },
 
+  replaceSelection($field, text) {
+    const prev = $field.val()?.toString();
+    $field.val(prev.substring(0, $field[0].selectionStart) + text + prev.substring($field[0].selectionEnd));
+  },
+
   stringInsert: (str, idx, insert) => {
     return str.slice(0, idx) + insert + str.slice(idx);
   },

--- a/app/assets/javascripts/qpixel_markdown.js
+++ b/app/assets/javascripts/qpixel_markdown.js
@@ -1,12 +1,16 @@
 window.QPixel = window.QPixel || {};
 
 QPixel.MD = {
+  stringInsert: (str, idx, insert) => {
+    return str.slice(0, idx) + insert + str.slice(idx);
+  },
+
   stripMarkdown: (content, options = {}) => {
     const stripped = content
       .replace(/(?:^#+ +|^-{3,}|^\[[^\]]+\]: ?.+$|^!\[[^\]]+\](?:\([^)]+\)|\[[^\]]+\])$|<[^>]+>)/g, '')
       .replace(/[*_~]+/g, '')
       .replace(/!?\[([^\]]+)\](?:\([^)]+\)|\[[^\]]+\])/g, '$1');
-    
+
     if (options.removeLeadingQuote ?? false) {
       return stripped.replace(/^>.+?$/g, '');
     }

--- a/app/assets/javascripts/qpixel_markdown.js
+++ b/app/assets/javascripts/qpixel_markdown.js
@@ -1,6 +1,18 @@
 window.QPixel = window.QPixel || {};
 
 QPixel.MD = {
+  insertIntoField($field, start, end) {
+    let value = $field.val();
+
+    value = QPixel.MD.stringInsert(value, $field[0].selectionStart, start);
+
+    if (end) {
+      value = QPixel.MD.stringInsert(value, $field[0].selectionEnd + start.length, end);
+    }
+
+    $field.val(value).trigger('markdown');
+  },
+
   stringInsert: (str, idx, insert) => {
     return str.slice(0, idx) + insert + str.slice(idx);
   },

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -27,7 +27,7 @@ $(() => {
       const id = $item.data('post-type-id');
       $tgt[0].selectionStart = caretPos - posInWord;
       $tgt[0].selectionEnd = (caretPos - posInWord) + currentWord.length;
-      QPixel.replaceSelection($tgt, `post_type:${id}`);
+      QPixel.MD.replaceSelection($tgt, `post_type:${id}`);
       popup.destroy();
       $tgt.focus();
     };

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -1,4 +1,4 @@
-<div class="grid--cell is-4-lg is-12" role="complementary">
+<div class="grid--cell is-4-lg is-12 js-sidebar" role="complementary">
   <%= yield(:sidebar) %>
 
   <% notice_text = SiteSetting['SidebarNoticeText'] %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -4,7 +4,7 @@
   <% notice_text = SiteSetting['SidebarNoticeText'] %>
   <% if notice_text.present? %>
     <% cache SiteSetting.find_by(name: 'SidebarNoticeText') do %>
-      <div class="widget has-margin-4 is-yellow">
+      <div class="widget has-margin-4 is-yellow js-sidebar-notice">
         <div class="widget--body">
           <%= raw(sanitize(render_markdown(notice_text), scrubber: scrubber)) %>
         </div>

--- a/app/views/shared/_markdown_tools.html.erb
+++ b/app/views/shared/_markdown_tools.html.erb
@@ -16,7 +16,7 @@
         <input type="text" id="markdown-link-url" class="form-element" />
       </div>
 
-      <button type="submit" class="js-markdown-insert-link button is-filled">Insert</button>
+      <button type="button" class="js-markdown-insert-link button is-filled">Insert</button>
     </div>
   </div>
 </div>

--- a/global.d.ts
+++ b/global.d.ts
@@ -97,7 +97,13 @@ interface QPixelMD {
    * @param start text to insert at selection start
    * @param end text to insert at selection end, if any
    */
-   insertIntoField($field: JQuery<HTMLInputElement | HTMLTextAreaElement>, start: string, end?: string | null): void;
+  insertIntoField($field: JQuery<HTMLInputElement | HTMLTextAreaElement>, start: string, end?: string | null): void;
+  /**
+   * Replace the selected text in an input field with a provided replacement.
+   * @param $field the field in which to replace text
+   * @param text the text with which to replace the selection
+   */
+  replaceSelection($field: JQuery<HTMLInputElement | HTMLTextAreaElement>, text: string): void;
    /**
     * Inserts text at a given {@link idx} in a given {@link str}
     * @param str text to insert into
@@ -482,12 +488,6 @@ interface QPixel {
    */
   preference?: (name: string, community?: boolean) => Promise<string>;
 
-  /**
-   * Replace the selected text in an input field with a provided replacement.
-   * @param $field the field in which to replace text
-   * @param text the text with which to replace the selection
-   */
-  replaceSelection?: ($field: JQuery<HTMLInputElement | HTMLTextAreaElement>, text: string) => void;
   setFilter?: (name: string, filter: QPixelFilter, category: string, isDefault: boolean) => Promise<void>;
 
   /**

--- a/global.d.ts
+++ b/global.d.ts
@@ -91,6 +91,13 @@ interface StripMarkdownOptions {
 }
 
 interface QPixelMD {
+  /**
+   * Inserts text around a given {@link $field}'s selection
+   * @param $field field to insert text into
+   * @param start text to insert at selection start
+   * @param end text to insert at selection end, if any
+   */
+   insertIntoField($field: JQuery<HTMLInputElement | HTMLTextAreaElement>, start: string, end?: string | null): void;
    /**
     * Inserts text at a given {@link idx} in a given {@link str}
     * @param str text to insert into

--- a/global.d.ts
+++ b/global.d.ts
@@ -702,6 +702,10 @@ declare var hljs: any;
 declare var MathJax: any;
 // DOMPurify lib, TODO: types
 declare var DOMPurify: any;
+// Sefaria Linker (no known types)
+declare var sefaria: {
+  link: () => void
+} | undefined;
 declare var QPixel: QPixel;
 
 declare var getCaretCoordinates: (

--- a/global.d.ts
+++ b/global.d.ts
@@ -702,9 +702,21 @@ declare var hljs: any;
 declare var MathJax: any;
 // DOMPurify lib, TODO: types
 declare var DOMPurify: any;
-// Sefaria Linker (no known types)
+// Sefaria Linker (no known types), see https://developers.sefaria.org/docs/linker-v2
 declare var sefaria: {
-  link: () => void
+  link: (options?: {
+    contentLang?: 'bilingual' | 'english' | 'hebrew',
+    dynamic?: boolean,
+    excludeFromLinking?: string,
+    excludeFromTracking?: string,
+    hidePopupsOnMobile?: boolean,
+    interfaceLang?: 'english' | 'hebrew',
+    mode?: 'link' | 'popup-click',
+    parenthesesOnly?: boolean,
+    popupStyles?: Record<string, string>,
+    selector?: string,
+    quotationOnly?: boolean
+  }) => void
 } | undefined;
 declare var QPixel: QPixel;
 

--- a/global.d.ts
+++ b/global.d.ts
@@ -91,6 +91,13 @@ interface StripMarkdownOptions {
 }
 
 interface QPixelMD {
+   /**
+    * Inserts text at a given {@link idx} in a given {@link str}
+    * @param str text to insert into
+    * @param idx position to insert at
+    * @param insert text to insert
+    */
+  stringInsert(str: string, idx: number, insert: string): string;
   /**
    * See [strip_markdown](app/helpers/application_helper.rb) application helper
    */

--- a/global.d.ts
+++ b/global.d.ts
@@ -62,7 +62,7 @@ interface QPixelDOM {
    * Checks common modifier states on a given keyboard event
    * @param event 
    */
-  getModifierState: (event: KeyboardEvent | MouseEvent | JQuery.KeyboardEventBase) => boolean;
+  getModifierState?: (event: KeyboardEvent | MouseEvent | JQuery.KeyboardEventBase) => boolean;
   /**
    * Is a given event target an HTMLElement?
    * @param target event target to check
@@ -97,24 +97,24 @@ interface QPixelMD {
    * @param start text to insert at selection start
    * @param end text to insert at selection end, if any
    */
-  insertIntoField($field: JQuery<HTMLInputElement | HTMLTextAreaElement>, start: string, end?: string | null): void;
+  insertIntoField?: ($field: JQuery<HTMLInputElement | HTMLTextAreaElement>, start: string, end?: string | null) => void;
   /**
    * Replace the selected text in an input field with a provided replacement.
    * @param $field the field in which to replace text
    * @param text the text with which to replace the selection
    */
-  replaceSelection($field: JQuery<HTMLInputElement | HTMLTextAreaElement>, text: string): void;
+  replaceSelection?: ($field: JQuery<HTMLInputElement | HTMLTextAreaElement>, text: string) => void;
    /**
     * Inserts text at a given {@link idx} in a given {@link str}
     * @param str text to insert into
     * @param idx position to insert at
     * @param insert text to insert
     */
-  stringInsert(str: string, idx: number, insert: string): string;
+  stringInsert?: (str: string, idx: number, insert: string) => string;
   /**
    * See [strip_markdown](app/helpers/application_helper.rb) application helper
    */
-  stripMarkdown(content: string, options?: StripMarkdownOptions): string;
+  stripMarkdown?: (content: string, options?: StripMarkdownOptions) => string;
 }
 
 interface QPixelStorageGetOptions {

--- a/public/assets/community/codegolf.js
+++ b/public/assets/community/codegolf.js
@@ -15,6 +15,7 @@
  *   variant?: string
  *   extensions?: string
  *   code?: string
+ *   placement?: number
  *   score?: number
  * }} ChallengeEntry
  * 
@@ -31,6 +32,10 @@
   }
 
   const CHALLENGE_ID = match[0];
+
+  /**
+   * @type {ChallengeEntry[] | undefined}
+   */
   let leaderboard;
 
   /**
@@ -53,14 +58,13 @@
       return this._get('groupByLanguage');
     },
     set groupByLanguage(value) {
-      return this._set('groupByLanguage', value);
+      this._set('groupByLanguage', value);
     },
-
     get showPlacements() {
       return this._get('showPlacements');
     },
     set showPlacements(value) {
-      return this._set('showPlacements', value);
+      this._set('showPlacements', value);
     },
 
     _get(name) {
@@ -92,7 +96,7 @@
     const doc = dom_parser.parseFromString(text.toString(), 'text/html');
 
     const pagination = doc.querySelector('.pagination');
-    const num_pages = pagination ? parseInt(pagination.querySelector('.next').previousElementSibling.innerText) : 1;
+    const num_pages = pagination ? parseInt(pagination.querySelector('.next').previousElementSibling.textContent) : 1;
 
     const pagePromises = [];
     for (let i = 1; i <= num_pages; i++) {
@@ -111,13 +115,15 @@
       for (const answerPost of non_deleted_answers) {
         /** @type {HTMLElement | null} */
         const header = answerPost.querySelector('h1, h2, h3');
-        const code = header?.parentElement.querySelector(':scope > pre > code');
+        /** @type {HTMLElement | null} */
+        const codeEl = header?.parentElement.querySelector(':scope > pre > code');
         const full_language = header?.innerText.split(',')[0].trim();
         const regexGroups = full_language?.match(/(?<language>.+?)(?: \((?<variant>.+)\))?(?: \+ (?<extensions>.+))?$/)?.groups ?? {};
         const { language, variant, extensions } = regexGroups;
-        const userlink = answerPost.querySelector(
-          ".user-card--content .user-card--link",
-        );
+        /** @type {HTMLAnchorElement | null} */
+        const userlinkEl = answerPost.querySelector(".user-card--content .user-card--link");
+        /** @type {HTMLAnchorElement | null} */
+        const answerLinkEl = answerPost.querySelector('.js-permalink');
 
         // https://regex101.com/r/BjIjk5/2
         const matchedScore = header?.innerText.match(/\d+(?:\.\d+)?/g)?.pop();
@@ -125,15 +131,15 @@
         /** @type {ChallengeEntry} */
         const entry = {
           answerID: answerPost.id,
-          answerURL: answerPost.querySelector('.js-permalink').href,
+          answerURL: answerLinkEl?.href,
           page: i + 1, // +1 because pages are 1-indexed while arrays are 0-indexed
-          username: userlink?.firstChild?.data?.trim() || 'deleted user',
-          userid: userlink?.href?.match(/\d+/)?.[0] || '',
+          username: userlinkEl?.firstChild?.textContent?.trim() || 'deleted user',
+          userid: userlinkEl?.href?.match(/\d+/)?.[0] || '',
           full_language,
           language,
           variant,
           extensions,
-          code: code?.innerText,
+          code: codeEl?.innerText,
           score: isFinite(+matchedScore) ? +matchedScore : void 0
         };
 
@@ -192,6 +198,7 @@
   <div id="toc-rows"></div>
 </div>`;
 
+  /** @type {HTMLElement | null} */
   const leaderboardsTable = embed.querySelector('#toc-rows');
   const toggle = embed.querySelector('#leaderboards-header');
   toggle.addEventListener('click', (_) => { 
@@ -202,7 +209,10 @@
       leaderboardsTable.style.display = 'none';
     }
   });
+
+  /** @type {HTMLInputElement | null} */
   const groupByLanguageInput = embed.querySelector('#group-by-lang');
+  /** @type {HTMLInputElement | null} */
   const showPlacementsInput = embed.querySelector('#show-placement');
 
   groupByLanguageInput.addEventListener('click', (_) => {
@@ -237,6 +247,7 @@
    * @returns {Record<string, T[]>}
    */
   function createGroups(array, categorizer) {
+    /** @type {Record<string, T[]>} */
     const groups = {};
 
     for (const item of array) {
@@ -267,13 +278,19 @@
       : (settings.showPlacements ? `<div class="toc--badge"><span class="badge is-tag">#${answer.placement}</span></div>` : '')}
     <div class="toc--badge"><span class="language-badge badge is-tag is-blue"></span></div>`;
 
-    row.querySelector('.username').innerText = answer.username
-    row.querySelector('.language-badge').innerText = answer.full_language ?? 'N/A';
+    /** @type {HTMLElement | null} */
+    const usernameEl = row.querySelector('.username');
+    /** @type {HTMLElement | null} */
+    const langBadgeEl = row.querySelector('.language-badge');
+
+    usernameEl.innerText = answer.username;
+    langBadgeEl.innerText = answer.full_language ?? 'N/A';
+
     if (answer.code) {
-      row.querySelector('.username').after(document.createElement('code'));
+      usernameEl.after(document.createElement('code'));
       row.querySelector('code').innerText = answer.code.split('\n')[0].substring(0, 200);
     } else if (answer.code !== '') {
-      row.querySelector('.username').insertAdjacentHTML('afterend', '<em>Invalid entry format</em>');
+      usernameEl.insertAdjacentHTML('afterend', '<em>Invalid entry format</em>');
     }
 
     return row;
@@ -313,19 +330,23 @@
   }
 
   window.addEventListener("DOMContentLoaded", (_) => {
-    const categoryName = document.querySelector(".category-header--name").innerText.trim();
+    /** @type {HTMLElement | null} */
+    const categoryNameEl = document.querySelector(".category-header--name");
+
+    const categoryName = categoryNameEl.innerText.trim();
 
     if (categoryName !== 'Challenges') {
       return;
     }
 
-    const question_tags = [
-      ...document.querySelector(".post--tags").children,
-    ].map((el) => el.innerText);
+    /** @type {NodeListOf<HTMLElement>} */
+    const questionTagsElements = document.querySelectorAll(".post--tags > a");
+
+    const questionTags = [...questionTagsElements].map((el) => el.innerText);
 
     if (
-      question_tags.includes("code-golf") ||
-      question_tags.includes("lowest-score")
+      questionTags.includes("code-golf") ||
+      questionTags.includes("lowest-score")
     ) {
       // If x were undefined, it would be automatically sorted to the end, but not so if x.score is undefined, so this needs to be stated explicitly.
       sort = (x, y) => typeof x.score === "undefined" ? 1 : x.score - y.score;
@@ -334,8 +355,8 @@
 
       refreshBoard(sort);
     } else if (
-      question_tags.includes("code-bowling") ||
-      question_tags.includes("highest-score")
+      questionTags.includes("code-bowling") ||
+      questionTags.includes("highest-score")
     ) {
       // If x were undefined, it would be automatically sorted to the end, but not so if x.score is undefined, so this needs to be stated explicitly.
       sort = (x, y) => typeof x.score === "undefined" ? 1 : y.score - x.score;

--- a/public/assets/community/judaism.js
+++ b/public/assets/community/judaism.js
@@ -266,13 +266,19 @@ THE SOFTWARE.
 
 
 $(() => {
+  const link = () => {
+    sefaria.link({
+      excludeFromLinking: '.js-post-field',
+    });
+  };
+
   const el = document.createElement('script');
   el.src = 'https://www.sefaria.org/linker.js';
   el.addEventListener('load', () => {
-    sefaria.link();
+    link();
 
     $(document).on('ajax:success', '.post--comments', () => {
-      sefaria.link();
+      link();
     });
 
     let linkTimeout = null;
@@ -283,7 +289,7 @@ $(() => {
       }
 
       linkTimeout = setTimeout(() => {
-        sefaria.link();
+        link();
       }, 1000);
     });
   });

--- a/public/assets/community/judaism.js
+++ b/public/assets/community/judaism.js
@@ -359,7 +359,13 @@ window.addEventListener("load", async () => {
   container.classList.add('widget', 'has-margin-4');
 
   const disclaimerNotice = document.querySelector('.js-sidebar-notice');
-  disclaimerNotice?.parentNode?.insertBefore(container, disclaimerNotice.nextSibling);
+  const sidebar = document.querySelector('.js-sidebar');
+
+  if (disclaimerNotice) {
+    disclaimerNotice.insertAdjacentElement('afterend', container);
+  } else {
+    sidebar?.prepend(container);
+  }
 
   let todayDate = new Date();
 

--- a/public/assets/community/judaism.js
+++ b/public/assets/community/judaism.js
@@ -38,6 +38,7 @@ THE SOFTWARE.
     },
   };
 
+  /** @type {JQuery<HTMLTextAreaElement | HTMLInputElement>} */
   var currentTextfield = $('textarea, input[type=text]');
   $(document).ready(function(){
     $(document).on('focus', 'textarea, input[type=text]', function(){
@@ -150,7 +151,7 @@ THE SOFTWARE.
 
     /* Event handling for buttons and checkboxes*/
     kb.find('.hbkey').click(function () {
-      t = currentTextfield[0];
+      var t = currentTextfield[0];
       var start = t.selectionStart,
         end = t.selectionEnd,
         text = t.value,
@@ -164,7 +165,7 @@ THE SOFTWARE.
     });
 
     kb.find('.hbins').click(function () {
-      t = currentTextfield[0];
+      var t = currentTextfield[0];
       var start = t.selectionStart,
         end = t.selectionEnd,
         text = t.value,
@@ -303,6 +304,7 @@ $(() => {
   const doReplacement = (ev) => {
     ev.preventDefault();
 
+    /** @type {JQuery<HTMLInputElement | HTMLTextAreaElement>} */
     const $field = $('.js-post-field');
     const $tgt = $(ev.target);
     const text = $tgt.attr('data-text');
@@ -318,6 +320,7 @@ $(() => {
   };
 
   QPixel.addEditorButton(`<i class="fas fa-torah"></i>`, 'Suggest Reference', async () => {
+    /** @type {JQuery<HTMLInputElement | HTMLTextAreaElement>} */
     const $field = $('.js-post-field');
     const selection = $field.val().substring($field[0].selectionStart, $field[0].selectionEnd) || '';
     if (!selection) {

--- a/public/assets/community/judaism.js
+++ b/public/assets/community/judaism.js
@@ -358,8 +358,8 @@ window.addEventListener("load", async () => {
   container.innerHTML = "<div class='widget--body'><div class='_cal_label'>Today is:</div><div class='_cal_val'>loading date...</div></div>";
   container.classList.add('widget', 'has-margin-4');
 
-  const disclaimerNotice = document.querySelector('.widget.is-yellow:first-child');
-  disclaimerNotice.parentNode.insertBefore(container, disclaimerNotice.nextSibling);
+  const disclaimerNotice = document.querySelector('.js-sidebar-notice');
+  disclaimerNotice?.parentNode?.insertBefore(container, disclaimerNotice.nextSibling);
 
   let todayDate = new Date();
 

--- a/public/assets/community/judaism.js
+++ b/public/assets/community/judaism.js
@@ -306,7 +306,7 @@ $(() => {
     const $field = $('.js-post-field');
     const $tgt = $(ev.target);
     const text = $tgt.attr('data-text');
-    QPixel.replaceSelection($field, text);
+    QPixel.MD.replaceSelection($field, text);
     $field.trigger('markdown');
   };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "target": "ES2021",
     "types": ["./global.d.ts", "@types/jquery", "@types/select2"]
   },
-  "include": ["./app/assets/javascripts"],
+  "include": ["./app/assets/javascripts", "./public/assets/community"],
   "exclude": [
     "config",
     "db",
@@ -17,7 +17,6 @@
     "img",
     "lib",
     "log",
-    "public",
     "scripts",
     "static",
     "test",


### PR DESCRIPTION
closes #1058

The PR also:
- enables TypeScript checks for our community assets (and fixes remaining type-related errors in them);
- moves remaining markdown-related helpers to our `QPixel.MD` common API global object;
- fixes runtime error when using the `judasim.js` community asset without the sidebar notice setting filled in;
- fixes Sefaria Linker clobbering post source in edit mode (it links every occurrence of the source text by default);

Since the PR touches upon community assets, DO NOT MERGE until both @trichoplax and @cellio approve (that is, unless you check that those assets work fine with changes yourself).