### PR TITLE
Keyboard shortcuts improvements

### DIFF
--- a/app/assets/javascripts/keyboard_tools.js
+++ b/app/assets/javascripts/keyboard_tools.js
@@ -160,6 +160,61 @@ document.addEventListener('DOMContentLoaded', async () => {
     );
   };
 
+  const renderGoToMenu = () => {
+    /** @type {KeyboardShortcut[]} */
+    const shortcuts = [
+      { key: 'm', text: 'Main page' },
+      { key: 'u', text: 'User list' },
+      { key: 'h', text: 'Help' },
+      { key: 'd', text: 'Dashboard' },
+      { key: 'p', text: 'Your profile page' },
+      { key: 'c', text: 'Category ...' },
+      { key: 't', text: 'Tags of category ...' },
+      { key: 'e', text: 'Suggested Edits of ...' },
+      { key: 'f', text: 'Flags (mod only)', if: QPixel.Keyboard.is_mod }
+    ];
+
+    QPixel.Keyboard.dialog(
+      'Go to ...\n' +
+      delimitShortcutsGroup(26) +
+      formatShortcuts(shortcuts, 3)
+    );
+  };
+
+  const renderToolsMenu = () => {
+    /** @type {KeyboardShortcut[]} */
+    const shortcuts = [
+      { key: 'f', text: 'Flag' },
+      { key: 'e', text: 'Edit' },
+      { key: 'c', text: 'Comment' },
+      { key: 'l', text: 'Get permalink' },
+      { key: 'h', text: 'View history' },
+      { key: 'v', text: 'Vote ...' },
+      { key: 't', text: 'Use tools', if: QPixel.Keyboard.is_mod }
+    ];
+
+    QPixel.Keyboard.dialog(
+      'Use tool ...\n' +
+      delimitShortcutsGroup(17) +
+      formatShortcuts(shortcuts, 3)
+    );
+  };
+
+  const renderToolsVoteMenu = () => {
+    /** @type {KeyboardShortcut[]} */
+    const shortcuts = [
+      { key: 'u', text: 'Up' },
+      { key: 'd', text: 'Down' },
+      { key: 'c', text: 'Close' }
+    ];
+    
+    QPixel.Keyboard.dialog(
+      'Vote ...\n' +
+      delimitShortcutsGroup(9) +
+      formatShortcuts(shortcuts, 3)
+    );
+  };
+
   /**
    * Handles the "home" keyboard state
    * @param {JQuery.KeyboardEventBase} e
@@ -179,24 +234,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         window.location.href = new_post_link;
       }
     } else if (e.key === 'g') {
-      /** @type {KeyboardShortcut[]} */
-      const shortcuts = [
-        { key: 'm', text: 'Main page' },
-        { key: 'u', text: 'User list' },
-        { key: 'h', text: 'Help' },
-        { key: 'd', text: 'Dashboard' },
-        { key: 'p', text: 'Your profile page' },
-        { key: 'c', text: 'Category ...' },
-        { key: 't', text: 'Tags of category ...' },
-        { key: 'e', text: 'Suggested Edits of ...' },
-        { key: 'f', text: 'Flags (mod only)', if: QPixel.Keyboard.is_mod }
-      ];
-
-      QPixel.Keyboard.dialog(
-        'Go to ...\n' +
-        delimitShortcutsGroup(26) +
-        formatShortcuts(shortcuts, 3)
-      );
+      renderGoToMenu();
       QPixel.Keyboard.state = 'goto';
     } else if (e.key === 'j') {
       if (QPixel.Keyboard.selectedItem == null) {
@@ -221,22 +259,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       QPixel.Keyboard.updateSelected();
 
       if (QPixel.Keyboard.selectedItemData.type === 'post') {
-        /** @type {KeyboardShortcut[]} */
-        const shortcuts = [
-          { key: 'f', text: 'Flag' },
-          { key: 'e', text: 'Edit' },
-          { key: 'c', text: 'Comment' },
-          { key: 'l', text: 'Get permalink' },
-          { key: 'h', text: 'View history' },
-          { key: 'v', text: 'Vote ...' },
-          { key: 't', text: 'Use tools', if: QPixel.Keyboard.is_mod }
-        ];
-
-        QPixel.Keyboard.dialog(
-          'Use tool ...\n' +
-          delimitShortcutsGroup(17) +
-          formatShortcuts(shortcuts, 3)
-        );
+        renderToolsMenu();
         QPixel.Keyboard.state = 'tools';
       }
     } else if (e.key === 'a') {
@@ -406,18 +429,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       cl.find('.js-flag-comment').focus();
       QPixel.Keyboard.dialogClose();
     } else if (e.key === 'v') {
-      /** @type {KeyboardShortcut[]} */
-      const shortcuts = [
-        { key: 'u', text: 'Up' },
-        { key: 'd', text: 'Down' },
-        { key: 'c', text: 'Close' }
-      ];
-
-      QPixel.Keyboard.dialog(
-        'Vote ...\n' +
-        delimitShortcutsGroup(9) +
-        formatShortcuts(shortcuts, 3)
-      );
+      renderToolsVoteMenu();
       QPixel.Keyboard.state = 'tools/vote';
     } else if (e.key === 't') {
       let cl = $(QPixel.Keyboard.selectedItem).find('a.tools--item i.fa.fa-wrench').parent();

--- a/app/assets/javascripts/keyboard_tools.js
+++ b/app/assets/javascripts/keyboard_tools.js
@@ -97,18 +97,18 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (isHelp) {
       QPixel.Keyboard.dialog(
         'Keyboard Shortcuts\n' +
-          '===========================\n' +
-          '?   Open this help\n' +
-          'esc Close this help\n' +
-          'n   New post\n' +
-          '    (in current category)\n' +
-          's   Search for something\n' +
-          'g   Go to a page...\n\n' +
-          'a   Go to answer field\n\n' +
+          '=================================\n' +
+          '?    Open this help\n' +
+          'esc  Close this help\n' +
+          'n    New post\n' +
+          '     (in current category)\n' +
+          's    Search for something\n' +
+          'g    Go to a page...\n\n' +
+          'a    Go to answer field\n\n' +
           'Selection shortcuts:\n\n' +
-          'j   Move one item down\n' +
-          'k   Move one item up\n' +
-          't  Use a tool (on selection)\n\n' +
+          'j    Move one item down\n' +
+          'k    Move one item up\n' +
+          't    Use a tool (on selection)\n\n' +
           '(Selection shortcuts will select\n' +
           'first post, if none selected)'
       );

--- a/app/assets/javascripts/keyboard_tools.js
+++ b/app/assets/javascripts/keyboard_tools.js
@@ -1,5 +1,13 @@
 window.QPixel ||= {};
 
+/**
+ * @typedef {{
+ *   key: string,
+ *   text: string,
+ *   if?: boolean
+ * }} KeyboardShortcut
+ */
+
 document.addEventListener('DOMContentLoaded', async () => {
   const userLink = $('.header--item.is-complex.is-visible-on-mobile[href^="/users/"]').attr('href');
   const preference = await QPixel.preference('keyboard_tools');
@@ -63,7 +71,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Use html, so that all prior attempts to access keyup event have priority
   $('html').on('keyup', function (e) {
-    if (e.target !== document.body) return;
+    if (e.target !== document.body) {
+      return;
+    }
+
     if (e.key === 'Escape') {
       QPixel.Keyboard.dialogClose();
     } else if (QPixel.Keyboard.state === 'home') {
@@ -84,6 +95,34 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
 
   /**
+   * @param {number} len
+   * @returns {string}
+   */
+  const delimitShortcutsGroup = (len) => {
+    return `${'='.repeat(len)}\n`;
+  };
+
+  /**
+   * @param {KeyboardShortcut} shortcut
+   * @param {number} [gap]
+   * @returns {string}
+   */
+  const formatShortcut = ({ key, text }, gap = 4) => {
+    return `${key}${' '.repeat(gap - (key.length - 1))}${text}`;
+  };
+
+  /**
+   * @param {KeyboardShortcut[]} shortcuts
+   * @param {number} [gap]
+   * @returns {string}
+   */
+  const formatShortcuts = (shortcuts, gap = 4) => {
+    return shortcuts.filter((s) => s.if === void 0 || s.if)
+                    .map((s) => formatShortcut(s, gap))
+                    .join('\n');
+  };
+
+  /**
    * Handles the "home" keyboard state
    * @param {JQuery.KeyboardEventBase} e
    */
@@ -95,22 +134,36 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     if (isHelp) {
+      /** @type {KeyboardShortcut[]} */
+      const generalShortcuts = [
+        { key: '?', text: 'Open this help' },
+        { key: 'esc', text: 'Close this help' },
+        { key: 'n', text: 'New post in the category' },
+        { key: 's', text: 'Search for something' },
+        { key: 'g', text: 'Go to ...' },
+        { key: 'a', text: 'Go to answer field' }
+      ];
+
+      /** @type {KeyboardShortcut[]} */
+      const selectionShortcuts = [
+        { key: 'j', text: 'Move one item down' },
+        { key: 'k', text: 'Move one item up' },
+        { key: 't',
+          text: 'Use a tool (on selection)',
+          if: !!QPixel.Keyboard.selectedItemData && QPixel.Keyboard.selectedItemData.type !== 'link'
+        }
+      ];
+
       QPixel.Keyboard.dialog(
         'Keyboard Shortcuts\n' +
-          '=================================\n' +
-          '?    Open this help\n' +
-          'esc  Close this help\n' +
-          'n    New post\n' +
-          '     (in current category)\n' +
-          's    Search for something\n' +
-          'g    Go to a page...\n\n' +
-          'a    Go to answer field\n\n' +
-          'Selection shortcuts:\n\n' +
-          'j    Move one item down\n' +
-          'k    Move one item up\n' +
-          't    Use a tool (on selection)\n\n' +
-          '(Selection shortcuts will select\n' +
-          'first post, if none selected)'
+        delimitShortcutsGroup(33) +
+        formatShortcuts(generalShortcuts, 4) +
+        '\n\n' +
+        'Selection shortcuts:\n\n' +
+        formatShortcuts(selectionShortcuts, 4) +
+        '\n\n' +
+        'Selection shortcuts will select\n' +
+        'first post, if none selected'
       );
     } else if (e.key === 'n') {
       const new_post_link = $('a.category-header--nav-item.is-button').attr('href');
@@ -118,18 +171,23 @@ document.addEventListener('DOMContentLoaded', async () => {
         window.location.href = new_post_link;
       }
     } else if (e.key === 'g') {
+      /** @type {KeyboardShortcut[]} */
+      const shortcuts = [
+        { key: 'm', text: 'Main page' },
+        { key: 'u', text: 'User list' },
+        { key: 'h', text: 'Help' },
+        { key: 'd', text: 'Dashboard' },
+        { key: 'p', text: 'Your profile page' },
+        { key: 'c', text: 'Category ...' },
+        { key: 't', text: 'Tags of category ...' },
+        { key: 'e', text: 'Suggested Edits of ...' },
+        { key: 'f', text: 'Flags (mod only)', if: QPixel.Keyboard.is_mod }
+      ];
+
       QPixel.Keyboard.dialog(
         'Go to ...\n' +
-          '=========\n' +
-          'm   Main page\n' +
-          'u   User list\n' +
-          'h   Help\n' +
-          'd   Dashboard\n' +
-          'p   Your profile page\n' +
-          'c   Category ...\n' +
-          't   Tags of category ...\n' +
-          'e   Suggested Edits of category ...' +
-          (QPixel.Keyboard.is_mod ? '\nf   Flags (mod only)' : '')
+        delimitShortcutsGroup(26) +
+        formatShortcuts(shortcuts, 3)
       );
       QPixel.Keyboard.state = 'goto';
     } else if (e.key === 'j') {
@@ -155,16 +213,21 @@ document.addEventListener('DOMContentLoaded', async () => {
       QPixel.Keyboard.updateSelected();
 
       if (QPixel.Keyboard.selectedItemData.type === 'post') {
+        /** @type {KeyboardShortcut[]} */
+        const shortcuts = [
+          { key: 'f', text: 'Flag' },
+          { key: 'e', text: 'Edit' },
+          { key: 'c', text: 'Comment' },
+          { key: 'l', text: 'Get permalink' },
+          { key: 'h', text: 'View history' },
+          { key: 'v', text: 'Vote ...' },
+          { key: 't', text: 'Use tools', if: QPixel.Keyboard.is_mod }
+        ];
+
         QPixel.Keyboard.dialog(
           'Use tool ...\n' +
-            '============\n' +
-            'f  Flag\n' +
-            'e  Edit\n' +
-            'c  Comment\n' +
-            'l  Get permalink\n' +
-            'h  View history\n' +
-            'v  Vote ...' +
-            (QPixel.Keyboard.is_mod ? '\nt  Use tools' : '')
+          delimitShortcutsGroup(17) +
+          formatShortcuts(shortcuts, 3)
         );
         QPixel.Keyboard.state = 'tools';
       }
@@ -181,7 +244,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   /**
-   * Handles "goto" keyboard state
+   * Handles the "goto" keyboard state
    * @param {JQuery.KeyboardEventBase} e
    */
   function gotoMenu(e) {
@@ -205,30 +268,46 @@ document.addEventListener('DOMContentLoaded', async () => {
       const data = Object.entries(QPixel.Keyboard.categories());
       let string_response = '';
       for (let i = 0; i < data.length; i++) {
-        const entry = data[i];
-        string_response += i + 1 + '  ' + entry[0] + '\n';
+        string_response += formatShortcut({
+          key: (i + 1).toString(),
+          text: data[i][0]
+        }, 3) + '\n';
       }
-      QPixel.Keyboard.dialog('Go to tags of category ...\n' + '==================\n' + string_response.trim());
+      QPixel.Keyboard.dialog(
+        'Go to tags of ...\n' +
+        delimitShortcutsGroup(18) +
+        string_response.trim()
+      );
       QPixel.Keyboard.state = 'goto/category-tags';
     } else if (e.key === 'e') {
       const data = Object.entries(QPixel.Keyboard.categories());
       let string_response = '';
       for (let i = 0; i < data.length; i++) {
-        const entry = data[i];
-        string_response += i + 1 + '  ' + entry[0] + '\n';
+        string_response += formatShortcut({
+          key: (i + 1).toString(),
+          text: data[i][0]
+        }, 3) + '\n';
       }
       QPixel.Keyboard.dialog(
-        'Go to suggested edits of category ...\n' + '==================\n' + string_response.trim()
+        'Go to suggested edits of ...\n' +
+        delimitShortcutsGroup(28) +
+        string_response.trim()
       );
       QPixel.Keyboard.state = 'goto/category-edits';
     } else if (e.key === 'c') {
       const data = Object.entries(QPixel.Keyboard.categories());
       let string_response = '';
       for (let i = 0; i < data.length; i++) {
-        const entry = data[i];
-        string_response += i + 1 + '  ' + entry[0] + '\n';
+        string_response += formatShortcut({
+          key: (i + 1).toString(),
+          text: data[i][0]
+        }, 3) + '\n';
       }
-      QPixel.Keyboard.dialog('Go to category ...\n' + '==================\n' + string_response.trim());
+      QPixel.Keyboard.dialog(
+        'Go to category ...\n' +
+        delimitShortcutsGroup(18) +
+        string_response.trim()
+      );
       QPixel.Keyboard.state = 'goto/category';
     }
   }
@@ -319,7 +398,18 @@ document.addEventListener('DOMContentLoaded', async () => {
       cl.find('.js-flag-comment').focus();
       QPixel.Keyboard.dialogClose();
     } else if (e.key === 'v') {
-      QPixel.Keyboard.dialog('Vote ...\n' + '========\n' + 'u  Up\n' + 'd  Down\n' + 'c  Close');
+      /** @type {KeyboardShortcut[]} */
+      const shortcuts = [
+        { key: 'u', text: 'Up' },
+        { key: 'd', text: 'Down' },
+        { key: 'c', text: 'Close' }
+      ];
+
+      QPixel.Keyboard.dialog(
+        'Vote ...\n' +
+        delimitShortcutsGroup(9) +
+        formatShortcuts(shortcuts, 3)
+      );
       QPixel.Keyboard.state = 'tools/vote';
     } else if (e.key === 't') {
       let cl = $(QPixel.Keyboard.selectedItem).find('a.tools--item i.fa.fa-wrench').parent();

--- a/app/assets/javascripts/keyboard_tools.js
+++ b/app/assets/javascripts/keyboard_tools.js
@@ -70,7 +70,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   };
 
   // Use html, so that all prior attempts to access keyup event have priority
-  $('html').on('keyup', function (e) {
+  $('html').on('keyup', (e) => {
     if (e.target !== document.body) {
       return;
     }
@@ -126,7 +126,7 @@ document.addEventListener('DOMContentLoaded', async () => {
    * Handles the "home" keyboard state
    * @param {JQuery.KeyboardEventBase} e
    */
-  function homeMenu(e) {
+  const homeMenu = (e) => {
     const isHelp = e.key === '?';
 
     if (!isHelp && QPixel.DOM?.getModifierState(e)) {
@@ -241,13 +241,13 @@ document.addEventListener('DOMContentLoaded', async () => {
         window.location.href = $(QPixel.Keyboard.selectedItem).find('[data-ckb-item-link]').attr('href');
       }
     }
-  }
+  };
 
   /**
    * Handles the "goto" keyboard state
    * @param {JQuery.KeyboardEventBase} e
    */
-  function gotoMenu(e) {
+  const gotoMenu = (e) => {
     if (QPixel.DOM?.getModifierState(e)) {
       return;
     }
@@ -310,13 +310,13 @@ document.addEventListener('DOMContentLoaded', async () => {
       );
       QPixel.Keyboard.state = 'goto/category';
     }
-  }
+  };
 
   /**
    * Handles the "goto/category" keyboard state
    * @param {JQuery.KeyboardEventBase} e
    */
-  function categoryMenu(e) {
+  const categoryMenu = (e) => {
     if (QPixel.DOM?.getModifierState(e)) {
       return;
     }
@@ -329,13 +329,13 @@ document.addEventListener('DOMContentLoaded', async () => {
       const category = data_entries[number - 1];
       window.location.href = category[1];
     }
-  }
+  };
 
   /**
    * Handles the "goto/category-tags" keyboard state
    * @param {JQuery.KeyboardEventBase} e
    */
-  function categoryTagsMenu(e) {
+  const categoryTagsMenu = (e) => {
     if (QPixel.DOM?.getModifierState(e)) {
       return;
     }
@@ -347,13 +347,13 @@ document.addEventListener('DOMContentLoaded', async () => {
       const category = data[number - 1];
       window.location.href = category[1] + '/tags';
     }
-  }
+  };
 
   /**
    * Handles the "goto/category-edits" keyboard state
    * @param {JQuery.KeyboardEventBase} e
    */
-  function categorySuggestedEditsMenu(e) {
+  const categorySuggestedEditsMenu = (e) => {
     if (QPixel.DOM?.getModifierState(e)) {
       return;
     }
@@ -365,13 +365,13 @@ document.addEventListener('DOMContentLoaded', async () => {
       const category = data[number - 1];
       window.location.href = category[1] + '/suggested-edits';
     }
-  }
+  };
 
   /**
    * Handles the "tools" keyboard state
    * @param {JQuery.KeyboardEventBase} e
    */
-  function toolsMenu(e) {
+  const toolsMenu = (e) => {
     if (QPixel.DOM?.getModifierState(e)) {
       return;
     }
@@ -418,13 +418,13 @@ document.addEventListener('DOMContentLoaded', async () => {
       cl.focus();
       QPixel.Keyboard.dialogClose();
     }
-  }
+  };
 
   /**
    * Handles the "tools/vote" keyboard state
    * @param {JQuery.KeyboardEventBase} e
    */
-  function voteMenu(e) {
+  const voteMenu = (e) => {
     if (QPixel.DOM?.getModifierState(e)) {
       return;
     }
@@ -444,5 +444,5 @@ document.addEventListener('DOMContentLoaded', async () => {
       cl.focus();
       QPixel.Keyboard.dialogClose();
     }
-  }
+  };
 });

--- a/app/assets/javascripts/keyboard_tools.js
+++ b/app/assets/javascripts/keyboard_tools.js
@@ -417,10 +417,21 @@ document.addEventListener('DOMContentLoaded', async () => {
     } else if (e.key === 'l') {
       window.location.href = $(QPixel.Keyboard.selectedItem).find('.tools--item i.fa.fa-link').parent().attr('href');
     } else if (e.key === 'c') {
-      const cl = $(QPixel.Keyboard.selectedItem).find('.js-add-comment');
-      cl.nextAll('form').css('display', 'block');
-      cl.nextAll('form')[0].scrollIntoView({ behavior: 'smooth' });
-      cl.nextAll('form').find('.js-comment-content').focus();
+      const selected = $(QPixel.Keyboard.selectedItem);
+
+      const $replyToThreadLink = selected.find('.js-reply-to-thread-link');
+
+      if (!$replyToThreadLink.length) {
+        const $newThreadLink = selected.find('.js-new-thread-link');
+        const newThreadLink = $newThreadLink?.get(0);
+        newThreadLink?.scrollIntoView({ behavior: 'smooth' });
+        newThreadLink?.click();
+      } else {
+        const replyToThreadLink = $replyToThreadLink?.get(0);
+        replyToThreadLink?.scrollIntoView({ behavior: 'smooth' });
+        replyToThreadLink?.click();
+      }
+
       QPixel.Keyboard.dialogClose();
     } else if (e.key === 'f') {
       const cl = $(QPixel.Keyboard.selectedItem).find('.post--action-dialog.js-flag-box');

--- a/app/assets/javascripts/keyboard_tools.js
+++ b/app/assets/javascripts/keyboard_tools.js
@@ -66,6 +66,10 @@ document.addEventListener('DOMContentLoaded', async () => {
           post_id: this.selectedItem.getAttribute('data-ckb-post-id')
         };
       }
+
+      if (this.state === 'home') {
+        renderHelpMenu();
+      }
     }
   };
 
@@ -122,6 +126,40 @@ document.addEventListener('DOMContentLoaded', async () => {
                     .join('\n');
   };
 
+  const renderHelpMenu = () => {
+    /** @type {KeyboardShortcut[]} */
+    const generalShortcuts = [
+      { key: '?', text: 'Open this help' },
+      { key: 'esc', text: 'Close this help' },
+      { key: 'n', text: 'New post in the category' },
+      { key: 's', text: 'Search for something' },
+      { key: 'g', text: 'Go to ...' },
+      { key: 'a', text: 'Go to answer field' }
+    ];
+
+    /** @type {KeyboardShortcut[]} */
+    const selectionShortcuts = [
+      { key: 'j', text: 'Move one item down' },
+      { key: 'k', text: 'Move one item up' },
+      { key: 't',
+        text: 'Use a tool (on selection)',
+        if: !!QPixel.Keyboard.selectedItemData && QPixel.Keyboard.selectedItemData.type !== 'link'
+      }
+    ];
+
+    QPixel.Keyboard.dialog(
+      'Keyboard Shortcuts\n' +
+      delimitShortcutsGroup(33) +
+      formatShortcuts(generalShortcuts, 4) +
+      '\n\n' +
+      'Selection shortcuts:\n\n' +
+      formatShortcuts(selectionShortcuts, 4) +
+      '\n\n' +
+      'Selection shortcuts will select\n' +
+      'first post, if none selected'
+    );
+  };
+
   /**
    * Handles the "home" keyboard state
    * @param {JQuery.KeyboardEventBase} e
@@ -134,37 +172,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     if (isHelp) {
-      /** @type {KeyboardShortcut[]} */
-      const generalShortcuts = [
-        { key: '?', text: 'Open this help' },
-        { key: 'esc', text: 'Close this help' },
-        { key: 'n', text: 'New post in the category' },
-        { key: 's', text: 'Search for something' },
-        { key: 'g', text: 'Go to ...' },
-        { key: 'a', text: 'Go to answer field' }
-      ];
-
-      /** @type {KeyboardShortcut[]} */
-      const selectionShortcuts = [
-        { key: 'j', text: 'Move one item down' },
-        { key: 'k', text: 'Move one item up' },
-        { key: 't',
-          text: 'Use a tool (on selection)',
-          if: !!QPixel.Keyboard.selectedItemData && QPixel.Keyboard.selectedItemData.type !== 'link'
-        }
-      ];
-
-      QPixel.Keyboard.dialog(
-        'Keyboard Shortcuts\n' +
-        delimitShortcutsGroup(33) +
-        formatShortcuts(generalShortcuts, 4) +
-        '\n\n' +
-        'Selection shortcuts:\n\n' +
-        formatShortcuts(selectionShortcuts, 4) +
-        '\n\n' +
-        'Selection shortcuts will select\n' +
-        'first post, if none selected'
-      );
+      renderHelpMenu();
     } else if (e.key === 'n') {
       const new_post_link = $('a.category-header--nav-item.is-button').attr('href');
       if (new_post_link) {

--- a/app/assets/javascripts/keyboard_tools.js
+++ b/app/assets/javascripts/keyboard_tools.js
@@ -258,7 +258,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       }
       QPixel.Keyboard.updateSelected();
 
-      if (QPixel.Keyboard.selectedItemData.type === 'post') {
+      if (QPixel.Keyboard.selectedItemData?.type === 'post') {
         renderToolsMenu();
         QPixel.Keyboard.state = 'tools';
       }

--- a/app/assets/stylesheets/keyboard_tools.scss
+++ b/app/assets/stylesheets/keyboard_tools.scss
@@ -2,7 +2,7 @@
     padding: 1rem;
     font-family: monospace;
     white-space: pre-wrap;
-    width: 350px;
+    max-width: 350px;
     background-color: rgba(0,0,0,0.8);
     color: white;
     border-radius: 0.25rem;


### PR DESCRIPTION
closes #1020
closes #646

The PR also makes keyboard shortcut definition dynamic to make it easier to make changes to them going forward.

Here's how the shortcuts will look like with this PR applied (note that the gap between keys and descriptions is now a bit wider to avoid longer keys such as `esc` to look like they are part of the description, that the width is now variable to avoid mostly empty 350px-=wide dialogs, and that there's no longer a "Use a tool (on selection)" shortcut when in post list contexts):

<img width="377" height="419" alt="image" src="https://github.com/user-attachments/assets/ee5fde0b-4f45-407f-b6b0-2cf77e1091ba" />
<img width="377" height="419" alt="Screenshot from 2026-01-22 08-32-16" src="https://github.com/user-attachments/assets/4d4abf4d-875e-43dc-a0ee-740fa23d1778" />
<img width="377" height="419" alt="Screenshot from 2026-01-22 08-32-22" src="https://github.com/user-attachments/assets/63b79844-d43d-4e20-a9ce-9dca99d6fc2b" />
<img width="377" height="419" alt="Screenshot from 2026-01-22 08-32-30" src="https://github.com/user-attachments/assets/be2ab836-88b0-4036-912d-46715d079c96" />
<img width="377" height="419" alt="Screenshot from 2026-01-22 08-42-18" src="https://github.com/user-attachments/assets/f00dc2c5-3d10-446f-a9bf-d0696f9c5c0f" />
