### PR TITLE
Minor suspension notice fix

### DIFF
--- a/app/views/users/notices/_suspension.html.erb
+++ b/app/views/users/notices/_suspension.html.erb
@@ -1,0 +1,17 @@
+<%#
+   "Renders suspension notice for a given user
+
+    Variables:
+      user: User to show the notice for
+"%>
+
+<div class="notice is-danger h-m-b-4">
+  <p>
+    <% if user.community_user.suspension_public_comment.blank? %>
+      This user has been <strong>temporarily suspended</strong>.
+    <% else %>
+      This user has been <strong>temporarily suspended</strong> <%= user.community_user.suspension_public_comment %>.
+    <% end %>
+
+    The suspension ends <span title="<%= user.community_user.suspension_end.iso8601 %>">in <%= time_ago_in_words(user.community_user.suspension_end) %></span>.</p>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,7 +10,7 @@
 
 <% if @user.community_user.suspended? %>
   <div class="notice is-danger h-m-b-4">
-  <% if @user.community_user.suspension_public_comment.nil? %>
+  <% if @user.community_user.suspension_public_comment.blank? %>
     <p>This user has been <strong>temporarily suspended</strong>.
   <% else %>
     <p>This user has been <strong>temporarily suspended</strong> <%= @user.community_user.suspension_public_comment %>.

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,15 +9,7 @@
 <h1><span dir="ltr"><%= rtl_safe_username(@user) %></span></h1>
 
 <% if @user.community_user.suspended? %>
-  <div class="notice is-danger h-m-b-4">
-  <% if @user.community_user.suspension_public_comment.blank? %>
-    <p>This user has been <strong>temporarily suspended</strong>.
-  <% else %>
-    <p>This user has been <strong>temporarily suspended</strong> <%= @user.community_user.suspension_public_comment %>.
-  <% end %>
-
-    The suspension ends <span title="<%= @user.community_user.suspension_end.iso8601 %>">in <%= time_ago_in_words(@user.community_user.suspension_end) %></span>.</p>
-  </div>
+  <%= render 'users/notices/suspension', user: @user %>
 <% end %>
 
 <% is_me = @user.same_as?(current_user) %>


### PR DESCRIPTION
closes #1940 

This PR fixes extra whitespace appearing in a suspended user's notice if no public reason is provided. Also adds a proper partial for the notice as I don't like PRs that take longer to describe than actually make.

<img width="1154" height="127" alt="Screenshot from 2026-01-20 04-09-08" src="https://github.com/user-attachments/assets/a9af7835-db9a-47b2-ab4a-e95f5a6d60dd" />

With the reason:

<img width="1154" height="127" alt="Screenshot from 2026-01-20 04-13-10" src="https://github.com/user-attachments/assets/8a2a1797-588c-42e8-8cd1-b27a70664159" />
