### PR TITLE
Fix trust_level not updating on direct attribute changes

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -449,8 +449,6 @@ class UsersController < ApplicationController
       @user.update(attrib => new_value)
     end
 
-    @user.community_user.recalc_trust_level
-
     AuditLog.admin_audit(event_type: 'role_toggle', related: @user, user: current_user,
                          comment: "#{attrib} to #{new_value}")
     AbilityQueue.add(@user, 'Role Change')

--- a/app/models/community_user.rb
+++ b/app/models/community_user.rb
@@ -12,6 +12,7 @@ class CommunityUser < ApplicationRecord
   scope :for_context, -> { where(community_id: RequestContext.community_id) }
 
   after_create :prevent_ulysses_case
+  after_update :recalc_trust_level, if: :saved_change_affects_trust_level?
 
   delegate :url_helpers, to: 'Rails.application.routes'
 
@@ -170,6 +171,12 @@ class CommunityUser < ApplicationRecord
   # @return [Boolean] check result
   def at_least_moderator?
     moderator? || admin?
+  end
+
+  # Checks if one of the persisted changes affects trust_level
+  # @return [Boolean] check result
+  def saved_change_affects_trust_level?
+    ['is_admin', 'is_moderator'].any? { |attr| saved_change_to_attribute?(attr) }
   end
 
   def recalc_trust_level

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,9 +39,11 @@ class User < ApplicationRecord
   has_many :assigned_complaints, class_name: 'Complaint', foreign_key: 'assignee_id', dependent: :nullify
   accepts_nested_attributes_for :user_websites
 
+  after_update :recalc_trust_level, if: :saved_change_affects_trust_level?
+
   validates :login_token, uniqueness: { allow_blank: true, case_sensitive: false }
 
-  delegate :reputation, :reputation=, :privilege?, :privilege, to: :community_user, allow_nil: true
+  delegate :recalc_trust_level, :reputation, :reputation=, :privilege?, :privilege, to: :community_user, allow_nil: true
 
   alias_attribute :name, :username
 
@@ -246,6 +248,12 @@ class User < ApplicationRecord
 
     post_privilege?('edit_posts', post) || at_least_moderator? ||
       (post_type.is_freely_editable && privilege?('unrestricted'))
+  end
+
+  # Checks if one of the persisted changes affects trust_level
+  # @return [Boolean] check result
+  def saved_change_affects_trust_level?
+    ['staff'].any? { |attr| saved_change_to_attribute?(attr) }
   end
 
   def metric(key)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -253,7 +253,9 @@ class User < ApplicationRecord
   # Checks if one of the persisted changes affects trust_level
   # @return [Boolean] check result
   def saved_change_affects_trust_level?
-    ['staff'].any? { |attr| saved_change_to_attribute?(attr) }
+    ['is_global_admin', 'is_global_moderator', 'staff'].any? do |attr|
+      saved_change_to_attribute?(attr)
+    end
   end
 
   def metric(key)

--- a/test/models/community_user_test.rb
+++ b/test/models/community_user_test.rb
@@ -20,4 +20,31 @@ class CommunityUserTest < ActiveSupport::TestCase
 
     assert_equal std.latest_warning, latest&.created_at
   end
+
+  test 'should correctly maintain trust_level' do
+    base_trust_level = SiteSetting['NewSiteMode'] ? 2 : 1
+    community = communities(:sample)
+    std_usr = users(:no_community_user)
+
+    cu = CommunityUser.create({ community_id: community.id,
+                                user_id: std_usr.id })
+
+    assert_equal base_trust_level, cu.trust_level
+
+    cu.update({ is_moderator: true })
+    cu.reload
+    assert_equal 4, cu.trust_level
+
+    std_usr.update({ staff: true })
+    cu.reload
+    assert_equal 5, cu.trust_level
+
+    std_usr.update({ staff: false })
+    cu.reload
+    assert_equal 4, cu.trust_level
+
+    cu.update({ is_moderator: false })
+    cu.reload
+    assert_equal base_trust_level, cu.trust_level
+  end
 end


### PR DESCRIPTION
closes #2082

@cellio the reason why you noticed the problem on the dev server is because I've adjusted your user's admin status directly from the console. This had a side-effect of not running `recalc_trust_level`, which is done when assigning/revoking roles via the `toggle_role` action.