### PR TITLE
Include post author in comment pings

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -92,9 +92,8 @@ class CommentsController < ApplicationController
                                         .where('link LIKE ?', "#{thread_url}%")
         next if existing_notification.exists?
 
-        title = @post.parent.nil? ? @post.title : @post.parent.title
         follower.user.create_notification("There are new comments in a followed thread '#{@comment_thread.title}' " \
-                                          "on the post '#{title}'",
+                                          "on the post '#{@comment.root.title}'",
                                           helpers.comment_link(@comment))
       end
     else

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -58,7 +58,7 @@ class CommentsController < ApplicationController
       notification = "New comment thread on #{@comment.root.title}: #{@comment_thread.title}"
 
       NewThreadFollower.where(post: @post).each do |ntf|
-        unless ntf.user.same_as?(current_user)
+        unless ntf.user.same_as?(current_user) || pings.include?(ntf.user_id)
           ntf.user.create_notification(notification, helpers.comment_link(@comment))
         end
         ThreadFollower.create(user: ntf.user, comment_thread: @comment_thread)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -477,8 +477,6 @@ class CommentsController < ApplicationController
       user = User.where(id: p).first
       next if user.nil?
 
-      next if user.same_as?(@comment.post.user)
-
       title = @post.parent.nil? ? @post.title : @post.parent.title
       user.create_notification("You were mentioned in a comment in the thread '#{@comment_thread.title}' " \
                                "on the post '#{title}'",

--- a/test/controllers/comments/create_test.rb
+++ b/test/controllers/comments/create_test.rb
@@ -24,6 +24,9 @@ class CommentsControllerTest < ActionController::TestCase
     assert_equal before_uninvolved_notifs, users(:moderator).notifications.count,
                  'Uninvolved notification created when it should not have been'
     assert assigns(:comment_thread).followed_by?(users(:editor)), 'Follower record not created for thread author'
+    assert_equal users(:standard_user).notifications.last.content,
+                 'New comment thread on Q1 - This is test question number one: sample thread title',
+                 'Post author notification of new thread has incorrect wording'
   end
 
   test 'should correctly notify post author of created thread pinging post author' do
@@ -41,6 +44,9 @@ class CommentsControllerTest < ActionController::TestCase
     assert_nil flash[:danger]
     assert_equal before_author_notifs + 1, users(:standard_user).notifications.count,
                  'Author notification not created when it should have been'
+    assert_equal users(:standard_user).notifications.last.content,
+                 "You were mentioned in a comment in the thread 'sample thread title' on the post 'Q1 - This is test question number one'",
+                 'Post author notification of mention in new thread has incorrect wording'
   end
 
   test 'should correctly default thread title if not provided' do
@@ -134,6 +140,9 @@ class CommentsControllerTest < ActionController::TestCase
     assert_equal before_uninvolved_notifs, users(:moderator).notifications.count,
                  'Uninvolved notification created when it should not have been'
     assert assigns(:comment_thread).followed_by?(users(:editor)), 'Follower record not created for comment author'
+    assert_equal users(:standard_user).notifications.last.content,
+                 "There are new comments in a followed thread 'sample' on the post 'Q1 - This is test question number one'",
+                 'Post author notification of new comment has incorrect wording'
   end
 
   test 'should correctly notify post author of comment pinging post author in thread' do
@@ -149,6 +158,9 @@ class CommentsControllerTest < ActionController::TestCase
     assert_not_nil assigns(:comment)&.id
     assert_equal before_author_notifs + 1, users(:standard_user).notifications.count,
                  'Post author notification not created when it should have been'
+    assert_equal users(:standard_user).notifications.last.content,
+                 "You were mentioned in a comment in the thread 'sample' on the post 'Q1 - This is test question number one'",
+                 'Post author notification of mention in comment has incorrect wording'
   end
 
   test 'should correctly redirect depending on the inline parameter' do

--- a/test/controllers/comments/create_test.rb
+++ b/test/controllers/comments/create_test.rb
@@ -26,6 +26,23 @@ class CommentsControllerTest < ActionController::TestCase
     assert assigns(:comment_thread).followed_by?(users(:editor)), 'Follower record not created for thread author'
   end
 
+  test 'should correctly notify post author of created thread pinging post author' do
+    sign_in users(:editor)
+
+    before_author_notifs = users(:standard_user).notifications.count
+
+    try_create_thread(posts(:question_one), mentions: [users(:standard_user)])
+
+    assert_response(:found)
+    assert_redirected_to post_path(assigns(:post))
+    assert_not_nil assigns(:post)
+    assert_not_nil assigns(:comment)&.id
+    assert_not_nil assigns(:comment_thread)&.id
+    assert_nil flash[:danger]
+    assert_equal before_author_notifs + 1, users(:standard_user).notifications.count,
+                 'Author notification not created when it should have been'
+  end
+
   test 'should correctly default thread title if not provided' do
     sign_in users(:editor)
 
@@ -117,6 +134,21 @@ class CommentsControllerTest < ActionController::TestCase
     assert_equal before_uninvolved_notifs, users(:moderator).notifications.count,
                  'Uninvolved notification created when it should not have been'
     assert assigns(:comment_thread).followed_by?(users(:editor)), 'Follower record not created for comment author'
+  end
+
+  test 'should correctly notify post author of comment pinging post author in thread' do
+    sign_in users(:editor)
+    before_author_notifs = users(:standard_user).notifications.count
+
+    try_create_comment(comment_threads(:normal), mentions: [users(:standard_user)])
+
+    assert_response(:found)
+    assert_redirected_to comment_thread_path(assigns(:comment_thread))
+    assert_not_nil assigns(:post)
+    assert_not_nil assigns(:comment_thread)
+    assert_not_nil assigns(:comment)&.id
+    assert_equal before_author_notifs + 1, users(:standard_user).notifications.count,
+                 'Post author notification not created when it should have been'
   end
 
   test 'should correctly redirect depending on the inline parameter' do


### PR DESCRIPTION
Fixes #2046.

In #1548 I neglected to remove 1 special case treatment of the post author, resulting in no notification when the post author is mentioned in a comment under their own post. This pull request adds a fix and tests.