### PR TITLE
SES and S3 config fixes

### DIFF
--- a/config/initializers/amazon_ses.rb
+++ b/config/initializers/amazon_ses.rb
@@ -1,10 +1,15 @@
 Rails.application.configure do
   if config.action_mailer.delivery_method == :ses
-    Aws.config.update(region: 'us-east-1',
-                      credentials: Aws::Credentials.new(Rails.application.credentials.ses_access_key,
-                                                        Rails.application.credentials.ses_secret_key))
+    Aws.config.update(region: 'us-east-1')
+
+    access_key = Rails.application.credentials.ses_access_key
+    secret_key = Rails.application.credentials.ses_secret_key
+    credentials = Aws::Credentials.new(access_key, secret_key)
+
+    Aws.config[:ses] = { credentials: credentials }
 
     ses_client = Aws::SESV2::Client.new
+
     config.action_mailer.ses_v2_settings = { sesv2_client: ses_client }
   end
 end


### PR DESCRIPTION
`Awa.config.update` overrides any config that is passed to it on a global level. This means that our SES initializer accidentally ended up replacing our S3 credentials, leading to broken file uploads and dump downloads. High priority to review and apply.