### PR TITLE
Pass active tab to tabs partial view

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -18,6 +18,7 @@ class SubscriptionsController < ApplicationController
 
   def index
     @subscriptions = current_user.subscriptions
+    render layout: 'without_sidebar'
   end
 
   def qualifiers

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :title, title %>
 
-<%= render 'users/tabs', user: current_user %>
+<%= render 'users/tabs', user: current_user, active_tab: "account" %>
 
 <h1><%= title %></h1>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :title, title %>
 
-<%= render 'users/tabs', user: current_user, active_tab: "account" %>
+<%= render 'users/tabs', user: current_user, active_tab: 'account' %>
 
 <h1><%= title %></h1>
 

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :title, title %>
 
-<%= render 'users/tabs', user: current_user %>
+<%= render 'users/tabs', user: current_user, active_tab: "notifications" %>
 
 <%
   status = params[:status].presence || 'all'

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :title, title %>
 
-<%= render 'users/tabs', user: current_user, active_tab: "notifications" %>
+<%= render 'users/tabs', user: current_user, active_tab: "inbox" %>
 
 <%
   status = params[:status].presence || 'all'

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :title, title %>
 
-<%= render 'users/tabs', user: current_user, active_tab: "inbox" %>
+<%= render 'users/tabs', user: current_user, active_tab: 'inbox' %>
 
 <%
   status = params[:status].presence || 'all'

--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :title, title %>
 
-<%= render 'users/tabs', user: current_user %>
+<%= render 'users/tabs', user: current_user, active_tab: 'subscriptions' %>
 
 <h1><%= title %></h1>
 <p>
@@ -17,7 +17,7 @@
     [
       sub.created_at,
       [sub.name.present? ? sub.name : "#{type.capitalize} subscription #{index + 1}",sub]
-    ] 
+    ]
   end
 end.sort_by { |a| a }.map { |_, v| v }.each do |name, sub| %>
   <details data-sub-id="<%= sub.id %>">

--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :title, title %>
 
-<%= render 'users/tabs', user: current_user, active_tab: 'subscriptions' %>
+<%= render 'users/tabs', user: current_user, active_tab: 'email' %>
 
 <h1><%= title %></h1>
 <p>

--- a/app/views/users/_tabs.html.erb
+++ b/app/views/users/_tabs.html.erb
@@ -1,31 +1,31 @@
 <div class="tabs is-classic-tabs">
-  <%= link_to user_path(user), class: "tabs--item #{current_page?(user_path(user)) ? 'is-active' : ''}" do %>
+  <%= link_to user_path(user), class: "tabs--item #{active_tab == "profile" ? 'is-active' : ''}" do %>
     <i class="fas fa-user"></i> Profile
   <% end %>
-  <%= link_to user_activity_path(user), class: "tabs--item #{current_page?(user_activity_path(user)) ? 'is-active' : ''}" do %>
+  <%= link_to user_activity_path(user), class: "tabs--item #{active_tab == "activity" ? 'is-active' : ''}" do %>
     Activity
   <% end %>
-  <%= link_to vote_summary_path(user), class: "tabs--item #{current_page?(vote_summary_path(user)) ? 'is-active' : ''}" do %>
+  <%= link_to vote_summary_path(user), class: "tabs--item #{active_tab == "vote summary" ? 'is-active' : ''}" do %>
     Vote Summary
   <% end %>
   <% if user == current_user %>
-    <%= link_to edit_user_registration_path, class: "tabs--item #{current_page?(edit_user_registration_path) ? 'is-active' : ''}" do %>
+    <%= link_to edit_user_registration_path, class: "tabs--item #{active_tab == "account" ? 'is-active' : ''}" do %>
       Account
     <% end %>
-    <%= link_to edit_user_profile_path, class: "tabs--item #{current_page?(edit_user_profile_path) ? 'is-active' : ''}" do %>
+    <%= link_to edit_user_profile_path, class: "tabs--item #{active_tab == "edit" ? 'is-active' : ''}" do %>
       Edit
     <% end %>
