### PR TITLE
Fix server error when resolving flags

### DIFF
--- a/app/controllers/flags_controller.rb
+++ b/app/controllers/flags_controller.rb
@@ -76,10 +76,14 @@ class FlagsController < ApplicationController
   end
 
   def resolve
-    if @flag.resolve(status: params[:result], message: params[:message], handled_by: current_user)
+    if @flag.resolve(status: params[:result],
+                     message: params[:message],
+                     handled_by: current_user)
       render json: { status: 'success' }
     else
-      render json: { status: 'failed', message: 'Failed to save new status.' }, status: :internal_server_error
+      render json: { status: 'failed',
+                     message: 'Failed to save new status.' },
+             status: :internal_server_error
     end
   end
 

--- a/app/models/ability_queue.rb
+++ b/app/models/ability_queue.rb
@@ -14,8 +14,9 @@ class AbilityQueue < ApplicationRecord
   # Adds a new ability queue entry for a user if one does not already exist.
   # @param user [User] user to add queue entry for
   # @param comment [String] comment to add to queue entry
+  # @return [Boolean] whether the scheduling succeeded
   def self.add(user, comment)
-    return if AbilityQueue.pending_for?(user)
+    return true if AbilityQueue.pending_for?(user)
 
     AbilityQueue.create(community_user: user.community_user, comment: comment, completed: false)
   end

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -59,17 +59,17 @@ class Flag < ApplicationRecord
   # @param handled_at [DateTime, nil] time the flag was handled (defaults to current time)
   # @return [Boolean] result
   def resolve(status:, message:, handled_by:, handled_at: nil)
-    status = false
+    resolve_status = false
 
     transaction do
-      status = update(status: status,
-                      message: message,
-                      handled_by: handled_by,
-                      handled_at: handled_at || DateTime.now)
+      resolve_status = update(status: status,
+                              message: message,
+                              handled_by: handled_by,
+                              handled_at: handled_at || DateTime.now)
 
-      status = status && AbilityQueue.add(user, "Flag Handled ##{id}")
+      resolve_status &&= AbilityQueue.add(user, "Flag Handled ##{id}")
 
-      unless status
+      unless resolve_status
         raise ActiveRecord::Rollback
       end
 
@@ -80,6 +80,6 @@ class Flag < ApplicationRecord
       end
     end
 
-    status
+    resolve_status
   end
 end

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -59,15 +59,27 @@ class Flag < ApplicationRecord
   # @param handled_at [DateTime, nil] time the flag was handled (defaults to current time)
   # @return [Boolean] result
   def resolve(status:, message:, handled_by:, handled_at: nil)
+    status = false
+
     transaction do
-      update!(status: status, message: message, handled_by: handled_by, handled_at: handled_at || DateTime.now)
-      AbilityQueue.add!(user, "Flag Handled ##{id}")
+      status = update(status: status,
+                      message: message,
+                      handled_by: handled_by,
+                      handled_at: handled_at || DateTime.now)
+
+      status = status && AbilityQueue.add(user, "Flag Handled ##{id}")
+
+      unless status
+        raise ActiveRecord::Rollback
+      end
+
       unless message.blank?
+        # TODO: create_notification actually behaves like a bang method
         user.create_notification('A moderator has written a response to your flag. Check your flag history page.',
                                  flag_history_url(user))
       end
     end
-  rescue ActiveRecord::ActiveRecordError
-    false
+
+    status
   end
 end

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -76,7 +76,7 @@ class Flag < ApplicationRecord
       unless message.blank?
         # TODO: create_notification actually behaves like a bang method
         user.create_notification('A moderator has written a response to your flag. Check your flag history page.',
-                                 flag_history_url(user))
+                                 flag_history_url(user, { host: community.host }))
       end
     end
 


### PR DESCRIPTION
+ ensures custom reason notification message refers to the community the flag was raised on and not the default one.

closes #2093