### PR TITLE
Fix the "skipping 0 more comments" case

### DIFF
--- a/app/views/comment_threads/_expanded.html.erb
+++ b/app/views/comment_threads/_expanded.html.erb
@@ -59,8 +59,9 @@
           <%= render 'comments/skip_deleted', inline: inline, num_skipped: skipped_deleted, thread: thread %>
           <% skipped_deleted = 0 %>
         <% end %>
-        <% if shown_comments_count > max_shown_comments && comment.id.to_i == comment_id.to_i %>
-          <%= render 'comments/skip_more', shown_count: shown_comments_count, thread: thread %>
+        <% skipped_more = thread.reply_count - shown_comments_count %>
+        <% if shown_comments_count > max_shown_comments && skipped_more.positive? && comment.id.to_i == comment_id.to_i %>
+          <%= render 'comments/skip_more', num_skipped: skipped_more, thread: thread %>
         <% end %>
         <div class="widget--body" role="listitem">
           <%= render 'comments/comment', comment: comment, pingable: pingable %>

--- a/app/views/comments/_skip_more.html.erb
+++ b/app/views/comments/_skip_more.html.erb
@@ -2,11 +2,10 @@
     Renders widgets indicating that there more comments are not shown
 
     Variables:
-      shown_count : number of comments shown on the thread
+      num_skipped : number of comments skipped on the thread
       thread      : CommentThread to display the widget for
 %>
 
 <div class="widget--body widget--more-comments" role="listitem">
-  <% skipped_count = thread.reply_count - shown_count %>
-  <p>Skipping <%= pluralize(skipped_count, 'more comment') %></p>
+  <p>Skipping <%= pluralize(num_skipped, 'more comment') %></p>
 </div>


### PR DESCRIPTION
closes #2017

To reproduce the issue on `develop`:

1. Create a new comment thread on any post;
2. Add _exactly_ 5 comments to the new thread (without navigating away);
3. Add a 6th comment to the thread;
4. Observe the "Skipping 0 more comments" widget showing up before the 6th comment;

