### PR TITLE
Remove redundant double colon prefix from includes in User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,13 +1,13 @@
 class User < ApplicationRecord
-  include ::EmailValidations
-  include ::UsernameValidations
-  include ::UserRateLimits
-  include ::UserMerge
-  include ::Timestamped
-  include ::SoftDeletable
-  include ::SamlInit
-  include ::Inspectable
-  include ::Identity
+  include EmailValidations
+  include UsernameValidations
+  include UserRateLimits
+  include UserMerge
+  include Timestamped
+  include SoftDeletable
+  include SamlInit
+  include Inspectable
+  include Identity
 
   devise :database_authenticatable, :registerable, :confirmable,
          :recoverable, :rememberable, :trackable, :validatable,


### PR DESCRIPTION
Match the User model to the new [style guide change](https://github.com/codidact/qpixel/issues/2058#issuecomment-4492534805) to close #2058.