-    <%= link_to user_preferences_path, class: "tabs--item #{current_page?(user_preferences_path) ? 'is-active' : ''}" do %>
+    <%= link_to user_preferences_path, class: "tabs--item #{active_tab == "preferences" ? 'is-active' : ''}" do %>
       Preferences
     <% end %>
-    <%= link_to user_filters_path, class: "tabs--item #{current_page?(user_filters_path) ? 'is-active' : ''}" do %>
+    <%= link_to user_filters_path, class: "tabs--item #{active_tab == "filters" ? 'is-active' : ''}" do %>
       Filters
     <% end %>
-    <%= link_to notifications_path, class: "tabs--item #{current_page?(notifications_path) ? 'is-active' : ''}" do %>
+    <%= link_to notifications_path, class: "tabs--item #{active_tab == "notifications" ? 'is-active' : ''}" do %>
       Notifications
     <% end %>
   <% end %>
-  <%= link_to network_path(user), class: "tabs--item #{current_page?(network_path(user)) ? 'is-active' : ''}" do %>
+  <%= link_to network_path(user), class: "tabs--item #{active_tab == "all communities" ? 'is-active' : ''}" do %>
   All Communities
   <% end %>
 </div>

--- a/app/views/users/_tabs.html.erb
+++ b/app/views/users/_tabs.html.erb
@@ -24,6 +24,9 @@
     <%= link_to notifications_path, class: "tabs--item #{active_tab == 'notifications' ? 'is-active' : ''}" do %>
       Notifications
     <% end %>
+    <%= link_to subscriptions_path, class: "tabs--item #{active_tab == 'subscriptions' ? 'is-active' : ''}" do %>
+      Subscriptions
+    <% end %>
   <% end %>
   <%= link_to network_path(user), class: "tabs--item #{active_tab == 'communities' ? 'is-active' : ''}" do %>
   All Communities

--- a/app/views/users/_tabs.html.erb
+++ b/app/views/users/_tabs.html.erb
@@ -21,14 +21,14 @@
     <%= link_to user_filters_path, class: "tabs--item #{active_tab == 'filters' ? 'is-active' : ''}" do %>
       Filters
     <% end %>
-    <%= link_to notifications_path, class: "tabs--item #{active_tab == 'notifications' ? 'is-active' : ''}" do %>
+    <%= link_to notifications_path, class: "tabs--item #{active_tab == 'inbox' ? 'is-active' : ''}" do %>
       Inbox
     <% end %>
-    <%= link_to subscriptions_path, class: "tabs--item #{active_tab == 'subscriptions' ? 'is-active' : ''}" do %>
+    <%= link_to subscriptions_path, class: "tabs--item #{active_tab == 'email' ? 'is-active' : ''}" do %>
       Email
     <% end %>
   <% end %>
-  <%= link_to network_path(user), class: "tabs--item #{active_tab == 'communities' ? 'is-active' : ''}" do %>
+  <%= link_to network_path(user), class: "tabs--item #{active_tab == 'network' ? 'is-active' : ''}" do %>
     Network
   <% end %>
 </div>

--- a/app/views/users/_tabs.html.erb
+++ b/app/views/users/_tabs.html.erb
@@ -1,34 +1,34 @@
 <div class="tabs is-classic-tabs">
-  <%= link_to user_path(user), class: "tabs--item #{active_tab == 'profile' ? 'is-active' : ''}" do %>
+  <%= link_to user_path(user), class: "tabs--item #{'is-active' if active_tab == 'profile'}" do %>
     Profile
   <% end %>
-  <%= link_to user_activity_path(user), class: "tabs--item #{active_tab == 'activity' ? 'is-active' : ''}" do %>
+  <%= link_to user_activity_path(user), class: "tabs--item #{'is-active' if active_tab == 'activity'}" do %>
     Activity
   <% end %>
-  <%= link_to vote_summary_path(user), class: "tabs--item #{active_tab == 'votes' ? 'is-active' : ''}" do %>
+  <%= link_to vote_summary_path(user), class: "tabs--item #{'is-active' if active_tab == 'votes'}" do %>
     Votes
   <% end %>
   <% if user == current_user %>
