### PR TITLE
Fix copy code button size when over oneline code blocks

### DIFF
--- a/app/assets/javascripts/codeblocks.js
+++ b/app/assets/javascripts/codeblocks.js
@@ -1,29 +1,62 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const buttonTemplate = `<button class="copy-button button is-muted is-outlined has-margin-2">Copy</button>`;
+  /**
+   * @param {string} content
+   * @returns {HTMLButtonElement}
+   */
+  const createCopyButton = (content, isSmall = false) => {
+    const button = document.createElement('button');
+    button.classList.add('copy-button', 'button', 'is-muted', 'is-outlined', 'has-margin-2');
+    button.textContent = 'Copy';
+
+    if (isSmall) {
+      button.classList.add('is-small');
+    }
+
+    button.addEventListener('click', async () => {
+      const originalButtonText = button.textContent;
+
+      try {
+        await navigator.clipboard.writeText(content);
+        button.textContent = 'Copied!';
+      }
+      catch (e) {
+        console.warn(e);
+        button.textContent = 'Failed!';
+      }
+      finally {
+        setTimeout(() => {
+          button.textContent = originalButtonText;
+        }, 2000);
+      }
+    });
+
+    return button;
+  };
+
+  /**
+   * @param {HTMLElement} element
+   * @returns {HTMLDivElement}
+   */
+  const wrapRelative = (element) => {
+    const wrapper = document.createElement('div');
+    wrapper.style.position = 'relative';
+    wrapper.append(element.cloneNode(true));
+    element.replaceWith(wrapper);
+    return wrapper;
+  };
+
+  if (!window.isSecureContext) {
+    return;
+  }
 
   $('.post--content pre > code')
     .parent()
-    .each(function () {
-      const $button = $(buttonTemplate);
+    .each(function (_, element) {
       const $content = $(this).text();
       const numLines = $content.trim().split(/\r?\n/).length;
 
-      if (numLines <= 1) {
-        $button.addClass('is-small');
-      }
-
-      $(this)
-        .wrap('<div style="position:relative;"></div>')
-        .parent()
-        .prepend(
-          $button.click(function () {
-            navigator.clipboard.writeText($content);
-            $(this).text('Copied!');
-            setTimeout(() => {
-              $(this).text('Copy');
-            }, 2000);
-          }),
-        );
+      const button = createCopyButton($content, numLines <= 1);
+      const wrapper = wrapRelative(element);
+      wrapper.prepend(button);
     });
 });
-

--- a/app/assets/javascripts/codeblocks.js
+++ b/app/assets/javascripts/codeblocks.js
@@ -1,16 +1,29 @@
 $(() => {
-  $(".post--content pre > code")
+  const buttonTemplate = `<button class="copy-button button is-muted is-outlined has-margin-2">Copy</button>`;
+
+  $('.post--content pre > code')
     .parent()
-    .each(function() {
-      const content = $(this).text()
+    .each(function () {
+      const $button = $(buttonTemplate);
+      const $content = $(this).text();
+      const numLines = $content.trim().split(/\r?\n/).length
+
+      if (numLines <= 1) {
+        $button.addClass('is-small');
+      }
+
       $(this)
         .wrap('<div style="position:relative;"></div>')
         .parent()
-        .prepend($('<button class="copy-button button is-muted is-outlined has-margin-2">Copy</button>')
-          .click(function () {
-            navigator.clipboard.writeText(content);
+        .prepend(
+          $button.click(function () {
+            navigator.clipboard.writeText($content);
             $(this).text('Copied!');
-            setTimeout(() => { $(this).text('Copy'); }, 2000);
-          }))
-  });
+            setTimeout(() => {
+              $(this).text('Copy');
+            }, 2000);
+          }),
+        );
+    });
 });
+

--- a/app/assets/javascripts/codeblocks.js
+++ b/app/assets/javascripts/codeblocks.js
@@ -34,7 +34,7 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   /**
-   * @param {HTMLElement} element
+   * @param {Element} element
    * @returns {HTMLDivElement}
    */
   const wrapRelative = (element) => {
@@ -49,14 +49,18 @@ document.addEventListener('DOMContentLoaded', () => {
     return;
   }
 
-  $('.post--content pre > code')
-    .parent()
-    .each(function (_, element) {
-      const $content = $(this).text();
-      const numLines = $content.trim().split(/\r?\n/).length;
+  document.querySelectorAll('.post--content pre > code').forEach((child) => {
+    const { parentElement: element } = child;
 
-      const button = createCopyButton($content, numLines <= 1);
-      const wrapper = wrapRelative(element);
-      wrapper.prepend(button);
-    });
+    if (!element) {
+      return;
+    }
+
+    const { textContent } = element;
+    const numLines = textContent.trim().split(/\r?\n/).length;
+
+    const button = createCopyButton(textContent, numLines <= 1);
+    const wrapper = wrapRelative(element);
+    wrapper.prepend(button);
+  });
 });

--- a/app/assets/javascripts/codeblocks.js
+++ b/app/assets/javascripts/codeblocks.js
@@ -1,4 +1,4 @@
-$(() => {
+document.addEventListener('DOMContentLoaded', () => {
   const buttonTemplate = `<button class="copy-button button is-muted is-outlined has-margin-2">Copy</button>`;
 
   $('.post--content pre > code')
@@ -6,7 +6,7 @@ $(() => {
     .each(function () {
       const $button = $(buttonTemplate);
       const $content = $(this).text();
-      const numLines = $content.trim().split(/\r?\n/).length
+      const numLines = $content.trim().split(/\r?\n/).length;
 
       if (numLines <= 1) {
         $button.addClass('is-small');

--- a/app/assets/javascripts/codeblocks.js
+++ b/app/assets/javascripts/codeblocks.js
@@ -57,9 +57,21 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const { textContent } = element;
-    const numLines = textContent.trim().split(/\r?\n/).length;
 
-    const button = createCopyButton(textContent, numLines <= 1);
+    // code blocks always have a trailing newline added
+    const normalizedText = textContent.replace(/\n$/, '');
+
+    if (!normalizedText) {
+      return;
+    }
+
+    const numLines = normalizedText.split(/\r?\n/).length;
+
+    if (numLines < 1) {
+      return;
+    }
+
+    const button = createCopyButton(textContent, numLines === 1);
     const wrapper = wrapRelative(element);
     wrapper.prepend(button);
   });

--- a/app/assets/stylesheets/utilities.scss
+++ b/app/assets/stylesheets/utilities.scss
@@ -123,6 +123,7 @@ pre.pre-wrap {
   display: none;
   position: absolute;
   right: 0;
+  top: -1px;
 }
 
 div:hover > .copy-button {

--- a/app/assets/stylesheets/utilities.scss
+++ b/app/assets/stylesheets/utilities.scss
@@ -123,7 +123,10 @@ pre.pre-wrap {
   display: none;
   position: absolute;
   right: 0;
-  top: -1px;
+
+  &.is-small {
+    top: -1px;
+  }
 }
 
 div:hover > .copy-button {


### PR DESCRIPTION
With this PR, multiline blocks will still show the big button as before: 

<img width="682" height="106" alt="Screenshot from 2026-03-07 00-51-06" src="https://github.com/user-attachments/assets/757f0579-c692-40f2-8786-a122f0ed49e7" />

Single-line blocks, however, will show a smaller better-fitting version of the button:

<img width="683" height="54" alt="Screenshot from 2026-03-07 00-51-18" src="https://github.com/user-attachments/assets/a588ad24-af27-44d1-8788-9ab13d00aae4" />

closes #2002