### PR TITLE
Fix user list avatar size at 48 by 48 pixels

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -41,10 +41,10 @@ img {
   }
 
   img {
-    min-height: 32px;
-    min-width: 32px;
-    width: 32px;
-    height: 32px;
+    min-height: 48px;
+    min-width: 48px;
+    width: 48px;
+    height: 48px;
     object-fit: contain;
   }
 


### PR DESCRIPTION
Fixes #462 by preventing avatars from shrinking when the text of a user card gets too wide. This forces text wrapping to happen a few characters sooner, but keeps all of the avatars the same size.

## Electrical Engineering user list currently
<img width="1466" height="1170" alt="User card in 3 columns, with the avatars at various sizes" src="https://github.com/user-attachments/assets/ff5ce060-45f2-4fb7-aaf9-53cd59379034" />

## Electrical Engineering user list with this fix
<img width="1466" height="1288" alt="User cards in 3 columns, with the avatars all with maximum dimension 48" src="https://github.com/user-attachments/assets/812c428e-12b8-493a-9d10-666378549afb" />

Square avatars are now always displayed at 48 by 48 pixels. Portrait avatars have height 48 pixels. Landscape avatars have width 48 pixels.