### PR TITLE
General improvements

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -110,7 +110,7 @@ class AdminController < ApplicationController
     @log_types = AuditLog.unscoped.select(:log_type).distinct.map(&:log_type) - ['user_annotation', 'user_history']
     @event_types = AuditLog.unscoped.select(:event_type).distinct.map(&:event_type)
 
-    @logs = if current_user.is_global_admin
+    @logs = if current_user.global_admin?
               AuditLog.unscoped.where.not(log_type: ['user_annotation', 'user_history'])
             else
               AuditLog.where.not(log_type: ['block_log', 'user_annotation', 'user_history'])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,7 +85,7 @@ class ApplicationController < ActionController::Base
   end
 
   def verify_global_admin
-    if !user_signed_in? || !current_user.is_global_admin
+    if !user_signed_in? || !current_user.global_admin?
       render 'errors/not_found', layout: 'without_sidebar', status: :not_found
       return false
     end
@@ -307,8 +307,7 @@ class ApplicationController < ActionController::Base
        SiteSetting['EnableMandatoryGlobalAdminMod2FA'] &&
        # Enable users to log out even if 2fa is enforced
        !request.fullpath.end_with?('/users/sign_out') &&
-       (current_user.is_global_admin ||
-         current_user.is_global_moderator) &&
+       current_user.at_least_global_moderator? &&
        (current_user.sso_profile.blank? || SiteSetting['Enable2FAForSsoUsers'])
       redirect_path = '/users/two-factor'
       unless request.fullpath.end_with?(redirect_path)

--- a/app/controllers/site_settings_controller.rb
+++ b/app/controllers/site_settings_controller.rb
@@ -9,7 +9,7 @@ class SiteSettingsController < ApplicationController
   # @param community_id [String, nil] id of the community to check access on
   # @return [Boolean] Check result
   def access?(user, community_id)
-    community_id.present? || user.is_global_admin
+    community_id.present? || user.global_admin?
   end
 
   def index

--- a/app/controllers/tag_sets_controller.rb
+++ b/app/controllers/tag_sets_controller.rb
@@ -37,6 +37,6 @@ class TagSetsController < ApplicationController
   private
 
   def set_tag_set
-    @tag_set = (current_user&.is_global_admin ? TagSet.unscoped : TagSet).find(params[:id])
+    @tag_set = (current_user&.global_admin? ? TagSet.unscoped : TagSet).find(params[:id])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -171,7 +171,7 @@ class UsersController < ApplicationController
     as_user = current_user
 
     if params[:system] == true
-      if current_user&.is_global_admin
+      if current_user&.global_admin?
         as_user = User.find(-1)
       else
         return render json: { status: 'failed', success: false, errors: ['You do not have permission to delete'] },

--- a/config/initializers/rails_performance.rb
+++ b/config/initializers/rails_performance.rb
@@ -1,5 +1,11 @@
 RailsPerformance.setup do |config|
-  config.redis    = Redis.new(url: ENV["REDIS_URL"].presence || "redis://127.0.0.1:6379/0")
+  processed = ERB.new(File.read(Rails.root.join('config', 'database.yml'))).result(binding)
+  config.redis = Redis.new(
+    YAML.safe_load(processed,
+                   permitted_classes: [],
+                   permitted_symbols: [],
+                   aliases: true)["redis_#{Rails.env}"].deep_symbolize_keys)
+
   # or Redis::Namespace.new("rails-performance", redis: Redis.new), see below in README
   config.duration = 4.hours
 


### PR DESCRIPTION
- picks some of the access control predicate changes from #2063 to reduce review complexity + the sooner these changes are on `develop`, the better;
- fixes loading of `rails_performance` in setups that only use the `database.yml` config without setting `RAILS_URL`;