### PR TITLE
Show dangerous user mod tools menu items in red

### DIFF
--- a/app/views/shared/_user_mod_sidebar.html.erb
+++ b/app/views/shared/_user_mod_sidebar.html.erb
@@ -67,7 +67,7 @@
           Compare PII
         <% end %>
         <%= link_to mod_delete_path(user),
-                    class: "menu--item #{current_page?(mod_delete_path(user)) ? 'is-active' : ''}" do %>
+                    class: "menu--item #{current_page?(mod_delete_path(user)) ? 'is-active' : 'is-red'}" do %>
           <i class="fas fa-trash fa-fw"></i>
           Delete Community Profile
         <% end %>
@@ -75,12 +75,12 @@
         <% if current_user.at_least_global_moderator? %>
         <div class="menu--heading">Global Mod Tools</div>
         <%= link_to mod_delete_network_account_path(user),
-                    class: "menu--item #{current_page?(mod_delete_network_account_path(user)) ? 'is-active' : ''}" do %>
+                    class: "menu--item #{current_page?(mod_delete_network_account_path(user)) ? 'is-active' : 'is-red'}" do %>
           <i class="fas fa-skull fa-fw"></i>
           Delete Network Account
         <% end %>
         <%= link_to mod_failban_path(user),
-                    class: "menu--item #{current_page?(mod_failban_path(user)) ? 'is-active' : ''}" do %>
+                    class: "menu--item #{current_page?(mod_failban_path(user)) ? 'is-active' : 'is-red'}" do %>
           <i class="fas fa-eye-slash fa-fw"></i>
           Feed to STAT
         <% end %>


### PR DESCRIPTION
Following a suggestion during review of #2063 this applies a red colour to the links in the left hand panel of the user moderator tools tab of the user page.

<img width="540" height="704" alt="Menu items showing grey or red for dangerous items or blue background for the active item" src="https://github.com/user-attachments/assets/8802e8ce-93d0-4cbd-a42c-67f0e57ad526" />

This uses the `.is-red` class, which for links is darkened by 25%. I've left this as is for now, but I'd like feedback on which of the following approaches to take:

- Use this same darkened red (as pictured) for menu item links as any other links.
- Make the red brighter just for menu items.
- Make the red brighter for all links.

The red text is only applied for menu items that are not the active one, since once active there is red text in the specific tab content. Active menu items show with a blue background regardless of whether dangerous. Would you prefer this or to change to a red background?