### PR TITLE
Allow pinned links (the tool) to be filtered by period

### DIFF
--- a/app/controllers/pinned_links_controller.rb
+++ b/app/controllers/pinned_links_controller.rb
@@ -4,7 +4,7 @@ class PinnedLinksController < ApplicationController
   before_action :verify_mod_on_current_community, only: [:edit, :update]
 
   def index
-    @period = params[:period].presence || 'present'
+    @period = params[:period].presence || 'current'
 
     @links = if current_user.at_least_global_moderator? && params[:global] == '2'
                PinnedLink.unscoped
@@ -17,8 +17,8 @@ class PinnedLinksController < ApplicationController
     @links = case @period
              when 'past'
                @links.past
-             when 'present'
-               @links.present
+             when 'current'
+               @links.current
              when 'future'
                @links.future
              else

--- a/app/controllers/pinned_links_controller.rb
+++ b/app/controllers/pinned_links_controller.rb
@@ -4,21 +4,36 @@ class PinnedLinksController < ApplicationController
   before_action :verify_mod_on_current_community, only: [:edit, :update]
 
   def index
-    links = if current_user.at_least_global_moderator? && params[:global] == '2'
-              PinnedLink.unscoped
-            elsif current_user.at_least_global_moderator? && params[:global] == '1'
-              PinnedLink.where(community: nil)
-            else
-              PinnedLink.where(community: @community)
-            end
+    @period = params[:period].presence || 'present'
+
+    @links = if current_user.at_least_global_moderator? && params[:global] == '2'
+               PinnedLink.unscoped
+             elsif current_user.at_least_global_moderator? && params[:global] == '1'
+               PinnedLink.where(community: nil)
+             else
+               PinnedLink.where(community: @community)
+             end
+
+    @links = case @period
+             when 'past'
+               @links.past
+             when 'present'
+               @links.present
+             when 'future'
+               @links.future
+             else
+               @links
+             end
+
     @links = case params[:filter]
              when 'all'
-               links.all
+               @links.all
              when 'inactive'
-               links.where(active: false).all
+               @links.where(active: false).all
              else
-               links.where(active: true).all
+               @links.where(active: true).all
              end
+
     render layout: 'without_sidebar'
   end
 

--- a/app/models/pinned_link.rb
+++ b/app/models/pinned_link.rb
@@ -12,8 +12,8 @@ class PinnedLink < ApplicationRecord
     timed.where('shown_before < ?', DateTime.now)
   }
 
-  # a present link is not timed or started in the past and ends in the future
-  scope :present, lambda {
+  # a current link is not timed or started in the past and ends in the future
+  scope :current, lambda {
     where(shown_after: nil, shown_before: nil).or(
       timed.where('shown_after <= ?', DateTime.now)
            .where('shown_before > ?', DateTime.now)

--- a/app/models/pinned_link.rb
+++ b/app/models/pinned_link.rb
@@ -7,23 +7,20 @@ class PinnedLink < ApplicationRecord
     includes(:post, post: [:community])
   }
 
-  # a past link is one that ended in the past
   scope :past, lambda {
     timed.where('shown_before < ?', DateTime.now)
   }
 
-  # a current link is not timed or started in the past and ends in the future
   scope :current, lambda {
     where(shown_after: nil, shown_before: nil).or(
-      timed.where('shown_after <= ?', DateTime.now)
-           .where('shown_before > ?', DateTime.now)
+      timed.where('shown_after is null or shown_after <= ?', DateTime.now)
+           .where.not('shown_before < ?', DateTime.now)
     )
   }
 
-  # a future link is one that both starts and ends in the future
   scope :future, lambda {
     timed.where('shown_after > ?', DateTime.now)
-         .where('shown_before > ?', DateTime.now)
+         .where('shown_before is null or shown_before >= ?', DateTime.now)
   }
 
   scope :timed, lambda {
@@ -33,6 +30,27 @@ class PinnedLink < ApplicationRecord
   }
 
   validate :check_post_or_url
+
+  # Is the link not timed or started in the past & hasn't ended yet?
+  # @param now [DateTime, nil] timestamp to compare to
+  # @return [Boolean] check result
+  def current?(now = DateTime.now)
+    !timed? || !(future?(now) || past?(now))
+  end
+
+  # Does the link start in the future?
+  # @param now [DateTime, nil] timestamp to compare to
+  # @return [Boolean] check result
+  def future?(now = DateTime.now)
+    shown_after.present? && shown_after > now && (shown_before.nil? || shown_before >= now)
+  end
+
+  # Has the link ended in the past?
+  # @param now [DateTime, nil] timestamp to compare to
+  # @return [Boolean] check result
+  def past?(now = DateTime.now)
+    shown_before.present? && shown_before < now
+  end
 
   # Is the link time-constrained?
   # @return [Boolean] check result

--- a/app/models/pinned_link.rb
+++ b/app/models/pinned_link.rb
@@ -7,6 +7,31 @@ class PinnedLink < ApplicationRecord
     includes(:post, post: [:community])
   }
 
+  # a past link is one that ended in the past
+  scope :past, lambda {
+    timed.where('shown_before < ?', DateTime.now)
+  }
+
+  # a present link is not timed or started in the past and ends in the future
+  scope :present, lambda {
+    where(shown_after: nil, shown_before: nil).or(
+      timed.where('shown_after <= ?', DateTime.now)
+           .where('shown_before > ?', DateTime.now)
+    )
+  }
+
+  # a future link is one that both starts and ends in the future
+  scope :future, lambda {
+    timed.where('shown_after > ?', DateTime.now)
+         .where('shown_before > ?', DateTime.now)
+  }
+
+  scope :timed, lambda {
+    after = where.not(shown_after: nil)
+    before = where.not(shown_before: nil)
+    before.or(after)
+  }
+
   validate :check_post_or_url
 
   # Is the link time-constrained?

--- a/app/models/pinned_link.rb
+++ b/app/models/pinned_link.rb
@@ -29,6 +29,7 @@ class PinnedLink < ApplicationRecord
     before.or(after)
   }
 