-    <%= link_to edit_user_registration_path, class: "tabs--item #{active_tab == 'account' ? 'is-active' : ''}" do %>
+    <%= link_to edit_user_registration_path, class: "tabs--item #{'is-active' if active_tab == 'account'}" do %>
       Account
     <% end %>
-    <%= link_to edit_user_profile_path, class: "tabs--item #{active_tab == 'edit' ? 'is-active' : ''}" do %>
+    <%= link_to edit_user_profile_path, class: "tabs--item #{'is-active' if active_tab == 'edit'}" do %>
       Edit
     <% end %>
-    <%= link_to user_preferences_path, class: "tabs--item #{active_tab == 'preferences' ? 'is-active' : ''}" do %>
+    <%= link_to user_preferences_path, class: "tabs--item #{'is-active' if active_tab == 'preferences'}" do %>
       Preferences
     <% end %>
-    <%= link_to user_filters_path, class: "tabs--item #{active_tab == 'filters' ? 'is-active' : ''}" do %>
+    <%= link_to user_filters_path, class: "tabs--item #{'is-active' if active_tab == 'filters'}" do %>
       Filters
     <% end %>
-    <%= link_to notifications_path, class: "tabs--item #{active_tab == 'inbox' ? 'is-active' : ''}" do %>
+    <%= link_to notifications_path, class: "tabs--item #{'is-active' if active_tab == 'inbox'}" do %>
       Inbox
     <% end %>
-    <%= link_to subscriptions_path, class: "tabs--item #{active_tab == 'email' ? 'is-active' : ''}" do %>
+    <%= link_to subscriptions_path, class: "tabs--item #{'is-active' if active_tab == 'email'}" do %>
       Email
     <% end %>
   <% end %>
-  <%= link_to network_path(user), class: "tabs--item #{active_tab == 'network' ? 'is-active' : ''}" do %>
+  <%= link_to network_path(user), class: "tabs--item #{'is-active' if active_tab == 'network'}" do %>
     Network
   <% end %>
 </div>

--- a/app/views/users/_tabs.html.erb
+++ b/app/views/users/_tabs.html.erb
@@ -1,12 +1,12 @@
 <div class="tabs is-classic-tabs">
   <%= link_to user_path(user), class: "tabs--item #{active_tab == 'profile' ? 'is-active' : ''}" do %>
-    <i class="fas fa-user"></i> Profile
+    Profile
   <% end %>
   <%= link_to user_activity_path(user), class: "tabs--item #{active_tab == 'activity' ? 'is-active' : ''}" do %>
     Activity
   <% end %>
   <%= link_to vote_summary_path(user), class: "tabs--item #{active_tab == 'votes' ? 'is-active' : ''}" do %>
-    Vote Summary
+    Votes
   <% end %>
   <% if user == current_user %>
     <%= link_to edit_user_registration_path, class: "tabs--item #{active_tab == 'account' ? 'is-active' : ''}" do %>
@@ -29,6 +29,6 @@
     <% end %>
   <% end %>
   <%= link_to network_path(user), class: "tabs--item #{active_tab == 'communities' ? 'is-active' : ''}" do %>
-  All Communities
+  Communities
   <% end %>
 </div>

--- a/app/views/users/_tabs.html.erb
+++ b/app/views/users/_tabs.html.erb
@@ -22,13 +22,13 @@
       Filters
     <% end %>
     <%= link_to notifications_path, class: "tabs--item #{active_tab == 'notifications' ? 'is-active' : ''}" do %>
-      Notifications
+      Inbox
     <% end %>
     <%= link_to subscriptions_path, class: "tabs--item #{active_tab == 'subscriptions' ? 'is-active' : ''}" do %>
-      Subscriptions
+      Email
     <% end %>
   <% end %>
   <%= link_to network_path(user), class: "tabs--item #{active_tab == 'communities' ? 'is-active' : ''}" do %>
-  Communities
+    Network
   <% end %>
 </div>

--- a/app/views/users/_tabs.html.erb
+++ b/app/views/users/_tabs.html.erb
@@ -1,31 +1,31 @@
 <div class="tabs is-classic-tabs">
