### PR TITLE
Order tag search matches by their length

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -49,7 +49,7 @@ class Tag < ApplicationRecord
 
     # Select from the union of the above queries, select only the tag columns such that we can distinct them
     from(Arel.sql("((#{q1.to_sql}) UNION (#{q2.to_sql})) tags"))
-      .order(Arel.sql(sanitize_sql_array(['name LIKE ? DESC, name', value])))
+      .order(Arel.sql(sanitize_sql_array(['name LIKE ? DESC, char_length(name), name', value])))
       .select(Tag.column_names.map { |c| "tags.#{c}" })
       .distinct
   end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -12,7 +12,7 @@ class TagTest < ActiveSupport::TestCase
 
     tags = Tag.search(term).to_a
 
-    name_match_sorted = tags.select { |t| t.name.include?(term) }.sort { |a, b| a.name <=> b.name }
+    name_match_sorted = tags.select { |t| t.name.include?(term) }.sort { |a, b| a.name.length <=> b.name.length }
     excerpt_match_sorted = tags.select { |t| t.excerpt&.include?(term) }.sort { |a, b| a.name <=> b.name }
     sorted_tags = name_match_sorted + excerpt_match_sorted
 


### PR DESCRIPTION
closes #2009 

With the PR applied, matching tags should prefer full or close to full matches over longer partial ones:

<img width="755" height="263" alt="Screenshot from 2026-03-12 02-27-33" src="https://github.com/user-attachments/assets/1df5662f-775c-4645-91fa-397effd76d8e" />

credit to @MoshiKoi for suggesting the solution in our [Discord discussion](<https://discord.com/channels/634104110131445811/676843271762214932/1481385629467148478>)

As opposed to the current sorting that only sorts tag names alphabetically:

<img width="755" height="263" alt="image" src="https://github.com/user-attachments/assets/2442094b-d860-4786-8dcc-fcf0417ddae2" />

