### PR TITLE
Fix pressing "Enter" in the "add link" modal submitting the parent form

### DIFF
--- a/app/assets/javascripts/markdown.js
+++ b/app/assets/javascripts/markdown.js
@@ -29,10 +29,9 @@ $(() => {
     }
   });
 
-  $('#markdown-link-name, #markdown-link-url').on('keydown', (ev) => {
-    if (ev.keyCode === 13) {
-      // don't submit post form on enter in link modal
-      ev.stopPropagation();
+  QPixel.DOM?.addSelectorListener('keypress', '#markdown-link-name, #markdown-link-url', (ev) => {
+    if (ev instanceof KeyboardEvent && ev.key === 'Enter') {
+      ev.preventDefault();
     }
   });
 


### PR DESCRIPTION
closes #2023

This is a "quick and dirty" version of the fix as I don't have full access to my usual tools at the moment (a proper fix would be moving the modal outside the `markdown_tools` partial as `form` tags can't be nested, wrapping the inputs in a `<form>` tag, and cancelling [`preventDefault`] any `submit` event on it - see the `image_upload` partial for how it should be done). Nevertheless, it should do the trick.