### PR TITLE
fixed at-mention suggestions at line start in multiline comments

### DIFF
--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -387,7 +387,7 @@ $(() => {
 
     const $tgt = $(ev.target);
     const content = $tgt.val();
-    const splat = content.split(' ');
+    const splat = content.split(/\s+/);
     const caretPos = $tgt[0].selectionStart;
     const [currentWord, posInWord] = QPixel.currentCaretSequence(splat, caretPos);
 


### PR DESCRIPTION
closes #2021

<img width="461" height="139" alt="Screenshot from 2026-03-17 17-57-07" src="https://github.com/user-attachments/assets/d878de1f-771d-4452-94b3-1c61441befb0" />

To reproduce on `develop`:

1. Start a new comment to an existing comment thread.
2. Type in a partial @-mention at the start of the first line - note the suggestions popup appearing.
3. Add a new line and repeat step 2 - note the suggestions popup **not** appearing at all.