### PR TITLE
Separating tests and system tests in our CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -42,14 +42,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repo
-      uses: actions/checkout@v3
-    - name: Install Node
-      uses: actions/setup-node@v1
-      with:
-        node-version: 22
-    - run: npm install
-    - run: tsc
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 22
+      - run: npm install
+      - run: tsc
 
   tests:
     name: Ruby on Rails tests
@@ -58,10 +58,9 @@ jobs:
     strategy:
       matrix:
         ruby_version: [3.1, 3.2]
-        test_type: [test, test:system]
 
     services:
-      mysql:
+      mysql: &db-service
         image: mysql:8.0
         env:
           MYSQL_ROOT_HOST: '%'
@@ -69,7 +68,7 @@ jobs:
           MYSQL_DATABASE: 'qpixel_test'
         ports:
           - 3306:3306
-      redis:
+      redis: &redis-service
         image: redis:8.0
         ports:
           - 6379:6379
@@ -81,11 +80,50 @@ jobs:
         run: |
           sudo apt-get -qq update
           sudo apt-get -yqq install libmariadb-dev libmagickwand-dev
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+          bundler-cache: true
+      - name: Prepare for testing
+        run: |
+          cp config/database.sample.yml config/database.yml
+          cp config/storage.sample.yml config/storage.yml
+          bundle exec rails db:create
+          bundle exec rails db:schema:load
+          bundle exec rails db:migrate
+          bundle exec rails test:prepare
+      - run: bundle exec rails test
+      - uses: codecov/codecov-action@v5
+        if: ${{ matrix.ruby_version == env.RUBY_VERSION && github.actor != 'dependabot[bot]' }}
+        with:
+          directory: coverage
+          fail_ci_if_error: true
+          report_type: coverage
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  system-tests:
+    name: Ruby on Rails system tests
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby_version: [3.1, 3.2]
+
+    services:
+      mysql: *db-service
+      redis: *redis-service
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Setup dependencies
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get -yqq install libmariadb-dev libmagickwand-dev
       - name: Setup Firefox
-        if: ${{ matrix.test_type == 'test:system' }}
         uses: browser-actions/setup-firefox@v1.5.4
       - name: Check Firefox setup
-        if: ${{ matrix.test_type == 'test:system' }}
         run: firefox --version
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -100,21 +138,13 @@ jobs:
           bundle exec rails db:schema:load
           bundle exec rails db:migrate
           bundle exec rails test:prepare
-      - run: bundle exec rails ${{ matrix.test_type }}
+      - run: bundle exec rails test:system
       - name: Upload screenshots
-        if: ${{ matrix.test_type == 'test:system' }}
         uses: actions/upload-artifact@v4
         with:
           name: screenshots-${{ matrix.ruby_version }}
           path: tmp/screenshots
           if-no-files-found: ignore
-      - uses: codecov/codecov-action@v5
-        if: ${{ matrix.ruby_version == env.RUBY_VERSION && matrix.test_type == 'test' && github.actor != 'dependabot[bot]' }}
-        with:
-          directory: coverage
-          fail_ci_if_error: true
-          report_type: coverage
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   deploy:
     name: Dev server deployment

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -154,6 +154,7 @@ jobs:
       - rubocop
       - typescript
       - tests
+      - system-tests
 
     env:
       SSH_IP: ${{ secrets.DEV_SSH_IP }}


### PR DESCRIPTION
Let's make our tests independent of our system tests - the latter still fail often which leads to having to rerun every other incomplete normal test each time they error out. It's not a lot of config duplication because we can now use YAML anchors in workflow files (that said, I will be moving us to proper reusable workflows later):

<img width="653" height="555" alt="image" src="https://github.com/user-attachments/assets/b766bb7d-5d73-42c4-95fe-345c136ec6bf" />
