### PR TITLE
Explicitly require the :post parameter to be present when attempting to create a post

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -36,15 +36,23 @@ class PostsController < ApplicationController
   end
 
   def create
+    submitted = params[:post]
+
+    unless submitted.present?
+      flash[:danger] = helpers.i18ns('posts.create_requires_post')
+      redirect_back fallback_location: root_path
+      return
+    end
+
     @parent = Post.where(id: params[:parent]).first
     @post_type = if @parent.present? && @parent.post_type.answer_type.present?
                    @parent.post_type.answer_type
                  else
-                   PostType.find(params[:post][:post_type_id])
+                   PostType.find(submitted[:post_type_id])
                  end
     @category = if @post_type.has_category
-                  if params[:post][:category_id].present?
-                    Category.find(params[:post][:category_id])
+                  if submitted[:category_id].present?
+                    Category.find(submitted[:category_id])
                   elsif @parent.present?
                     @parent.category
                   end

--- a/config/locales/strings/en.posts.yml
+++ b/config/locales/strings/en.posts.yml
@@ -1,6 +1,8 @@
 en:
   posts:
     #alert/notice
+    create_requires_post: >
+      Can't create a post without content. Please try again later or contact us.
     category_low_trust_level: >
       You don't have a high enough trust level to post in the :name category.
     type_requires_category: >

--- a/test/controllers/posts/create_test.rb
+++ b/test/controllers/posts/create_test.rb
@@ -31,6 +31,20 @@ class PostsControllerTest < ActionController::TestCase
     assert_redirected_to_sign_in
   end
 
+  test 'create requires post' do
+    sign_in users(:standard_user)
+
+    post :create, params: {
+      category: categories(:main).id,
+      post_type: post_types(:question).id
+    }
+
+    assert_response(:found)
+    assert_redirected_to root_path
+    assert_not_nil flash[:danger]
+    assert_nil assigns(:post)
+  end
+
   test 'can create help post' do
     sign_in users(:moderator)
 


### PR DESCRIPTION
closes #1891

The error is likely not reproducible outside of very specific circumstances, but it doesn't mean we shouldn't gracefully handle it instead of outright failing with a server error 500:

<img width="768" height="411" alt="Screenshot from 2026-01-11 03-41-49" src="https://github.com/user-attachments/assets/e58efe35-36dc-4afd-90ed-1c8d061719a1" />

Repro is handled by the added test case, so the only part to test here manually if one wants to do that is that normal post creation still works.