+  validate :check_period
   validate :check_post_or_url
 
   # Is the link not timed or started in the past & hasn't ended yet?
@@ -56,6 +57,14 @@ class PinnedLink < ApplicationRecord
   # @return [Boolean] check result
   def timed?
     shown_before.present? || shown_after.present?
+  end
+
+  def check_period
+    return unless shown_before.present? && shown_after.present?
+
+    if shown_before < shown_after
+      errors.add(:base, 'end date cannot be earlier than the start date')
+    end
   end
 
   def check_post_or_url

--- a/app/views/pinned_links/index.html.erb
+++ b/app/views/pinned_links/index.html.erb
@@ -28,6 +28,22 @@
                         class: "button is-muted is-outlined #{(params[:filter] == 'all') ? 'is-active' : ''}" %>
         </div>
     </div>
+    <div class="grid--cell">
+        <div class="button-list is-gutterless">
+            <%= link_to 'past',
+                        query_url(period: 'past'),
+                        class: "button is-muted is-outlined #{'is-active' if @period == 'past'}" %>
+            <%= link_to 'present',
+                        query_url(period: 'present'),
+                        class: "button is-muted is-outlined #{'is-active' if @period == 'present'}" %>
+            <%= link_to 'future',
+                        query_url(period: 'future'),
+                        class: "button is-muted is-outlined #{'is-active' if @period == 'future'}" %>
+            <%= link_to 'any',
+                        query_url(period: 'any'),
+                        class: "button is-muted is-outlined #{'is-active' if @period == 'any'}" %>
+        </div>
+    </div>
     <div class="grid--cell is-flexible">
     </div>
     <div class="grid--cell">

--- a/app/views/pinned_links/index.html.erb
+++ b/app/views/pinned_links/index.html.erb
@@ -33,9 +33,9 @@
             <%= link_to 'past',
                         query_url(period: 'past'),
                         class: "button is-muted is-outlined #{'is-active' if @period == 'past'}" %>
-            <%= link_to 'present',
-                        query_url(period: 'present'),
-                        class: "button is-muted is-outlined #{'is-active' if @period == 'present'}" %>
+            <%= link_to 'current',
+                        query_url(period: 'current'),
+                        class: "button is-muted is-outlined #{'is-active' if @period == 'current'}" %>
             <%= link_to 'future',
                         query_url(period: 'future'),
                         class: "button is-muted is-outlined #{'is-active' if @period == 'future'}" %>

--- a/app/views/pinned_links/index.html.erb
+++ b/app/views/pinned_links/index.html.erb
@@ -70,7 +70,7 @@
         <% pl_link = pl.post.nil? ? pl.link : ('Post #' + pl.post.id.to_s) %>
         <% pl_label = pl.post.nil? ? pl.label : (pl.post.parent.nil? ? pl.post.title : pl.post.parent.title) %>
         <tr>
-            <td>
+            <td class="nowrap">
                 <% if pl.shown_before.nil? %>
                     <% if pl.post.nil? %>
                         link

