### PR TITLE
Hotfix: Preload community and user for error report

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -15,7 +15,7 @@ class AdminController < ApplicationController
                    ErrorLog.all
                  else
                    ErrorLog.where(community: RequestContext.community)
-                 end
+                 end.includes(:community, :user)
 
     @error_types = base_scope.select(:klass).distinct.to_a.map(&:klass)
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -15,9 +15,11 @@ class AdminController < ApplicationController
                    ErrorLog.all
                  else
                    ErrorLog.where(community: RequestContext.community)
-                 end.includes(:community, :user)
+                 end
 
     @error_types = base_scope.select(:klass).distinct.to_a.map(&:klass)
+
+    base_scope = base_scope.includes(:community, :user)
 
     if params[:type].present?
       base_scope = base_scope.where(klass: params[:type])


### PR DESCRIPTION
Admin error reports pages are currently taking ~20s to load on prod because we're hitting an N+1 query where we don't preload `community`. I've added this preload (and one for `user` because we also use that, although it doesn't seem to be causing an issue).