### PR TITLE
Fix incorrect formatTimestamp hour token format

### DIFF
--- a/app/assets/javascripts/qpixel_dom.js
+++ b/app/assets/javascripts/qpixel_dom.js
@@ -57,7 +57,7 @@ window.QPixel ||= {};
     },
 
     formatTimestamp: (timestamp) => {
-     return moment(timestamp).format('YYYY-MM-DD hh:mm:ss UTC');
+     return moment(timestamp).format('YYYY-MM-DD HH:mm:ss UTC');
     },
 
     getModifierState: (e) => {


### PR DESCRIPTION
mea culpa - typo'd in `formatTimestamp`'s hour token.

closes #1997