--- a/test/controllers/pinned_links_controller_test.rb
+++ b/test/controllers/pinned_links_controller_test.rb
@@ -3,6 +3,15 @@ require 'test_helper'
 class PinnedLinksControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
+  test 'only mods or higher should be able to see pinned links' do
+    users.each do |user|
+      sign_in user
+      get :index
+
+      assert_response(user.at_least_moderator? ? :success : :not_found)
+    end
+  end
+
   test 'only mods or higher should be able to create pinned links' do
     post = posts(:question_one)
 
@@ -61,7 +70,7 @@ class PinnedLinksControllerTest < ActionController::TestCase
     assert_equal 'updated label', assigns(:link).label
   end
 
-  test 'update should correctly handle invlid pinned links' do
+  test 'update should correctly handle invalid pinned links' do
     sign_in users(:moderator)
     try_update_pinned_link(pinned_links(:active_with_label), link: nil)
     assert_response(:bad_request)

--- a/test/controllers/pinned_links_controller_test.rb
+++ b/test/controllers/pinned_links_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class PinnedLinksControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
-  test ':index should correctly filter byt activity status' do
+  test ':index should correctly filter by activity status' do
     sign_in users(:moderator)
 
     get :index, params: { filter: 'all' }
@@ -16,6 +16,39 @@ class PinnedLinksControllerTest < ActionController::TestCase
     assert_response(:success)
     assert @links.any?
     assert @links.none?(&:active?)
+  end
+
+  test ':index should correctly filter by period' do
+    sign_in users(:moderator)
+
+    now = DateTime.now
+
+    get :index, params: { period: 'past' }
+    @links = assigns(:links)
+    assert_response(:success)
+    assert @links.any?
+
+    @links.each do |link|
+      assert link.timed? && link.shown_before < now
+    end
+
+    get :index, params: { period: 'present' }
+    @links = assigns(:links)
+    assert_response(:success)
+    assert @links.any?
+
+    @links.each do |link|
+      assert !link.timed? || (link.shown_before > now && link.shown_after <= now)
+    end
+
+    get :index, params: { period: 'future' }
+    @links = assigns(:links)
+    assert_response(:success)
+    assert @links.any?
+
+    @links.each do |link|
+      assert link.timed? && link.shown_before > now && link.shown_after > now
+    end
   end
 
   test 'only mods or higher should be able to see pinned links' do

--- a/test/controllers/pinned_links_controller_test.rb
+++ b/test/controllers/pinned_links_controller_test.rb
@@ -52,31 +52,31 @@ class PinnedLinksControllerTest < ActionController::TestCase
     links_ids = pinned_links.map(&:id)
     assert(@links.all? { |link| links_ids.include?(link.id) })
 
-    get :index, params: { period: 'past' }
-    @links = assigns(:links)
-    assert_response(:success)
-    assert @links.any?
-
-    @links.each do |link|
-      assert link.timed? && link.shown_before < now
-    end
-
     get :index, params: { period: 'current' }
     @links = assigns(:links)
+
     assert_response(:success)
     assert @links.any?
-
     @links.each do |link|
-      assert !link.timed? || (link.shown_before > now && link.shown_after <= now)
+      assert link.current?(now)
+    end
+
+    get :index, params: { period: 'past' }
+    @links = assigns(:links)
+
+    assert_response(:success)
+    assert @links.any?
+    @links.each do |link|
+      assert link.past?(now)
     end
 
     get :index, params: { period: 'future' }
     @links = assigns(:links)
+
     assert_response(:success)
     assert @links.any?
-
     @links.each do |link|
-      assert link.timed? && link.shown_before > now && link.shown_after > now
+      assert link.future?(now)
     end
   end
 

--- a/test/controllers/pinned_links_controller_test.rb
+++ b/test/controllers/pinned_links_controller_test.rb
@@ -61,7 +61,7 @@ class PinnedLinksControllerTest < ActionController::TestCase
       assert link.timed? && link.shown_before < now
     end
 
-    get :index, params: { period: 'present' }
+    get :index, params: { period: 'current' }
     @links = assigns(:links)
     assert_response(:success)
     assert @links.any?

--- a/test/controllers/pinned_links_controller_test.rb
+++ b/test/controllers/pinned_links_controller_test.rb
@@ -50,7 +50,6 @@ class PinnedLinksControllerTest < ActionController::TestCase
     assert @links.any?
 
     links_ids = pinned_links.map(&:id)
-
     assert(@links.all? { |link| links_ids.include?(link.id) })
 
     get :index, params: { period: 'past' }
