### PR TITLE
Make pagination item disabled state clearer

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -84,24 +84,6 @@ a.header--site-name {
   }
 }
 
-/* Copied from Co-Design for compatibility purposes */
-ul.pagination li.active {
-  border-color:#293338;
-  background-color:#3f4e56;
-  box-shadow:2px 3px 2px -2px #344147;
-  color:#fff;
-  font-weight:600
-}
-
-ul.pagination li.active a:hover {
-  background-color:transparent
-}
-
-ul.pagination li.disabled {
-  box-shadow:none
-}
-/* *** */
-
 .notice__dev-mode {
   font-size: 14px;
 }

--- a/app/assets/stylesheets/pagination.scss
+++ b/app/assets/stylesheets/pagination.scss
@@ -1,0 +1,18 @@
+/* Copied from Co-Design for compatibility purposes */
+@import 'variables';
+
+ul.pagination li.active {
+  border-color:#293338;
+  background-color:#3f4e56;
+  box-shadow:2px 3px 2px -2px #344147;
+  color:#fff;
+  font-weight:600
+}
+
+ul.pagination li.active a:hover {
+  background-color:transparent
+}
+
+ul.pagination li.disabled {
+  box-shadow:none
+}

--- a/app/assets/stylesheets/pagination.scss
+++ b/app/assets/stylesheets/pagination.scss
@@ -1,18 +1,23 @@
-/* Copied from Co-Design for compatibility purposes */
 @import 'variables';
 
-ul.pagination li.active {
-  border-color:#293338;
-  background-color:#3f4e56;
-  box-shadow:2px 3px 2px -2px #344147;
-  color:#fff;
-  font-weight:600
-}
+ul {
+  &.pagination {
+    li {
+      &.active {
+        border-color: #293338;
+        background-color: #3f4e56;
+        box-shadow: 2px 3px 2px -2px #344147;
+        color: #fff;
+        font-weight: 600;
 
-ul.pagination li.active a:hover {
-  background-color:transparent
-}
+        a:hover {
+          background-color: transparent;
+        }
+      }
 
-ul.pagination li.disabled {
-  box-shadow:none
+      &.disabled {
+        box-shadow: none;
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/pagination.scss
+++ b/app/assets/stylesheets/pagination.scss
@@ -17,6 +17,8 @@ ul {
 
       &.disabled {
         box-shadow: none;
+        filter: grayscale(1) opacity(0.7);
+        cursor: not-allowed;
       }
     }
   }


### PR DESCRIPTION
closes #1465

This PR makes disabled state of pagination items clearer (aligned with that of Co-design's disabled state for buttons):

<img width="292" height="66" alt="image" src="https://github.com/user-attachments/assets/005859d9-3473-40bd-9caf-9d5228bc0799" />

It's not shown in the screenshot above, but the cursor now clearly indicates that the action is inactive.
