### PR TITLE
Make user profile query more efficiently

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -21,7 +21,7 @@ class ReportsController < ApplicationController
     @answers = Answer.recent(1.year.ago).undeleted
     @comments = Comment.recent(1.year.ago).undeleted
     @this_month = Post.recent(1.month.ago).undeleted
-    @categories = Category.where('IFNULL(categories.min_view_trust_level, 0) <= ?', current_user&.trust_level || 0)
+    @categories = Category.where('categories.min_view_trust_level <= ?', current_user&.trust_level || 0)
                           .order(:sequence)
     @posts_categories = Post.in(@categories).group(:category_id).count
   end
@@ -51,7 +51,7 @@ class ReportsController < ApplicationController
     @comments = Comment.unscoped.recent(1.year.ago).undeleted
     @this_month = Post.unscoped.recent(1.month.ago).undeleted
     @categories = Category.unscoped
-                          .where('IFNULL(categories.min_view_trust_level, 0) <= ?', current_user&.trust_level || 0)
+                          .where('categories.min_view_trust_level <= ?', current_user&.trust_level || 0)
                           .includes(:community).order(:community_id, :sequence)
     @posts_categories = Post.unscoped.in(@categories).group(:category_id).count
     @global = true

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -50,7 +50,11 @@ class UsersController < ApplicationController
     @posts = set_posts.user_sort({ term: params[:sort], default: :score },
                                  age: :created_at, score: :score)
 
-    @total_post_count = @posts.count
+    @total_post_count = if @user == current_user
+                          @user.posts.undeleted.count
+                        else
+                          @user.posts.count
+                        end
     @posts = @posts.first(@limit)
     render layout: 'without_sidebar'
   end
@@ -651,14 +655,16 @@ class UsersController < ApplicationController
   end
 
   def set_posts
-    @posts = if current_user&.privilege?('flag_curate') || @user == current_user
-               @user.posts
-             else
-               @user.posts.undeleted
-             end
-             .list_includes
-             .joins(:category)
-             .where('IFNULL(categories.min_view_trust_level, 0) <= ?', current_user&.trust_level || 0)
+    Rack::MiniProfiler.step('set_posts') do
+      @posts = if current_user&.privilege?('flag_curate') || @user == current_user
+                 @user.posts
+               else
+                 @user.posts.undeleted
+               end
+               .list_includes
+               .joins(:category)
+               .where('categories.min_view_trust_level <= ?', current_user&.trust_level || 0)
+    end
   end
 
   def set_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -50,7 +50,15 @@ class UsersController < ApplicationController
     @posts = set_posts.user_sort({ term: params[:sort], default: :score },
                                  age: :created_at, score: :score)
 
-    @total_post_count = Post.all.by(@user).count
+    @total_post_count = if @user == current_user || current_user&.at_least_moderator?
+                          Post.all.by(@user).count
+                        else
+                          Post.all.by(@user)
+                              .undeleted
+                              .joins(:category)
+                              .where('categories.min_view_trust_level <= ?', current_user&.trust_level || 0)
+                              .count
+                        end
     @posts = @posts.first(@limit)
     render layout: 'without_sidebar'
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -50,11 +50,7 @@ class UsersController < ApplicationController
     @posts = set_posts.user_sort({ term: params[:sort], default: :score },
                                  age: :created_at, score: :score)
 
-    @total_post_count = if @user == current_user
-                          @user.posts.undeleted.count
-                        else
-                          @user.posts.count
-                        end
+    @total_post_count = Post.all.by(@user).count
     @posts = @posts.first(@limit)
     render layout: 'without_sidebar'
   end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -72,7 +72,7 @@ class Category < ApplicationRecord
     end
 
     trust_level = user&.trust_level || 0
-    Category.where('IFNULL(min_view_trust_level, -1) <= ?', trust_level)
+    Category.where('min_view_trust_level <= ?', trust_level)
   end
 
   # Gets category matching a given name

--- a/db/migrate/20260320104406_add_not_null_default_to_categories.rb
+++ b/db/migrate/20260320104406_add_not_null_default_to_categories.rb
@@ -1,0 +1,7 @@
+class AddNotNullDefaultToCategories < ActiveRecord::Migration[7.2]
+  def change
+    Category.unscoped.where(min_view_trust_level: nil).update_all(min_view_trust_level: 0)
+    change_column :categories, :min_view_trust_level, :integer, default: 0, null: false
+    add_index :categories, :min_view_trust_level
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_04_104100) do
+ActiveRecord::Schema[7.2].define(version: 2026_03_20_104406) do
   create_table "abilities", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "community_id"
     t.string "name"
@@ -104,7 +104,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_04_104100) do
     t.string "color_code"
     t.text "asking_guidance_override", size: :medium
     t.text "answering_guidance_override", size: :medium
-    t.integer "min_view_trust_level"
+    t.integer "min_view_trust_level", default: 0, null: false
     t.bigint "license_id"
     t.integer "sequence"
     t.boolean "use_for_hot_posts", default: true


### PR DESCRIPTION
Strips the count query back without all the joins. Also adds a NOT NULL to `categories.min_view_trust_level` because the way we were querying that was inefficient, and adds an index for it.