### PR TITLE
Make ping notification reflect new thread or comment in a thread

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -472,12 +472,14 @@ class CommentsController < ApplicationController
 
   # @param pings [Array<Integer>] list of pinged user ids
   def apply_pings(pings)
-    context = @comment_thread.comments.first.same_as?(@comment) ? "new" : "comment in the"
-    notification_text = "You were mentioned in a #{context} thread '#{@comment_thread.title}' on the post '#{@comment.root.title}'"
+    context = @comment_thread.comments.first.same_as?(@comment) ? 'new' : 'comment in the'
+    notification_text =
+      "You were mentioned in a #{context} thread '#{@comment_thread.title}' on the post '#{@comment.root.title}'"
 
     pings.each do |p|
       user = User.where(id: p).first
       next if user.nil?
+
       user.create_notification(notification_text, helpers.comment_link(@comment))
     end
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -472,14 +472,13 @@ class CommentsController < ApplicationController
 
   # @param pings [Array<Integer>] list of pinged user ids
   def apply_pings(pings)
+    context = @comment_thread.comments.first.same_as?(@comment) ? "new" : "comment in the"
+    notification_text = "You were mentioned in a #{context} thread '#{@comment_thread.title}' on the post '#{@comment.root.title}'"
+
     pings.each do |p|
       user = User.where(id: p).first
       next if user.nil?
-
-      title = @post.parent.nil? ? @post.title : @post.parent.title
-      user.create_notification("You were mentioned in a comment in the thread '#{@comment_thread.title}' " \
-                               "on the post '#{title}'",
-                               helpers.comment_link(@comment))
+      user.create_notification(notification_text, helpers.comment_link(@comment))
     end
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,6 +3,7 @@ class Comment < ApplicationRecord
   include PostRelated
   include SoftDeletable
   include Timestamped
+  include Identity
 
   USER_PING_REG_EXP = /@#(-?\d+)/
 

--- a/test/controllers/comments/create_test.rb
+++ b/test/controllers/comments/create_test.rb
@@ -24,8 +24,8 @@ class CommentsControllerTest < ActionController::TestCase
     assert_equal before_uninvolved_notifs, users(:moderator).notifications.count,
                  'Uninvolved notification created when it should not have been'
     assert assigns(:comment_thread).followed_by?(users(:editor)), 'Follower record not created for thread author'
-    assert_equal users(:standard_user).notifications.last.content,
-                 'New comment thread on Q1 - This is test question number one: sample thread title',
+    assert_equal 'New comment thread on Q1 - This is test question number one: sample thread title',
+                 users(:standard_user).notifications.last.content,
                  'Post author notification of new thread has incorrect wording'
   end
 
@@ -44,8 +44,8 @@ class CommentsControllerTest < ActionController::TestCase
     assert_nil flash[:danger]
     assert_equal before_author_notifs + 1, users(:standard_user).notifications.count,
                  'Author notification not created when it should have been'
-    assert_equal users(:standard_user).notifications.last.content,
-                 "You were mentioned in a comment in the thread 'sample thread title' on the post 'Q1 - This is test question number one'",
+    assert_equal "You were mentioned in a new thread 'sample thread title' on the post 'Q1 - This is test question number one'",
+                 users(:standard_user).notifications.last.content,
                  'Post author notification of mention in new thread has incorrect wording'
   end
 
@@ -140,8 +140,8 @@ class CommentsControllerTest < ActionController::TestCase
     assert_equal before_uninvolved_notifs, users(:moderator).notifications.count,
                  'Uninvolved notification created when it should not have been'
     assert assigns(:comment_thread).followed_by?(users(:editor)), 'Follower record not created for comment author'
-    assert_equal users(:standard_user).notifications.last.content,
-                 "There are new comments in a followed thread 'sample' on the post 'Q1 - This is test question number one'",
+    assert_equal "There are new comments in a followed thread 'sample' on the post 'Q1 - This is test question number one'",
+                 users(:standard_user).notifications.last.content,
                  'Post author notification of new comment has incorrect wording'
   end
 
@@ -158,8 +158,8 @@ class CommentsControllerTest < ActionController::TestCase
     assert_not_nil assigns(:comment)&.id
     assert_equal before_author_notifs + 1, users(:standard_user).notifications.count,
                  'Post author notification not created when it should have been'
-    assert_equal users(:standard_user).notifications.last.content,
-                 "You were mentioned in a comment in the thread 'sample' on the post 'Q1 - This is test question number one'",
+    assert_equal "You were mentioned in a comment in the thread 'sample' on the post 'Q1 - This is test question number one'",
+                 users(:standard_user).notifications.last.content,
                  'Post author notification of mention in comment has incorrect wording'
   end
 


### PR DESCRIPTION
When a follower of new threads on a post is `@` mentioned in a comment that starts a new thread, the notification now refers to "a new thread" rather than "a comment in a thread", for consistency with the notification received when there is no `@` mention.