### PR TITLE
Fix automatic logout of deleted users

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,5 @@
 # Provides helper methods for use by views under <tt>ApplicationController</tt> (and by extension, every view).
 module ApplicationHelper
-  include Warden::Test::Helpers
-
   ##
   # Is the current user a moderator or admin on the current community?
   # @return [Boolean]
@@ -330,7 +328,7 @@ module ApplicationHelper
     @current_user ||= warden.authenticate(scope: :user)
     if @current_user&.deleted? || @current_user&.community_user&.deleted?
       scope = Devise::Mapping.find_scope!(:user)
-      logout scope
+      warden.logout(scope)
       @current_user = nil
     end
     @current_user


### PR DESCRIPTION
closes #591

To test the change:
1. Log in as any user (important note: the "Stay signed in on this device" option **must** be checked);
2. While logged in, mark the user as deleted (the easiest way is to set `deleted` to `true` for that user directly in the database);
3. Reload the page - the header should now look as if you were logged out;
4. Click on the "sign in" button;
5. Observe being redirected to the sign in page with the danger notice (incorrectly) saying "You are already signed in";
6. Checkout the PR, reload the page, and click on the "sign in" button again;
7. Observe being redirected to the sign in page with the danger notice (correctly) saying:
    - "Invalid email or password" if the user is marked as deleted network-wide;
    - "Your profile on this community has been deleted" if only the user's community user is marked as deleted;