### PR TITLE
fixed setting SiteLogoPath to a missing asset causing server errors

### DIFF
--- a/app/helpers/advertisement_helper.rb
+++ b/app/helpers/advertisement_helper.rb
@@ -78,18 +78,25 @@ module AdvertisementHelper
   # images.
   # @param icon_path [String] A path or URI from which to load the image. If using a path this should be the asset path
   #   as it would be accessible through the Rails server - see example.
-  # @return [Magick::ImageList] An ImageList containing the icon.
+  # @return [Magick::ImageList, nil] An ImageList containing the icon if found
   # @example Load an image from app/assets/images:
   #   # This uses the path from which the image would be accessed via HTTP.
   #   helpers.community_icon('/assets/codidact.png')
   def community_icon(icon_path)
-    if icon_path.start_with? '/assets/'
-      icon = Magick::ImageList.new("./app/assets/images/#{File.basename(icon_path)}")
+    return nil unless icon_path.present?
+
+    expanded_path = File.expand_path(icon_path)
+
+    if expanded_path.start_with?('/assets/')
+      icon = Magick::ImageList.new("./app/assets/images/#{File.basename(expanded_path)}")
     else
       icon = Magick::ImageList.new
       icon_path_content = URI.open(icon_path).read # rubocop:disable Security/Open
       icon.from_blob(icon_path_content)
     end
+
     icon
+  rescue
+    nil
   end
 end

--- a/app/helpers/advertisements/article_helper.rb
+++ b/app/helpers/advertisements/article_helper.rb
@@ -26,9 +26,9 @@ module Advertisements::ArticleHelper
         s.fill = 'white'
       end
 
-      icon_path = SiteSetting.find_by(name: 'SiteLogoPath', community: article.community).typed
-      if icon_path.present?
-        icon = community_icon(icon_path)
+      icon = community_icon(SiteSetting['SiteLogoPath', community: article.community])
+
+      if icon.present?
         icon.resize_to_fit!(120, 50)
         ad.composite!(icon, SouthWestGravity, 20, 15, SrcAtopCompositeOp)
       else

--- a/app/helpers/advertisements/community_helper.rb
+++ b/app/helpers/advertisements/community_helper.rb
@@ -25,9 +25,9 @@ module Advertisements::CommunityHelper
         img.fill = 'white'
       end
 
-      icon_path = SiteSetting['SiteLogoPath']
-      if icon_path.present?
-        icon = community_icon(icon_path)
+      icon = community_icon(SiteSetting['SiteLogoPath'])
+
+      if icon.present?
         icon.resize_to_fit!(400, 200)
         ad.composite!(icon, CenterGravity, 0, -175, SrcAtopCompositeOp)
       else

--- a/app/helpers/advertisements/question_helper.rb
+++ b/app/helpers/advertisements/question_helper.rb
@@ -29,9 +29,9 @@ module Advertisements::QuestionHelper
         img.fill = 'white'
       end
 
-      icon_path = SiteSetting.find_by(name: 'SiteLogoPath', community: question.community).typed
-      if icon_path.present?
-        icon = community_icon(icon_path)
+      icon = community_icon(SiteSetting['SiteLogoPath', community: question.community])
+
+      if icon.present?
         icon.resize_to_fit!(175, 75)
         ad.composite!(icon, SouthWestGravity, 20, 15, SrcAtopCompositeOp)
       else

--- a/test/helpers/advertisement_helper_test.rb
+++ b/test/helpers/advertisement_helper_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class AdvertisementHelperTest < ActionView::TestCase
+  include ApplicationHelper
+  include AdvertisementHelper
+
+  setup do
+    @external_png = File.open(Rails.root.join('app/assets/images/logo.png'))
+    stub_request(:get, 'https://example.com/external.png').to_return(body: @external_png)
+  end
+
+  teardown do
+    @external_png.close
+  end
+
+  test ':community_icon should gracefully handle non-existent paths' do
+    assert_nothing_raised do
+      icon = community_icon('/assets/non-existent.jpeg')
+      assert_nil icon
+    end
+  end
+
+  test ':community_icon should correctly handle external URLs' do
+    icon = community_icon('https://example.com/external.png')
+    assert icon.is_a?(Magick::ImageList)
+  end
+end


### PR DESCRIPTION
closes #2034

To reproduce on develop, set the `SiteLogoPath` site setting to a path starting with `/assets/` and pointing to a non-existent asset (any gibberish should be fine). Observe a server error upon visiting, for example, `<your origin here>/ca/posts/random.png` (will attempt to generate a community ad for a random post). With the PR applied doing the latter should result in a valid image response with the community name instead of the logo.

Example community ad with a valid logo path:
<img width="637" height="524" alt="2026-04-01_07-33" src="https://github.com/user-attachments/assets/f28b3c56-2605-4954-935b-eef85b1a9db0" />

And the same ad with an invalid logo path:
<img width="631" height="526" alt="2026-04-01_07-35" src="https://github.com/user-attachments/assets/04ed315f-4e2e-47b2-809a-61e43a2cc271" />