-  <%= link_to user_path(user), class: "tabs--item #{active_tab == "profile" ? 'is-active' : ''}" do %>
+  <%= link_to user_path(user), class: "tabs--item #{active_tab == 'profile' ? 'is-active' : ''}" do %>
     <i class="fas fa-user"></i> Profile
   <% end %>
-  <%= link_to user_activity_path(user), class: "tabs--item #{active_tab == "activity" ? 'is-active' : ''}" do %>
+  <%= link_to user_activity_path(user), class: "tabs--item #{active_tab == 'activity' ? 'is-active' : ''}" do %>
     Activity
   <% end %>
-  <%= link_to vote_summary_path(user), class: "tabs--item #{active_tab == "vote summary" ? 'is-active' : ''}" do %>
+  <%= link_to vote_summary_path(user), class: "tabs--item #{active_tab == 'votes' ? 'is-active' : ''}" do %>
     Vote Summary
   <% end %>
   <% if user == current_user %>
-    <%= link_to edit_user_registration_path, class: "tabs--item #{active_tab == "account" ? 'is-active' : ''}" do %>
+    <%= link_to edit_user_registration_path, class: "tabs--item #{active_tab == 'account' ? 'is-active' : ''}" do %>
       Account
     <% end %>
-    <%= link_to edit_user_profile_path, class: "tabs--item #{active_tab == "edit" ? 'is-active' : ''}" do %>
+    <%= link_to edit_user_profile_path, class: "tabs--item #{active_tab == 'edit' ? 'is-active' : ''}" do %>
       Edit
     <% end %>
-    <%= link_to user_preferences_path, class: "tabs--item #{active_tab == "preferences" ? 'is-active' : ''}" do %>
+    <%= link_to user_preferences_path, class: "tabs--item #{active_tab == 'preferences' ? 'is-active' : ''}" do %>
       Preferences
     <% end %>
-    <%= link_to user_filters_path, class: "tabs--item #{active_tab == "filters" ? 'is-active' : ''}" do %>
+    <%= link_to user_filters_path, class: "tabs--item #{active_tab == 'filters' ? 'is-active' : ''}" do %>
       Filters
     <% end %>
-    <%= link_to notifications_path, class: "tabs--item #{active_tab == "notifications" ? 'is-active' : ''}" do %>
+    <%= link_to notifications_path, class: "tabs--item #{active_tab == 'notifications' ? 'is-active' : ''}" do %>
       Notifications
     <% end %>
   <% end %>
-  <%= link_to network_path(user), class: "tabs--item #{active_tab == "all communities" ? 'is-active' : ''}" do %>
+  <%= link_to network_path(user), class: "tabs--item #{active_tab == 'communities' ? 'is-active' : ''}" do %>
   All Communities
   <% end %>
 </div>

--- a/app/views/users/activity.html.erb
+++ b/app/views/users/activity.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :title, strip_tags(title) %>
 
-<%= render 'tabs', user: @user %>
+<%= render 'tabs', user: @user, active_tab: "activity" %>
 
 <% if at_least_moderator? && deleted_user?(@user) %>
   <%= render 'deleted', user: @user %>

--- a/app/views/users/activity.html.erb
+++ b/app/views/users/activity.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :title, strip_tags(title) %>
 
-<%= render 'tabs', user: @user, active_tab: "activity" %>
+<%= render 'tabs', user: @user, active_tab: 'activity' %>
 
 <% if at_least_moderator? && deleted_user?(@user) %>
   <%= render 'deleted', user: @user %>

--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -8,7 +8,7 @@
 
 <% content_for :title, title %>
 
-<%= render 'tabs', user: current_user %>
+<%= render 'tabs', user: current_user, active_tab: "edit" %>
 
 <h1><%= title %></h1>
 

--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -8,7 +8,7 @@
 
 <% content_for :title, title %>
 
-<%= render 'tabs', user: current_user, active_tab: "edit" %>
+<%= render 'tabs', user: current_user, active_tab: 'edit' %>
 
 <h1><%= title %></h1>
 

--- a/app/views/users/filters.html.erb
+++ b/app/views/users/filters.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :title, title %>
 
