### PR TITLE
prevent nuking a tag that has children

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -228,7 +228,6 @@ class TagsController < ApplicationController
     if @tag.children.any?
       flash[:error] = 'Cannot delete a tag that has children.'
     else
-
       Post.transaction do
         AuditLog.admin_audit event_type: 'tag_nuke', related: @tag, user: current_user,
                              comment: "#{@tag.name} (#{@tag.id})"
@@ -253,8 +252,8 @@ class TagsController < ApplicationController
       end
 
       flash[:success] = "Deleted #{@tag.name}"
-      redirect_to category_tags_path(@category)
     end
+    redirect_to category_tags_path(@category)
   end
 
   def nuke_warning; end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -226,34 +226,34 @@ class TagsController < ApplicationController
 
   def nuke
     if @tag.children.any?
-      flash[:error] = "Cannot delete a tag that has children."
+      flash[:error] = 'Cannot delete a tag that has children.'
     else
 
-    Post.transaction do
-      AuditLog.admin_audit event_type: 'tag_nuke', related: @tag, user: current_user,
-                           comment: "#{@tag.name} (#{@tag.id})"
+      Post.transaction do
+        AuditLog.admin_audit event_type: 'tag_nuke', related: @tag, user: current_user,
+                             comment: "#{@tag.name} (#{@tag.id})"
 
-      tables = ['posts_tags', 'categories_moderator_tags', 'categories_required_tags', 'categories_topic_tags',
-                'post_history_tags', 'suggested_edits_tags', 'suggested_edits_before_tags']
+        tables = ['posts_tags', 'categories_moderator_tags', 'categories_required_tags', 'categories_topic_tags',
+                  'post_history_tags', 'suggested_edits_tags', 'suggested_edits_before_tags']
 
-      # Remove tag from caches
-      caches_sql = 'UPDATE posts INNER JOIN posts_tags ON posts.id = posts_tags.post_id ' \
-                   'SET posts.tags_cache = REPLACE(posts.tags_cache, ?, ?) ' \
-                   'WHERE posts_tags.tag_id = ?'
-      exec_sql([caches_sql, "\n- #{@tag.name}\n", "\n", @tag.id])
+        # Remove tag from caches
+        caches_sql = 'UPDATE posts INNER JOIN posts_tags ON posts.id = posts_tags.post_id ' \
+                     'SET posts.tags_cache = REPLACE(posts.tags_cache, ?, ?) ' \
+                     'WHERE posts_tags.tag_id = ?'
+        exec_sql([caches_sql, "\n- #{@tag.name}\n", "\n", @tag.id])
 
-      # Delete all references to the tag
-      tables.each do |tbl|
-        sql = "DELETE FROM #{tbl} WHERE tag_id = ?"
-        exec_sql([sql, @tag.id])
+        # Delete all references to the tag
+        tables.each do |tbl|
+          sql = "DELETE FROM #{tbl} WHERE tag_id = ?"
+          exec_sql([sql, @tag.id])
+        end
+
+        # Nuke it
+        @tag.destroy
       end
 
-      # Nuke it
-      @tag.destroy
-    end
-
-    flash[:success] = "Deleted #{@tag.name}"
-    redirect_to category_tags_path(@category)
+      flash[:success] = "Deleted #{@tag.name}"
+      redirect_to category_tags_path(@category)
     end
   end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -225,6 +225,10 @@ class TagsController < ApplicationController
   end
 
   def nuke
+    if @tag.children.any?
+      flash[:error] = "Cannot delete a tag that has children."
+    else
+
     Post.transaction do
       AuditLog.admin_audit event_type: 'tag_nuke', related: @tag, user: current_user,
                            comment: "#{@tag.name} (#{@tag.id})"
@@ -250,6 +254,7 @@ class TagsController < ApplicationController
 
     flash[:success] = "Deleted #{@tag.name}"
     redirect_to category_tags_path(@category)
+    end
   end
 
   def nuke_warning; end

--- a/app/views/tags/nuke_warning.html.erb
+++ b/app/views/tags/nuke_warning.html.erb
@@ -7,7 +7,9 @@
 <h1>Delete tag <%= @tag.name %></h1>
 
 <% if @tag.children.any? %>
-<p><strong>Tags with children cannot be deleted. Please reparent the children first.</strong></p>
+<div class="notice is-warning has-color-yellow-900">
+  <p>Tags with children cannot be deleted. Please reparent the children first.</p>
+</div>
 <% else %>
 
 <div class="notice is-danger has-color-red-900">

--- a/app/views/tags/nuke_warning.html.erb
+++ b/app/views/tags/nuke_warning.html.erb
@@ -6,6 +6,10 @@
 
 <h1>Delete tag <%= @tag.name %></h1>
 
+<% if @tag.children.any? %>
+<p><strong>Tags with children cannot be deleted. Please reparent the children first.</strong></p>
+<% else %>
+
 <div class="notice is-danger has-color-red-900">
   <p>
     Deleting a tag results in making it seem to have never existed in the first place. No record will be kept of the tag.
@@ -26,4 +30,5 @@
 <%= link_to nuke_tag_path(id: @category.id, tag_id: @tag.id), class: 'button is-danger is-filled', method: :delete,
             role: 'button' do %>
   I understand, delete <%= @tag.name %>
+<% end %>
 <% end %>


### PR DESCRIPTION
If a tag has children, replace the nuke page with its warnings and "are you sure?" button with a message saying you need to handle the children first.  I opted for a simple message rather than disabling the button because with that whole page full of red boxes, doing that felt like burying the lede.

While it shouldn't be possible to reach the `nuke` method in the controller, I also added a check there just in case.

Minimally fixes https://github.com/codidact/qpixel/issues/2025.  A more advanced fix would be to do something reasonable with the children, but that requires some design discussion as I'm not sure we want to simply reparent them.  Maybe we want a human to decide.  In the meantime, this at least prevents the server error.