@@ -79,6 +78,17 @@ class PinnedLinksControllerTest < ActionController::TestCase
     @links.each do |link|
       assert link.timed? && link.shown_before > now && link.shown_after > now
     end
+  end
+
+  test ':index should treat invalid period filter as no filter' do
+    sign_in users(:moderator)
+
+    get :index, params: { period: 'invalid' }
+    @links = assigns(:links)
+    assert_response(:success)
+
+    links_ids = pinned_links.map(&:id)
+    assert(@links.all? { |link| links_ids.include?(link.id) })
   end
 
   test 'only mods or higher should be able to see pinned links' do

--- a/test/controllers/pinned_links_controller_test.rb
+++ b/test/controllers/pinned_links_controller_test.rb
@@ -3,6 +3,21 @@ require 'test_helper'
 class PinnedLinksControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
+  test ':index should correctly filter byt activity status' do
+    sign_in users(:moderator)
+
+    get :index, params: { filter: 'all' }
+    assert_response(:success)
+    assert assigns(:links).any?
+
+    get :index, params: { filter: 'inactive' }
+    @links = assigns(:links)
+
+    assert_response(:success)
+    assert @links.any?
+    assert @links.none?(&:active?)
+  end
+
   test 'only mods or higher should be able to see pinned links' do
     users.each do |user|
       sign_in user

--- a/test/controllers/pinned_links_controller_test.rb
+++ b/test/controllers/pinned_links_controller_test.rb
@@ -12,6 +12,16 @@ class PinnedLinksControllerTest < ActionController::TestCase
     assert_response(:success)
     assert @links.any?
     assert @links.none?(&:community_id?)
+
+    get :index, params: { global: '2' }
+    @links = assigns(:links)
+
+    assert_response(:success)
+    assert @links.any?
+
+    links_ids = pinned_links.map(&:id)
+
+    assert(@links.all? { |link| links_ids.include?(link.id) })
   end
 
   test ':index should correctly filter by activity status' do

--- a/test/controllers/pinned_links_controller_test.rb
+++ b/test/controllers/pinned_links_controller_test.rb
@@ -44,6 +44,15 @@ class PinnedLinksControllerTest < ActionController::TestCase
 
     now = DateTime.now
 
+    get :index
+    @links = assigns(:links)
+    assert_response(:success)
+    assert @links.any?
+
+    links_ids = pinned_links.map(&:id)
+
+    assert(@links.all? { |link| links_ids.include?(link.id) })
+
     get :index, params: { period: 'past' }
     @links = assigns(:links)
     assert_response(:success)

--- a/test/controllers/pinned_links_controller_test.rb
+++ b/test/controllers/pinned_links_controller_test.rb
@@ -3,6 +3,17 @@ require 'test_helper'
 class PinnedLinksControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
+  test ':index should correctly filter by community' do
+    sign_in users(:global_moderator)
+
+    get :index, params: { global: '1' }
+    @links = assigns(:links)
+
+    assert_response(:success)
+    assert @links.any?
+    assert @links.none?(&:community_id?)
+  end
+
   test ':index should correctly filter by activity status' do
     sign_in users(:moderator)
 

--- a/test/fixtures/pinned_links.yml
+++ b/test/fixtures/pinned_links.yml
@@ -14,3 +14,26 @@ inactive:
   label: test link
   link: https://example.com
   active: false
+
+timed_past:
+  community: sample
+  label: link in the past
+  link: https://example.com
+  active: true
+  shown_before: 2019-01-01T00:00:00.000000Z
+
+timed_present:
+  community: sample
+  label: link in the present
+  link: https://example.com
+  active: true
+  shown_after: 2019-01-01T00:00:00.000000Z
+  shown_before: <%= DateTime.now + 1 %>
+
+timed_future:
+  community: sample
+  label: link in the future
+  link: https://example.com
+  active: true
+  shown_after: <%= DateTime.now + 1 %>
+  shown_before: <%= DateTime.now + 1 %>

--- a/test/fixtures/pinned_links.yml
+++ b/test/fixtures/pinned_links.yml
@@ -37,3 +37,9 @@ timed_future:
   active: true
   shown_after: <%= DateTime.now + 1 %>
   shown_before: <%= DateTime.now + 1 %>
+
+global_active_with_label:
+  community: ~
+  label: test global link
+  link: https://example.com
+  active: true

--- a/test/models/pinned_link_test.rb
+++ b/test/models/pinned_link_test.rb
@@ -5,7 +5,6 @@ class PinnedLinkTest < ActiveSupport::TestCase
     timed = PinnedLink.timed
 
     assert timed.any?
