### PR TITLE
Remove reimplementations of String#truncate

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -255,6 +255,8 @@ module ApplicationHelper
   # @param max_length [Integer] The maximum number of characters to leave in the resulting strings.
   # @return [Array<String>]
   def split_words_max_length(text, max_length)
+    logger.warn 'ApplicationHelper#split_words_max_length is deprecated. Use String#truncate instead.'
+    logger.warn caller[0]
     words = text.split
     splat = [[]]
     words.each do |word|

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -250,6 +250,7 @@ module ApplicationHelper
 
   ##
   # Split a string after a specified number of characters, only breaking at word boundaries.
+  # @deprecated Use {String#truncate}[https://www.rubydoc.info/gems/activesupport/String#truncate-instance_method].
   # @param text [String] The text to split.
   # @param max_length [Integer] The maximum number of characters to leave in the resulting strings.
   # @return [Array<String>]

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -13,7 +13,7 @@
   <% end %>
   <meta property="og:url" content="<%= post_url(@post) %>" />
   <meta property="og:title" content="<%= @post.title %>" />
-  <meta property="og:description" content="<%= @post.body_plain[0..150].strip %>..." />
+  <meta property="og:description" content="<%= @post.body_plain&.truncate(150) %>" />
   <meta property="og:image" content="<%= "#{SiteSetting['SiteLogoPath']}" %>" />
 <% end %>
 

--- a/app/views/reactions/_list.html.erb
+++ b/app/views/reactions/_list.html.erb
@@ -58,7 +58,7 @@
                                     <%= raw(sanitize(render_markdown(r.comment.content),
                                                      scrubber: CommentScrubber.new)) %>
                                     <% else %>
-                                    <%= raw(sanitize(render_markdown(r.comment.content[0..150] + "..."),
+                                    <%= raw(sanitize(render_markdown(r.comment.content&.truncate(150)),
                                                      scrubber: CommentScrubber.new)) %>
                                     <% end %>
                                 </div>

--- a/app/views/tags/_tag.html.erb
+++ b/app/views/tags/_tag.html.erb
@@ -17,11 +17,7 @@
   <% end %>
   <% if tag.excerpt.present? %>
     <p class="has-font-size-caption has-color-tertiary-900">
-      <% splat = split_words_max_length(tag.excerpt, 120) %>
-      <%= splat[0] %>
-      <% if splat.size > 1 %>
-        ...
-      <% end %>
+      <%= tag.excerpt&.truncate(120, separator: ' ') %>
     </p>
   <% end %>
 </div>

--- a/app/views/users/_activity_items.html.erb
+++ b/app/views/users/_activity_items.html.erb
@@ -15,7 +15,7 @@
         <td class="h-fs-caption">
           <% working_title = i.answer? ? "A: #{i.parent.title}" : i.title %>
           <strong><%= working_title %></strong><br>
-          <%= i.body_plain[0..300] + ((i.body_plain.length > 300) ? "..." : "") %><br>
+          <%= i.body_plain&.truncate(300) %><br>
           <%= link_to '(more)',
                       generic_share_link(i),
                       'aria-label': "More information about #{type_name} #{working_title}" %>
@@ -25,7 +25,7 @@
         <td class="wrap-word">Comment</td>
         <td><%= link_to "Post #" + i.post.id.to_s, generic_share_link(i.post) %></td>
         <td class="h-fs-caption">
-          <%= i.content[0..300] + ((i.content.length > 300) ? '...' : '') %><br>
+          <%= i.content&.truncate(300) %><br>
           <%= link_to '(more)', comment_link(i), 'aria-label': 'More information about comment' %>
         </td>
         <td>&mdash;</td>
@@ -56,7 +56,7 @@
         <td class="wrap-word"><span class="h-fw-bold h-c-red-700">Warning</span></td>
         <td>&mdash;</td>
         <td class="h-fs-caption">
-          <%= i.body[0..300] + ((i.body.length > 300) ? "..." : "") %>
+          <%= i.body&.truncate(300) %>
         </td>
         <td>&mdash;</td>
       <% elsif mod && i.class == Flag %>
@@ -69,7 +69,7 @@
     <% end %>
         </td>
         <td class="h-fs-caption">
-          <%= i.reason[0..300] + ((i.reason.length > 300) ? "..." : "") %><br>
+          <%= i.reason&.truncate(300) %><br>
         </td>
         <td>
           <%= i.status || "pending" %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,11 +44,15 @@ Rails.application.configure do
   config.hosts << /[a-z0-9\-.]+\.ngrok-free\.app/
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.delivery_method = :ses
+  raise_delivery_errors = ActiveRecord::Type::Boolean.new.cast(ENV['RAISE_DELIVERY_ERRORS'])
+  config.action_mailer.raise_delivery_errors = raise_delivery_errors || false
   config.action_mailer.asset_host = 'https://meta.codidact.com'
-
   config.action_mailer.perform_caching = false
+  delivery_method = ENV['MAILER_DELIVERY_METHOD']
+  config.action_mailer.delivery_method = delivery_method&.to_sym || :letter_opener_web
+  config.action_mailer.default_url_options = {
+    host: 'meta.codidact.com', protocol: ENV['MAILER_PROTOCOL'] || 'https'
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
@@ -84,12 +88,6 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   config.i18n.raise_on_missing_translations = true
-
-  config.action_mailer.delivery_method = :letter_opener_web
-
-  config.action_mailer.default_url_options = { 
-    host: 'meta.codidact.com', protocol: ENV['MAILER_PROTOCOL'] || 'https'
-  }
 
   config.active_job.queue_adapter = :inline
 


### PR DESCRIPTION
Closes #1420.

Removes instances where we've semi-re-implemented `String#truncate` and uses that instead. Also deprecates `ApplicationHelper#split_words_max_length` in favour of the former.

Unrelated small change: adds additional environment variables for dev environments to control email settings.