### PR TITLE
Add rails_performance gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ gem 'whenever', '~> 1.0', require: false
 
 # Debugging, linting, testing.
 gem 'awesome_print', '~> 1.9'
+gem 'rails_performance', '~> 1.6'
 gem 'rubocop', '~> 1'
 gem 'rubocop-rails', '~> 2.15'
 gem 'rubocop-rake', '~> 0.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,7 @@ GEM
     bcrypt (3.1.22)
     bigdecimal (4.1.2)
     bindex (0.8.1)
+    browser (6.2.0)
     builder (3.3.0)
     byebug (11.1.3)
     capybara (3.40.0)
@@ -369,6 +370,10 @@ GEM
     rails-html-sanitizer (1.7.0)
       loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails_performance (1.6.0)
+      browser
+      railties
+      redis
     railties (8.1.3)
       actionpack (= 8.1.3)
       activesupport (= 8.1.3)
@@ -587,6 +592,7 @@ DEPENDENCIES
   rails (~> 8.1)
   rails-controller-testing (~> 1.0)
   rails-html-sanitizer (~> 1.6)
+  rails_performance (~> 1.6)
   redis (~> 4.8)
   reverse_markdown (~> 2.1)
   rmagick (~> 5.3)

--- a/config/initializers/rails_performance.rb
+++ b/config/initializers/rails_performance.rb
@@ -1,0 +1,63 @@
+RailsPerformance.setup do |config|
+  config.redis    = Redis.new(url: ENV["REDIS_URL"].presence || "redis://127.0.0.1:6379/0")
+  # or Redis::Namespace.new("rails-performance", redis: Redis.new), see below in README
+  config.duration = 4.hours
+
+  config.debug    = false
+  config.enabled  = true
+
+  # configure Recent tab (time window and limit of requests)
+  config.recent_requests_time_window = 60.minutes
+  config.recent_requests_limit = 1000
+
+  # configure Slow Requests tab (time window, limit of requests and threshold)
+  config.slow_requests_time_window = 24.hours # time window for slow requests
+  config.slow_requests_limit = 1000 # number of max rows
+  config.slow_requests_threshold = 1000 # number of ms
+
+  # default path where to mount gem,
+  # alternatively you can mount the RailsPerformance::Engine in your routes.rb
+  config.mount_at = '/rails/performance'
+
+  # protect your Performance Dashboard with HTTP BASIC password
+  # config.http_basic_authentication_enabled   = false
+  # config.http_basic_authentication_user_name = 'rails_performance'
+  # config.http_basic_authentication_password  = 'password12'
+
+  # if you need an additional rules to check user permissions
+  # config.verify_access_proc = proc { |controller| true }
+  # for example when you have `current_user`
+  config.verify_access_proc = proc { |controller| controller.current_user&.developer? }
+
+  # You can ignore endpoints with Rails standard notation controller#action
+  # config.ignored_endpoints = ['HomeController#contact']
+
+  # You can ignore request paths by specifying the beginning of the path.
+  # For example, all routes starting with '/admin' can be ignored:
+  config.ignored_paths = ['/rails/performance']
+
+  # store custom data for the request
+  # config.custom_data_proc = proc do |env|
+  #   request = Rack::Request.new(env)
+  #   {
+  #     email: request.env['warden'].user&.email, # if you are using Devise for example
+  #     user_agent: request.env['HTTP_USER_AGENT']
+  #   }
+  # end
+
+  # config home button link
+  config.home_link = '/'
+
+  # To skip some Rake tasks from monitoring
+  # config.skipable_rake_tasks = ['webpacker:compile']
+
+  # To monitor rake tasks performance, you need to include rake tasks
+  # config.include_rake_tasks = false
+
+  # To monitor custom events with `RailsPerformance.measure` block
+  # config.include_custom_events = true
+
+  # To monitor system resources (CPU, memory, disk)
+  # to enabled add required gems (see README)
+  # config.system_monitor_duration = 24.hours
+end if defined?(RailsPerformance)


### PR DESCRIPTION
Allows more detailed performance monitoring in production to let us pick out slow paths to optimize.