### PR TITLE
Fix category change select dropdown

### DIFF
--- a/app/assets/javascripts/categories.js
+++ b/app/assets/javascripts/categories.js
@@ -45,7 +45,10 @@ $(() => {
 
   $('.js-category-select').each((_i, el) => {
     const $tgt = $(el);
+    /** @type {HTMLElement|undefined} */
+    const modal = el.closest('.modal--container') || void 0;
     $tgt.select2({
+      dropdownParent: modal,
       ajax: {
         url: '/categories',
         headers: { 'Accept': 'application/json' },

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -5,7 +5,15 @@ class CategoriesController < ApplicationController
   before_action :verify_view_access, except: [:index, :homepage, :new, :create, :post_types]
 
   def index
-    @categories = Category.accessible_to(current_user).all.order(sequence: :asc, id: :asc)
+    @categories = if params[:term].present?
+                    Category.search(params[:term])
+                  else
+                    Category.all
+                  end
+
+    @categories = @categories.accessible_to(current_user)
+                             .order(sequence: :asc, id: :asc)
+
     respond_to do |format|
       format.html
       format.json do

--- a/test/controllers/categories_controller_test.rb
+++ b/test/controllers/categories_controller_test.rb
@@ -9,6 +9,23 @@ class CategoriesControllerTest < ActionController::TestCase
     assert_not_nil assigns(:categories)
   end
 
+  test ':index should  correctly search categories' do
+    get :index
+    assert_response(:success)
+    @all_categories = assigns(:categories)
+    assert_not_nil @all_categories
+    assert @all_categories.any?
+
+    get :index, params: { term: 'meta' }
+    assert_response(:success)
+    @search_categories = assigns(:categories)
+    assert_not_nil @search_categories
+    assert @search_categories.any?
+    assigns(@search_categories.all? { |c| c.name.downcase.match?('meta') })
+
+    assert_not_equal @all_categories.size, @search_categories.size
+  end
+
   test 'homepage should show categories in the correct order' do
     get :homepage
     assert_not_nil assigns(:header_categories)


### PR DESCRIPTION
closes #2032

<img width="790" height="562" alt="image" src="https://github.com/user-attachments/assets/3a964bbf-5c30-4318-997f-c4ba77d809db" />

The PR also actually enables category search by name (that it doesn't work is, ironically, only noticeable when trying to narrow down a category change dropdown's options):

<img width="790" height="174" alt="image" src="https://github.com/user-attachments/assets/3e2b57ba-1f93-442b-80af-3b118aeda598" />

