### PR TITLE
Replace ineffective follow_own_posts migration with a working one

### DIFF
--- a/db/migrate/20260304104100_follow_own_posts.rb
+++ b/db/migrate/20260304104100_follow_own_posts.rb
@@ -1,6 +1,7 @@
 class FollowOwnPosts < ActiveRecord::Migration[7.2]
   def change
-    to_insert = Post.where.not(post_type_id: [PolicyDoc.post_type_id, HelpDoc.post_type_id])
+    to_insert = Post.unscoped
+                    .where.not(post_type_id: [PolicyDoc.post_type_id, HelpDoc.post_type_id])
                     .where.not(user_id: nil)
                     .pluck(:id, :user_id)
                     .map { |post_id, user_id| { post_id: post_id, user_id: user_id } }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_26_185531) do
+ActiveRecord::Schema[7.2].define(version: 2026_03_04_104100) do
   create_table "abilities", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "community_id"
     t.string "name"


### PR DESCRIPTION
This deletes the migration `db/migrate/20260208223211_follow_own_posts.rb` and adds a new migration `db/migrate/20260304104100_follow_own_posts.rb` that uses unscoped `Post` to make the post author a follower of new threads for every post.