-
     timed.each do |link|
       assert link.timed?, "link \"#{link.label}\" is not timed"
     end
@@ -16,9 +15,8 @@ class PinnedLinkTest < ActiveSupport::TestCase
     current = PinnedLink.current
 
     assert current.any?
-
     current.each do |link|
-      assert !link.timed? || (link.shown_before > now && link.shown_after <= now)
+      assert link.current?(now)
     end
   end
 
@@ -27,9 +25,8 @@ class PinnedLinkTest < ActiveSupport::TestCase
     past = PinnedLink.past
 
     assert past.any?
-
     past.each do |link|
-      assert link.timed? && link.shown_before < now
+      assert link.past?(now)
     end
   end
 
@@ -38,9 +35,8 @@ class PinnedLinkTest < ActiveSupport::TestCase
     future = PinnedLink.future
 
     assert future.any?
-
     future.each do |link|
-      assert link.timed? && link.shown_before > now && link.shown_after > now
+      assert link.future?(now)
     end
   end
 end

--- a/test/models/pinned_link_test.rb
+++ b/test/models/pinned_link_test.rb
@@ -39,4 +39,19 @@ class PinnedLinkTest < ActiveSupport::TestCase
       assert link.future?(now)
     end
   end
+
+  test 'pinned links should be correctly validated' do
+    valid_with_link = PinnedLink.new(link: 'https://example.com')
+    valid_with_post = PinnedLink.new(post: posts(:question_one))
+    period_mismatch = PinnedLink.new(shown_before: DateTime.now - 1, shown_after: DateTime.now)
+
+    [
+      [valid_with_link, true],
+      [valid_with_post, true],
+      [period_mismatch, false]
+    ].each do |test|
+      link, status = test
+      assert_equal status, link.valid?
+    end
+  end
 end

--- a/test/models/pinned_link_test.rb
+++ b/test/models/pinned_link_test.rb
@@ -1,7 +1,46 @@
 require 'test_helper'
 
 class PinnedLinkTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test ':timed scope should only return time-constrained links' do
+    timed = PinnedLink.timed
+
+    assert timed.any?
+
+    timed.each do |link|
+      assert link.timed?, "link \"#{link.label}\" is not timed"
+    end
+  end
+
+  test ':present scope should return non-timed or current links' do
+    now = DateTime.now
+    present = PinnedLink.present
+
+    assert present.any?
+
+    present.each do |link|
+      assert !link.timed? || (link.shown_before > now && link.shown_after <= now)
+    end
+  end
+
+  test ':past scope should only return past links' do
+    now = DateTime.now
+    past = PinnedLink.past
+
+    assert past.any?
+
+    past.each do |link|
+      assert link.timed? && link.shown_before < now
+    end
+  end
+
+  test ':future scope should only return future links' do
+    now = DateTime.now
+    future = PinnedLink.future
+
+    assert future.any?
+
+    future.each do |link|
+      assert link.timed? && link.shown_before > now && link.shown_after > now
+    end
+  end
 end

--- a/test/models/pinned_link_test.rb
+++ b/test/models/pinned_link_test.rb
@@ -11,13 +11,13 @@ class PinnedLinkTest < ActiveSupport::TestCase
     end
   end
 
-  test ':present scope should return non-timed or current links' do
+  test ':current scope should return non-timed or current links' do
     now = DateTime.now
-    present = PinnedLink.present
+    current = PinnedLink.current
 
-    assert present.any?
+    assert current.any?
 
-    present.each do |link|
+    current.each do |link|
       assert !link.timed? || (link.shown_before > now && link.shown_after <= now)
     end
   end


### PR DESCRIPTION
closes #1250

I chose to add a new filter defaulting to showing only **non-timed or current** links as an alternative to making "expired" pinned links inactive that also allows for more flexible filtering (future only, past only, present only, any period).

Additionally, we now validate that a given link's end date is not before its start date (if both are set, of course) as it's an invalid state.

---

<img width="1156" height="599" alt="image" src="https://github.com/user-attachments/assets/8d25be95-1fcc-4580-8c7e-4e7e34c9d342" />
<img width="1156" height="295" alt="image" src="https://github.com/user-attachments/assets/e0b459cf-283b-4989-81d3-4fbbd44d62ee" />
<img width="1156" height="500" alt="image" src="https://github.com/user-attachments/assets/c6e82a5b-7eda-4c9e-9369-8f75818ea1ad" />
<img width="1156" height="297" alt="image" src="https://github.com/user-attachments/assets/f81b8d6f-89a6-4431-8526-9f5768554e9a" />
