### PR TITLE
Various fixes for filters

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -170,9 +170,9 @@ class UsersController < ApplicationController
 
     as_user = current_user
 
-    if params[:system] == true
+    if params[:system] == 'true'
       if current_user&.global_admin?
-        as_user = User.find(-1)
+        as_user = helpers.system_user
       else
         return render json: { status: 'failed', success: false, errors: ['You do not have permission to delete'] },
                       status: 400

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -163,7 +163,7 @@ class UsersController < ApplicationController
   end
 
   def delete_filter
-    unless params[:name]
+    unless params[:name].present?
       return render json: { status: 'failed', success: false, errors: ['Filter name is required'] },
                     status: 400
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -180,6 +180,12 @@ class UsersController < ApplicationController
     end
 
     filter = Filter.find_by(user: as_user, name: params[:name])
+
+    unless filter.present?
+      return render json: { status: 'failed', success: false, errors: ['Filter not found'] },
+                    status: :not_found
+    end
+
     if filter.destroy
       render json: { status: 'success', success: true, filters: filters_json }
     else

--- a/test/controllers/users/filters_test.rb
+++ b/test/controllers/users/filters_test.rb
@@ -1,4 +1,3 @@
-
 require 'test_helper'
 
 class UsersControllerTest < ActionController::TestCase
@@ -10,10 +9,31 @@ class UsersControllerTest < ActionController::TestCase
     try_delete_filter
     assert_json_failure(:bad_request)
 
-    # 400 on missing name, status: failed
-    # if system and global_admin? -> 200 success
-    # if system and not admin -> 400
-    # else 200 , status: success,
+    try_delete_filter(name: 'non-existent')
+    assert_json_failure(:not_found)
+
+    try_delete_filter(name: filters(:one).name)
+    assert_json_success
+  end
+
+  test 'only global admins should be able to delete system filters' do
+    filter = filters(:system)
+
+    users.each do |user|
+      sign_in user
+
+      name = "system_#{user.name}"
+      Filter.create!(filter.dup.attributes.merge({ name: name,
+                                                   user: User.system }))
+
+      try_delete_filter(name: name, system: true)
+
+      if user.global_admin?
+        assert_json_success
+      else
+        assert_json_failure(:bad_request)
+      end
+    end
   end
 
   test 'set_filter should correctly save valid filters' do
@@ -69,7 +89,7 @@ class UsersControllerTest < ActionController::TestCase
   end
 
   def try_delete_filter(**opts)
-    post :delete_filter, params: {
+    delete :delete_filter, params: {
       name: '',
       system: false
     }.merge(opts)

--- a/test/controllers/users/filters_test.rb
+++ b/test/controllers/users/filters_test.rb
@@ -1,0 +1,82 @@
+
+require 'test_helper'
+
+class UsersControllerTest < ActionController::TestCase
+  include Devise::Test::ControllerHelpers
+
+  test 'delete_filter should correctly handle deletion' do
+    sign_in users(:standard_user)
+
+    try_delete_filter
+    assert_json_failure(:bad_request)
+
+    # 400 on missing name, status: failed
+    # if system and global_admin? -> 200 success
+    # if system and not admin -> 400
+    # else 200 , status: success,
+  end
+
+  test 'set_filter should correctly save valid filters' do
+    sign_in users(:standard_user)
+
+    [false, true].each do |is_default|
+      try_save_filter(is_default: is_default)
+      assert_json_success
+    end
+  end
+
+  test 'default_filter should correctly respond to missing category' do
+    sign_in users(:standard_user)
+    try_default_filter(nil)
+    assert_response(:bad_request)
+  end
+
+  test 'default_filter should correctly get default category filters' do
+    sign_in users(:standard_user)
+    try_default_filter(categories(:main))
+    assert_json_success
+  end
+
+  test 'HTML filters should redirect to sign in for anonymous users' do
+    try_filters(format: :html)
+    assert_redirected_to_sign_in
+  end
+
+  test 'JSON filters should return system filters for anonymous users' do
+    try_filters(format: :json)
+
+    assert_response(:success)
+    assert_valid_json_response
+
+    parsed = JSON.parse(response.body)
+    assert parsed.any?
+    parsed.each do |name, filter|
+      assert filter['system'], "'#{name}' is not a system filter"
+    end
+  end
+
+  private
+
+  def try_filters(format: :json)
+    get :filters, params: { format: format }
+  end
+
+  def try_default_filter(category)
+    get :default_filter, params: {
+      category: category&.id,
+      format: :json
+    }
+  end
+
+  def try_delete_filter(**opts)
+    post :delete_filter, params: {
+      name: '',
+      system: false
+    }.merge(opts)
+  end
+
+  def try_save_filter(**opts)
+    filter = { name: 'test filter' }.merge(opts)
+    post :set_filter, params: filter.merge({ format: :json })
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -582,15 +582,6 @@ class UsersControllerTest < ActionController::TestCase
     assert(items.any? { |x| x.instance_of?(Flag) && x.id == declined_flag.id })
   end
 
-  test 'set_filter should correctly save valid filters' do
-    sign_in users(:standard_user)
-
-    [false, true].each do |is_default|
-      try_save_filter(is_default: is_default)
-      assert_json_success
-    end
-  end
-
   test 'set_preference should correclty save valid preferences' do
     sign_in users(:standard_user)
 
@@ -628,36 +619,6 @@ class UsersControllerTest < ActionController::TestCase
     end
   end
 
-  test 'default_filter should correctly respond to missing category' do
-    sign_in users(:standard_user)
-    try_default_filter(nil)
-    assert_response(:bad_request)
-  end
-
-  test 'default_filter should correctly get default category filters' do
-    sign_in users(:standard_user)
-    try_default_filter(categories(:main))
-    assert_json_success
-  end
-
-  test 'HTML filters should redirect to sign in for anonymous users' do
-    try_filters(format: :html)
-    assert_redirected_to_sign_in
-  end
-
-  test 'JSON filters should return system filters for anonymous users' do
-    try_filters(format: :json)
-
-    assert_response(:success)
-    assert_valid_json_response
-
-    parsed = JSON.parse(response.body)
-    assert parsed.any?
-    parsed.each do |name, filter|
-      assert filter['system'], "'#{name}' is not a system filter"
-    end
-  end
-
   private
 
   def create_other_user
@@ -666,22 +627,6 @@ class UsersControllerTest < ActionController::TestCase
     other_user = User.create!(email: 'other@example.com', password: 'abcdefghijklmnopqrstuvwxyz', username: 'other_user')
     other_user.community_users.create!(community: other_community)
     other_user
-  end
-
-  def try_filters(format: :json)
-    get :filters, params: { format: format }
-  end
-
-  def try_default_filter(category)
-    get :default_filter, params: {
-      category: category&.id,
-      format: :json
-    }
-  end
-
-  def try_save_filter(**opts)
-    filter = { name: 'test filter' }.merge(opts)
-    post :set_filter, params: filter.merge({ format: :json })
   end
 
   # @param type [String] deletion type (user or profile)


### PR DESCRIPTION
- not passing `name` when deleting a filter no longer results in a server error;
- when a filter is not found by name+user, trying to destroy it no longer causes a server error;
- while not possible from the UI (most likely the reason why no one noticed), deleting a system filter by a global admin is broken due to incorrectly assuming that `params[:system]` is a boolean (not the first time it happens - IMO, we need a helper);

\+ tests covering all of the above and normal behavior