### PR TITLE
Show community logo & name for inbox notifications

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -43,14 +43,6 @@ a {
   overflow-wrap: break-word;
 }
 
-a.header--site-name {
-  display: flex !important;
-}
-.header .header--item.is-complex:not(.is-mobile-menu) {
-  align-items: center !important;
-  display: flex !important;
-}
-
 @media all and (max-width: 73.5em) {
   .grid {
     margin-left: 0;
@@ -104,18 +96,6 @@ ul.pagination li.disabled {
 
 .notice__dev-mode {
   font-size: 14px;
-}
-
-header {
-  &.header {
-    z-index: 5;
-    position: relative;
-    box-shadow: 0 3px 3px 0 rgba(0, 0, 0, 0.2);
-  }
-  &.header.sticky {
-    position: sticky;
-    top: 0;
-  }
 }
 
 .notice a.has-font-size-larger {
@@ -172,10 +152,6 @@ hr {
 .inbox--container {
   max-height: 600px;
   overflow-y: scroll;
-}
-
-.header--container {
-  align-items: center !important;
 }
 
 img {
@@ -260,18 +236,8 @@ table.is-with-hover tr:hover td {
   background-color: #eee
 }
 
-/* The default header size (2.5rem) is too huge for small headers. */
-.header.is-small .header--brand .header--site-name {
-  font-size: 2rem;
-}
-
 .notice {
   z-index: 9999;
-}
-
-/* Fix header images being stretched - https://meta.codidact.com/posts/278377 */
-img.header--item-image {
-  object-fit: contain;
 }
 
 .widget--header-link {

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -1,7 +1,7 @@
 @import 'variables';
 
-a.header--site-name {
-  display: flex !important;
+a.header--site-name:any-link {
+  display: flex;
 }
 
 .header .header--item.is-complex:not(.is-mobile-menu) {

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -1,0 +1,38 @@
+@import 'variables';
+
+a.header--site-name {
+  display: flex !important;
+}
+
+.header .header--item.is-complex:not(.is-mobile-menu) {
+  align-items: center !important;
+  display: flex !important;
+}
+
+
+header {
+  &.header {
+    z-index: 5;
+    position: relative;
+    box-shadow: 0 3px 3px 0 rgba(0, 0, 0, 0.2);
+  }
+
+  &.header.sticky {
+    position: sticky;
+    top: 0;
+  }
+}
+
+.header--container {
+  align-items: center !important;
+}
+
+/* The default header size (2.5rem) is too huge for small headers. */
+.header.is-small .header--brand .header--site-name {
+  font-size: 2rem;
+}
+
+/* Fix header images being stretched - https://meta.codidact.com/posts/278377 */
+img.header--item-image {
+  object-fit: contain;
+}

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -34,6 +34,10 @@
     }
   }
 
+  .notification--icon {
+    max-height: 1em;
+  }
+
   .notification--timestamp {
     line-break: strict;
   }

--- a/app/assets/stylesheets/utilities.scss
+++ b/app/assets/stylesheets/utilities.scss
@@ -263,13 +263,15 @@ div:hover > .copy-button {
   }
 }
 
-.__mobile-only {
+.__mobile-only,
+a.__mobile-only:any-link {
   @media screen and (min-width: $screen-sm) {
     display: none;
   }
 }
 
-.__desktop-only {
+.__desktop-only,
+a.__desktop-only:any-link {
   @media screen and (max-width: $screen-sm) {
     display: none;
   }

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -8,7 +8,7 @@
 <div class="notification">
   <div class="notification-content">
     <div class="form-caption">
-      <%= notification.rendered_timestamp %>
+      <%= notification.community_name %> &middot; <%= notification.rendered_timestamp %>
     </div>
     <a href="<%= notification.link %>"><%= render_pings_text(notification.content) %></a>
   </div>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -8,6 +8,11 @@
 <div class="notification">
   <div class="notification-content">
     <div class="form-caption">
+      <% if SiteSetting['SiteLogoPath'].present? %>
+        <img class="notification--icon"
+             src="<%= SiteSetting['SiteLogoPath'] %>"
+             alt="<% notification.community_name %> logo" />
+      <% end %>
       <%= notification.community_name %> &middot; <%= notification.rendered_timestamp %>
     </div>
     <a href="<%= notification.link %>"><%= render_pings_text(notification.content) %></a>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -5,12 +5,18 @@
       notification : Notification to render
 "%>
 
+<%
+  mobile_logo_path = SiteSetting['MobileLogoPath', community: notification.community]
+  full_logo_path = SiteSetting['SiteLogoPath', community: notification.community]
+  logo_path = mobile_logo_path.presence || full_logo_path
+%>
+
 <div class="notification">
   <div class="notification-content">
     <div class="form-caption">
-      <% if SiteSetting['SiteLogoPath', community: notification.community].present? %>
+      <% if logo_path.present? %>
         <img class="notification--icon"
-             src="<%= SiteSetting['SiteLogoPath', community: notification.community] %>"
+             src="<%= logo_path %>"
              alt="<% notification.community_name %> logo" />
       <% end %>
       <%= notification.community_name %> &middot; <%= notification.rendered_timestamp %>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -8,9 +8,9 @@
 <div class="notification">
   <div class="notification-content">
     <div class="form-caption">
-      <% if SiteSetting['SiteLogoPath'].present? %>
+      <% if SiteSetting['SiteLogoPath', community: notification.community].present? %>
         <img class="notification--icon"
-             src="<%= SiteSetting['SiteLogoPath'] %>"
+             src="<%= SiteSetting['SiteLogoPath', community: notification.community] %>"
              alt="<% notification.community_name %> logo" />
       <% end %>
       <%= notification.community_name %> &middot; <%= notification.rendered_timestamp %>


### PR DESCRIPTION
closes #1599 

This PR adds community icons & names to inbox notifications. We don't have (at least as far as I am aware) proper small square icons of our communities for this list, so I opted to simply use `SiteLogoPath` - it doesn't look ideal, but better than nothing (if we _do_ have proper icons or have some designer resources to spare, please let me know):

<img width="825" height="233" alt="image" src="https://github.com/user-attachments/assets/1ba8273c-64f3-4f51-be7f-79f00873816a" />

Also fixes CSS specificity shenanigans breaking site header if both `MobileLogoPath` and `SiteLogoPath` are set.
