### PR TITLE
Return proper results for posts searches consisting only of word exclusions

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -28,10 +28,10 @@ module SearchHelper
     posts = posts.paginate(page: params[:page], per_page: 25)
 
     posts = if search_string.present?
-              posts.search(search_data[:search]).user_sort({ term: params[:sort], default: :search_score },
-                                                           relevance: :search_score,
-                                                           score: :score, age: :created_at,
-                                                           activity: :updated_at)
+              posts.search(search_string).user_sort({ term: params[:sort], default: :search_score },
+                                                    relevance: :search_score,
+                                                    score: :score, age: :created_at,
+                                                    activity: :updated_at)
             else
               posts.user_sort({ term: params[:sort], default: :score },
                               score: :score, age: :created_at, activity: :updated_at)

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -11,6 +11,11 @@ class ApplicationRecord < ActiveRecord::Base
     select(Arel.sql("`#{table_name}`.*, #{sanitized} AS search_score")).where(sanitized)
   end
 
+  def self.exclusion_search(term, **cols)
+    matched = match_search(term[1..], **cols)
+    select(Arel.sql("`#{table_name}`.*, 1 AS search_score")).excluding(matched)
+  end
+
   def self.sanitize_name(name)
     name.to_s.delete('`').insert(0, '`').insert(-1, '`')
   end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -12,7 +12,8 @@ class ApplicationRecord < ActiveRecord::Base
   end
 
   def self.exclusion_search(term, **cols)
-    matched = match_search(term[1..], **cols)
+    sanitized = sanitize_for_exclusion_search(term)
+    matched = match_search(sanitized, **cols)
     select(Arel.sql("`#{table_name}`.*, 1 AS search_score")).excluding(matched)
   end
 
@@ -29,6 +30,10 @@ class ApplicationRecord < ActiveRecord::Base
       val = v.inspect.length > 100 ? "#{v.inspect[0, 100]}..." : v.inspect
       "#{k}: #{val}"
     end.join(join)
+  end
+
+  def self.sanitize_for_exclusion_search(term)
+    term.gsub(/-+?([^\s-]+?\s*?)/, '\1')
   end
 
   def self.sanitize_for_search(term, **cols)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -76,7 +76,11 @@ class Post < ApplicationRecord
   # @param term [String] the search term
   # @return [ActiveRecord::Relation<Post>]
   def self.search(term)
-    match_search term, posts: [:body_markdown, :title]
+    if term.match(/^(?:\s*?-\S+?)+?$/)
+      exclusion_search term, posts: [:body_markdown, :title]
+    else
+      match_search term, posts: [:body_markdown, :title]
+    end
   end
 
   def self.by_slug(slug, user)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -76,7 +76,7 @@ class Post < ApplicationRecord
   # @param term [String] the search term
   # @return [ActiveRecord::Relation<Post>]
   def self.search(term)
-    if term.match(/^(?:-\S+?\s*?)+$/)
+    if term.match(/^(?:-[^\s-]+?\s*?)+$/)
       exclusion_search term, posts: [:body_markdown, :title]
     else
       match_search term, posts: [:body_markdown, :title]

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -76,7 +76,7 @@ class Post < ApplicationRecord
   # @param term [String] the search term
   # @return [ActiveRecord::Relation<Post>]
   def self.search(term)
-    if term.match(/^(?:\s*?-\S+?)+?$/)
+    if term.match(/^(?:-\S+?\s*?)+$/)
       exclusion_search term, posts: [:body_markdown, :title]
     else
       match_search term, posts: [:body_markdown, :title]

--- a/test/models/application_record_test.rb
+++ b/test/models/application_record_test.rb
@@ -1,6 +1,16 @@
 require 'test_helper'
 
 class ApplicationRecordTest < ActiveSupport::TestCase
+  test 'sanitize_for_exclusion_search should correctly invert all words' do
+    [
+      ['-one -two -three --four', 'one two three four']
+    ].each do |test|
+      input, expected = test
+      assert_equal expected,
+                   ApplicationRecord.sanitize_for_exclusion_search(input)
+    end
+  end
+
   test 'fuzzy_search should correctly search records' do
     results = Post.fuzzy_search('Q2', posts: [:body_markdown, :title]).map(&:id)
     post_ids = posts.select { |p| /^Q\d+/.match?(p.title) }.map(&:id)


### PR DESCRIPTION
closes #938

> The ship stays where it is and the engines move the universe around it.

If we cannot use only negative terms, well... let's search *for* those terms and exclude them from results. I believe this is what end users expect from a search with all words set to "exclude".