### PR TITLE
Fix incorrect handling of rendered tag wikis

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -15,6 +15,13 @@ module TagsHelper
       end
   end
 
+  # Renders wiki for a given tag
+  # @param tag [Tag] tag to render the wiki for
+  # @return [ActiveSupport::SafeBuffer] rendered usage wiki
+  def rendered_wiki(tag)
+    sanitize(tag.wiki, scrubber: scrubber)
+  end
+
   ##
   # Generate a list of classes to be applied to a tag.
   # @param tag [Tag]
@@ -37,5 +44,15 @@ module TagsHelper
   def post_ids_for_tags(tag_ids)
     sql = "SELECT post_id FROM posts_tags WHERE tag_id IN #{ApplicationRecord.sanitize_sql_in(tag_ids)}"
     ActiveRecord::Base.connection.execute(sql).to_a.flatten
+  end
+
+  class TagWikiScrubber < PostsHelper::PostScrubber
+    def allowed_node?(node)
+      super && !node.matches?("a[href=''], p:only-child:empty")
+    end
+  end
+
+  def scrubber
+    TagsHelper::TagWikiScrubber.new
   end
 end

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -1,5 +1,9 @@
 <% content_for :title, "Posts tagged #{@tag.name}" %>
 
+<%
+  wiki = rendered_wiki(@tag)
+%>
+
 <h1 class="has-margin-0 has-margin-top-4">
   Posts tagged <span class="<%= tag_classes(@tag, @category) %> is-large wrap-anywhere"><%= @tag.name %></span>
   <% if at_least_moderator? %>
@@ -60,17 +64,17 @@
     <% end %>
   </div>
   <div class="widget--body">
-    <% if @tag.wiki.present? %>
-      <% if @tag.wiki.length < 600 %>
-        <%= raw(sanitize(@tag.wiki, scrubber: scrubber)) %>
+    <% if wiki.present? %>
+      <% if wiki.length < 600 %>
+        <%= wiki %>
       <% else %>
         <details>
           <summary>Tag Wiki</summary>
-          <%= raw(sanitize(@tag.wiki, scrubber: scrubber)) %>
+          <%= wiki %>
         </details>
       <% end %>
     <% end %>
-    <% unless @tag.wiki.present? %>
+    <% unless wiki.present? %>
       <p class="has-font-size-caption has-margin-0">
         <em>
           This tag doesn't have a detailed wiki yet.

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -44,3 +44,17 @@ base:
   name: base
   community: sample
   tag_set: main
+
+with_vacuous_wiki:
+  name: vacuous-wiki
+  community: sample
+  tag_set: main
+  wiki: '<p><a href=""></a></p>'
+  wiki_markdown: '[]()'
+
+with_wiki:
+  name: with-wiki
+  community: sample
+  tag_set: main
+  wiki: <p>This tag has a wiki</p>
+  wiki_markdown: This tag has a wiki

--- a/test/helpers/tags_helper_test.rb
+++ b/test/helpers/tags_helper_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class TagsHelperTest < ActionView::TestCase
+  test 'rendered_wiki should correctly sanitize content' do
+    vacuous_wiki_tag = tags(:with_vacuous_wiki)
+    vacuous_wiki = rendered_wiki(vacuous_wiki_tag)
+    assert vacuous_wiki.blank?
+
+    normal_wiki_tag = tags(:with_wiki)
+    normal_wiki = rendered_wiki(normal_wiki_tag)
+    assert_equal normal_wiki_tag.wiki, normal_wiki
+  end
+end


### PR DESCRIPTION
closes #1059

If you want to test that the issue at hand is fixed, create a tag with the only content in its wiki being `[]()`.