-<%= render 'tabs', user: current_user %>
+<%= render 'tabs', user: current_user, active_tab: "filters" %>
 
 <h1><%= title %></h1>
 <p>

--- a/app/views/users/filters.html.erb
+++ b/app/views/users/filters.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :title, title %>
 
-<%= render 'tabs', user: current_user, active_tab: "filters" %>
+<%= render 'tabs', user: current_user, active_tab: 'filters' %>
 
 <h1><%= title %></h1>
 <p>

--- a/app/views/users/network.html.erb
+++ b/app/views/users/network.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :title, strip_tags(title) %>
 
-<%= render 'tabs', user: @user, active_tab: "all communities" %>
+<%= render 'tabs', user: @user, active_tab: 'communities' %>
 
 <h1><%= title %></h1>
 

--- a/app/views/users/network.html.erb
+++ b/app/views/users/network.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :title, strip_tags(title) %>
 
-<%= render 'tabs', user: @user %>
+<%= render 'tabs', user: @user, active_tab: "all communities" %>
 
 <h1><%= title %></h1>
 

--- a/app/views/users/network.html.erb
+++ b/app/views/users/network.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :title, strip_tags(title) %>
 
-<%= render 'tabs', user: @user, active_tab: 'communities' %>
+<%= render 'tabs', user: @user, active_tab: 'network' %>
 
 <h1><%= title %></h1>
 

--- a/app/views/users/preferences.html.erb
+++ b/app/views/users/preferences.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :title, title %>
 
-<%= render 'tabs', user: current_user %>
+<%= render 'tabs', user: current_user, active_tab: "preferences" %>
 
 <h1><%= title %></h1>
 <p>

--- a/app/views/users/preferences.html.erb
+++ b/app/views/users/preferences.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :title, title %>
 
-<%= render 'tabs', user: current_user, active_tab: "preferences" %>
+<%= render 'tabs', user: current_user, active_tab: 'preferences' %>
 
 <h1><%= title %></h1>
 <p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
-<%= render 'tabs', user: @user, active_tab: "profile" %>
+<%= render 'tabs', user: @user, active_tab: 'profile' %>
 
 <% content_for :title, "User #{rtl_safe_username(@user)}" %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
-<%= render 'tabs', user: @user %>
+<%= render 'tabs', user: @user, active_tab: "profile" %>
 
 <% content_for :title, "User #{rtl_safe_username(@user)}" %>
 

--- a/app/views/users/vote_summary.html.erb
+++ b/app/views/users/vote_summary.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :title, strip_tags(title) %>
 
-<%= render 'tabs', user: @user %>
+<%= render 'tabs', user: @user, active_tab: "vote summary" %>
 
 <h1><%= title %></h1>
 

--- a/app/views/users/vote_summary.html.erb
+++ b/app/views/users/vote_summary.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :title, strip_tags(title) %>
 
-<%= render 'tabs', user: @user, active_tab: "vote summary" %>
+<%= render 'tabs', user: @user, active_tab: 'votes' %>
 
 <h1><%= title %></h1>
 


### PR DESCRIPTION
## Main change
This passes the name of the active tab to the partial view `app/views/users/_tabs.html.erb` to remove the need for each tab to check the current page to decide if it should show as active.

This is a fairly trivial change at this stage, but will become more useful in #2063 where a Moderator Tools tab will be introduced that needs to show as active for 11 different URLs.

## Additional changes
This pull request also includes other changes triggered by working on the tabs:
- The Subscriptions page (for emails) had the tabs along the top, but wasn't listed among them, resulting in an odd look with no active tab. I've added a tab for Subscriptions to fix this, and removed the right hand panel for consistency with the other tabs.
- The tabs now take up enough horizontal space that reading through them takes a while and they run on to two lines on smaller screens or at higher zoom levels. I've reduced their width with the following changes:
  - Removed the icon from the "Profile" tab.
  - Changed "Vote Summary" to "Votes".
  - Changed "Notifications" to "Inbox".
  - Changed "Subscriptions" to "Email".
  - Changed "All Communities" to "Network".

Let me know if you'd prefer the Subscriptions page to be an independent page with no tabs along the top, or if you'd prefer to avoid any of these width reducing changes.