### PR TITLE
Judaism community JS asset cleanup

### DIFF
--- a/public/assets/community/judaism.js
+++ b/public/assets/community/judaism.js
@@ -54,8 +54,8 @@ THE SOFTWARE.
 
   /** @type {JQuery<HTMLTextAreaElement | HTMLInputElement>} */
   let currentTextfield = $('textarea, input[type=text]');
-  $(document).ready(function(){
-    $(document).on('focus', 'textarea, input[type=text]', function(){
+  $(document).ready(function () {
+    $(document).on('focus', 'textarea, input[type=text]', function () {
       currentTextfield = $(this);
     });
 
@@ -87,11 +87,11 @@ THE SOFTWARE.
 
   function createKeyboard() {
     const stand = "קראטוןםפשדגכעיחלךףזסבהנמצתץ",
-      alpha = "חזוהדגבאסןנםמלךכיטתשרקץצףפע",
-      nek = ["שׁ", "שׂ", "וְ", "וֱ", "וֲ", "וֳ", "וִ", "וֵ", "וֶ", "וַ", "וָ", "וֹ", "וֻ", "וּ"],
-      x = 50,
-      y = 50,
-      kb = $('<div class="hbkeyboard"></div>').appendTo($("body"));
+          alpha = "חזוהדגבאסןנםמלךכיטתשרקץצףפע",
+          nek = ["שׁ", "שׂ", "וְ", "וֱ", "וֲ", "וֳ", "וִ", "וֵ", "וֶ", "וַ", "וָ", "וֹ", "וֻ", "וּ"],
+          x = 50,
+          y = 50,
+          kb = $('<div class="hbkeyboard"></div>').appendTo($("body"));
 
     $.each(alpha.split('').concat(nek), function (i, letter) {
       kb.append('<button type="button" class="hbkey" data-t="' + letter.slice(-1) + '">' + letter + '</button>');
@@ -225,7 +225,7 @@ THE SOFTWARE.
       kb.fadeToggle('medium');
     });
 
-    $('#keylayout').change(function(){
+    $('#keylayout').change(function () {
       const layout = $(this).prop('checked') ? stand : alpha;
       $('.hbkey').slice(0, 27).each(function (index) {
         $(this).data('t', layout[index]).text(layout[index]);
@@ -242,8 +242,6 @@ THE SOFTWARE.
     return kb;
   }
 
-
-
   //Draggability
   const drag = {
       elem: null,
@@ -255,6 +253,7 @@ THE SOFTWARE.
       x: 0,
       y: 0
     };
+
   $(document).on('mousedown', '.hbkeyboard', function (e) {
     if (!drag.state) {
       drag.elem = this;
@@ -262,8 +261,10 @@ THE SOFTWARE.
       drag.y = e.pageY;
       drag.state = true;
     }
+
     return false;
   });
+
   $(document).mousemove(function (e) {
     if (drag.state) {
       delta.x = e.pageX - drag.x;
@@ -279,6 +280,7 @@ THE SOFTWARE.
       drag.y = e.pageY;
     }
   });
+
   $(document).mouseup(function () {
     drag.state && (drag.state = false);
   });
@@ -316,6 +318,7 @@ $(() => {
       }, 1000);
     });
   });
+
   document.body.appendChild(el);
 });
 
@@ -324,12 +327,19 @@ $(() => {
 
 
 $(() => {
+  /**
+   * @param {string} term
+   * @returns {Promise<string[]>}
+   */
   const getSuggestions = async (term) => {
     const resp = await fetch(`https://sefaria.org/api/name/${term}`);
     const data = await resp.json();
     return data.completions;
   };
 
+  /**
+   * @param {JQuery.ClickEvent} ev
+   */
   const doReplacement = (ev) => {
     ev.preventDefault();
 
@@ -341,6 +351,9 @@ $(() => {
     $field.trigger('markdown');
   };
 
+  /**
+   * @param {string[]} suggestions
+   */
   const createPopup = (suggestions) => {
     const $itemTemplate = $(`<a class="item" href="#"></a>`);
     return suggestions.map((s) => {
@@ -363,26 +376,32 @@ $(() => {
   });
 });
 
+
 // ============================================================================================== //
-/** 
+
+
+/**
  * Calendar script, added 2021-04-01 by @luap42
  */
 
-  // Use *local* time for ISO string (Date.toISOString() uses UTC).
-  // We only need the date here, so punting on time.
-  function toIsoDate(date) {
-  /**
-   * @param {number} num
-   * @returns {string}
-   */
-  const pad = function(num) {
-          const norm = Math.floor(Math.abs(num));
-          return (norm < 10 ? '0' : '') + norm;
-      };
+/**
+ * @param {number} num
+ * @returns {string}
+ */
+const pad = (num) => {
+  const norm = Math.floor(Math.abs(num));
+  return (norm < 10 ? '0' : '') + norm;
+};
 
+/**
+ * Use *local* time when converting to ISO string (Date.toISOString() uses UTC).
+ * @param {Date} date
+ * @returns {string}
+ */
+const toIsoDate = (date) => {
   return date.getFullYear() +
-      '-' + pad(date.getMonth() + 1) +
-      '-' + pad(date.getDate());
+    '-' + pad(date.getMonth() + 1) +
+    '-' + pad(date.getDate());
 }
 
 

--- a/public/assets/community/judaism.js
+++ b/public/assets/community/judaism.js
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 (function HBKeyboard() {
   // see https://developer.mozilla.org/en-US/docs/Web/API/document.cookie
-  var docCookies = {
+  const docCookies = {
     /**
      * @param {string} sKey
      * @returns {string | null}
@@ -53,21 +53,23 @@ THE SOFTWARE.
   };
 
   /** @type {JQuery<HTMLTextAreaElement | HTMLInputElement>} */
-  var currentTextfield = $('textarea, input[type=text]');
+  let currentTextfield = $('textarea, input[type=text]');
   $(document).ready(function(){
     $(document).on('focus', 'textarea, input[type=text]', function(){
       currentTextfield = $(this);
     });
 
-    var wh = $(window).height(),
-      ww = $(window).width(),
-      kb = createKeyboard().hide();
+    let wh = $(window).height(),
+        ww = $(window).width(),
+        kb = createKeyboard().hide();
+
     $('#hbk-toggle span').css({
       'padding': '3px',
       'text-align': 'center',
       'background-image': "none",
       'font-weight':'bolder'
     });
+
     $(window).resize(function(){
       kb.css({
         top: '+=' + ($(window).height() - wh) + 'px',
@@ -84,7 +86,7 @@ THE SOFTWARE.
   });
 
   function createKeyboard() {
-    var stand = "קראטוןםפשדגכעיחלךףזסבהנמצתץ",
+    const stand = "קראטוןםפשדגכעיחלךףזסבהנמצתץ",
       alpha = "חזוהדגבאסןנםמלךכיטתשרקץצףפע",
       nek = ["שׁ", "שׂ", "וְ", "וֱ", "וֲ", "וֳ", "וִ", "וֵ", "וֶ", "וַ", "וָ", "וֹ", "וֻ", "וּ"],
       x = 50,
@@ -165,27 +167,34 @@ THE SOFTWARE.
 
     /* Event handling for buttons and checkboxes*/
     kb.find('.hbkey').click(function () {
-      var t = currentTextfield[0];
-      var start = t.selectionStart,
-        end = t.selectionEnd,
-        text = t.value,
-        chr = $(this).data('t');
+      const t = currentTextfield[0];
+
+      const start = t.selectionStart,
+            end = t.selectionEnd,
+            text = t.value;
+
+      let chr = $(this).data('t');
 
       if (chr === '‏' && $('#rlm').is(':checked') && t.id !== 'input') chr = '&rlm;';//special case for rlm.
-      var res = text.slice(0, start) + chr + text.slice(end),
-        len = chr.length;
+
+      const res = text.slice(0, start) + chr + text.slice(end),
+            len = chr.length;
+
       $(t).val(res).trigger('input').focus();
       t.setSelectionRange(start + len, start + len);
     });
 
     kb.find('.hbins').click(function () {
-      var t = currentTextfield[0];
-      var start = t.selectionStart,
-        end = t.selectionEnd,
-        text = t.value,
-        chr = $(this).data('t');
-      var res = text.slice(0, start) + chr + text.slice(end),
-        len = chr.length;
+      const t = currentTextfield[0];
+
+      const start = t.selectionStart,
+            end = t.selectionEnd,
+            text = t.value,
+            chr = $(this).data('t');
+
+      const res = text.slice(0, start) + chr + text.slice(end),
+            len = chr.length;
+
       $(t).val(res).trigger('input').focus();
       t.setSelectionRange(start + len, start + len);
     });
@@ -217,7 +226,7 @@ THE SOFTWARE.
     });
 
     $('#keylayout').change(function(){
-      var layout = $(this).prop('checked') ? stand : alpha;
+      const layout = $(this).prop('checked') ? stand : alpha;
       $('.hbkey').slice(0, 27).each(function (index) {
         $(this).data('t', layout[index]).text(layout[index]);
       });
@@ -236,7 +245,7 @@ THE SOFTWARE.
 
 
   //Draggability
-  var drag = {
+  const drag = {
       elem: null,
       x: 0,
       y: 0,
@@ -259,7 +268,7 @@ THE SOFTWARE.
     if (drag.state) {
       delta.x = e.pageX - drag.x;
       delta.y = e.pageY - drag.y;
-      var cur_offset = $(drag.elem).offset();
+      const cur_offset = $(drag.elem).offset();
 
       $(drag.elem).offset({
         left: (cur_offset.left + delta.x),
@@ -362,8 +371,12 @@ $(() => {
   // Use *local* time for ISO string (Date.toISOString() uses UTC).
   // We only need the date here, so punting on time.
   function toIsoDate(date) {
-  var pad = function(num) {
-          var norm = Math.floor(Math.abs(num));
+  /**
+   * @param {number} num
+   * @returns {string}
+   */
+  const pad = function(num) {
+          const norm = Math.floor(Math.abs(num));
           return (norm < 10 ? '0' : '') + norm;
       };
 

--- a/public/assets/community/judaism.js
+++ b/public/assets/community/judaism.js
@@ -40,7 +40,7 @@ THE SOFTWARE.
       if (!sKey || /^(?:expires|max\-age|path|domain|secure)$/i.test(sKey)) {
         return false;
       }
-      document.cookie = escape(sKey) + "=" + escape(sValue) + "; expires=Fri, 31 Dec 9999 23:59:59 GMT; domain=stackexchange.com; path=/";
+      document.cookie = `${escape(sKey)}=${escape(sValue)}; expires=Fri, 31 Dec 9999 23:59:59 GMT; domain=${location.hostname}; path=/`;
       return true;
     },
     /**

--- a/public/assets/community/judaism.js
+++ b/public/assets/community/judaism.js
@@ -22,10 +22,20 @@ THE SOFTWARE.
 // Thanks to all who've helped debug and discuss, especially the Mac users, nebech.
 
 (function HBKeyboard() {
-  var docCookies = { //from developer.mozilla.org/en-US/docs/Web/API/document.cookie
+  // see https://developer.mozilla.org/en-US/docs/Web/API/document.cookie
+  var docCookies = {
+    /**
+     * @param {string} sKey
+     * @returns {string | null}
+     */
     getItem: function (sKey) {
       return unescape(document.cookie.replace(new RegExp("(?:(?:^|.*;)\\s*" + escape(sKey).replace(/[\-\.\+\*]/g, "\\$&") + "\\s*\\=\\s*([^;]*).*$)|^.*$"), "$1")) || null;
     },
+    /**
+     * @param {string} sKey
+     * @param {string} sValue
+     * @returns {boolean}
+     */
     setItem: function (sKey, sValue) {
       if (!sKey || /^(?:expires|max\-age|path|domain|secure)$/i.test(sKey)) {
         return false;
@@ -33,6 +43,10 @@ THE SOFTWARE.
       document.cookie = escape(sKey) + "=" + escape(sValue) + "; expires=Fri, 31 Dec 9999 23:59:59 GMT; domain=stackexchange.com; path=/";
       return true;
     },
+    /**
+     * @param {string} sKey
+     * @returns {boolean}
+     */
     hasItem: function (sKey) {
       return (new RegExp("(?:^|;\\s*)" + escape(sKey).replace(/[\-\.\+\*]/g, "\\$&") + "\\s*\\=")).test(document.cookie);
     },


### PR DESCRIPTION
closes #1942 

This is a minor PR that replaces all instances of `var` declarations with `const` / `let`, improves JSDoc for most of the functions in the script + ensures we don't redefine `pad` shim on every call to `toIsoDate`. No "real" changes - to test, just confirm that the expected functionality is not broken.

Also fixes the Hebrew keyboard's settings as it used to try to set cookies for the `stackexchange.com` domain, which we obviously cannot (and should not) do:

<img width="590" height="292" alt="2026-01-20_21-53" src="https://github.com/user-attachments/assets/e6a3c66d-1b07-41ca-bc68-9a5d2711797e" />
