### PR TITLE
Fix undefined secondary sort for user posts breaking pagination

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,12 +45,13 @@ class UsersController < ApplicationController
 
   def show
     @abilities = Ability.on_user(@user)
+    @limit = params[:limit]&.to_i || 15
 
     @posts = set_posts.user_sort({ term: params[:sort], default: :score },
                                  age: :created_at, score: :score)
-                      .first(15)
 
     @total_post_count = @posts.count
+    @posts = @posts.first(@limit)
     render layout: 'without_sidebar'
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,19 +46,11 @@ class UsersController < ApplicationController
   def show
     @abilities = Ability.on_user(@user)
 
-    all_posts = if current_user&.privilege?('flag_curate') || @user == current_user
-                  @user.posts
-                else
-                  @user.posts.undeleted
-                end
-                .list_includes
-                .joins(:category)
-                .where('IFNULL(categories.min_view_trust_level, 0) <= ?', current_user&.trust_level || 0)
-                .user_sort({ term: params[:sort], default: :score },
-                           age: :created_at, score: :score)
+    @posts = set_posts.user_sort({ term: params[:sort], default: :score },
+                                 age: :created_at, score: :score)
+                      .first(15)
 
-    @posts = all_posts.first(15)
-    @total_post_count = all_posts.count
+    @total_post_count = @posts.count
     render layout: 'without_sidebar'
   end
 
@@ -215,17 +207,13 @@ class UsersController < ApplicationController
   end
 
   def posts
-    @posts = if current_user&.privilege?('flag_curate') || @user == current_user
-               Post.all
-             else
-               Post.undeleted
-             end.by(@user).list_includes.joins(:category)
-             .where('IFNULL(categories.min_view_trust_level, 0) <= ?', current_user&.trust_level || 0)
-             .user_sort({ term: params[:sort], default: :score },
-                        activity: :last_activity,
-                        age: :created_at,
-                        score: :score)
-             .paginate(page: params[:page], per_page: 25)
+    @posts = set_posts.user_sort({ term: params[:sort], default: :score },
+                                 activity: :last_activity,
+                                 age: :created_at,
+                                 score: :score)
+                      .order(created_at: :desc)
+                      .paginate(page: params[:page], per_page: 25)
+
     respond_to do |format|
       format.html do
         render :posts
@@ -659,6 +647,17 @@ class UsersController < ApplicationController
                   :status, :source,
                   :include_tags, :exclude_tags,
                   include_tags: [], exclude_tags: [])
+  end
+
+  def set_posts
+    @posts = if current_user&.privilege?('flag_curate') || @user == current_user
+               @user.posts
+             else
+               @user.posts.undeleted
+             end
+             .list_includes
+             .joins(:category)
+             .where('IFNULL(categories.min_view_trust_level, 0) <= ?', current_user&.trust_level || 0)
   end
 
   def set_user

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -48,6 +48,20 @@ class UsersControllerTest < ActionController::TestCase
     assert_response(:not_found)
   end
 
+  test 'should correctly show user post count' do
+    std = users(:standard_user)
+    post_count = Post.all.by(std).count
+    limit = post_count - 1
+
+    assert post_count.positive? && limit.positive?
+
+    sign_in std
+    get :show, params: { id: std.id, limit: limit }
+
+    assert_equal assigns(:posts)&.count, limit
+    assert_equal assigns(:total_post_count), post_count
+  end
+
   test 'should get mod tools page' do
     sign_in users(:moderator)
     get :mod, params: { id: users(:standard_user).id }


### PR DESCRIPTION
closes #2008 

This PR adds a _secondary_ order by creation timestamp to user's posts (newest first) - this should be safe enough for 99.99% cases (creation timestamp collision is highly unlikely). In addition, the PR lays the groundwork for a proper action callback by making the logic for setting posts in the `show` and `posts` actions shared (that's as far as I am willing to go in scope for this particular fix).