### PR TITLE
Normalize post body_markdown newlines

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -31,6 +31,10 @@ class Post < ApplicationRecord
 
   serialize :tags_cache, coder: YAML, type: Array
 
+  normalizes :body_markdown, with: -> body_markdown {
+    body_markdown.encode(body_markdown.encoding, universal_newline: true)
+  }
+
   validates :body, presence: true, length: { maximum: 65_535 }
   validates :body_markdown, presence: true, length: { maximum: 30_000 }
   validates :doc_slug, uniqueness: { scope: [:community_id], case_sensitive: false }, if: -> { doc_slug.present? }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -31,7 +31,7 @@ class Post < ApplicationRecord
 
   serialize :tags_cache, coder: YAML, type: Array
 
-  normalizes :body_markdown, with: -> body_markdown {
+  normalizes :body_markdown, with: lambda { |body_markdown|
     body_markdown.encode(body_markdown.encoding, universal_newline: true)
   }
 

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -102,7 +102,7 @@ class PostTest < ActiveSupport::TestCase
       ['a' * 30_001, '<p>body_markdown is too long</p>', false],
       ['body is too long', 'a' * 65_536, false],
       ["a\r\n" * 15_000, '<p>body_markdown is too long before converting newlines to \n</p>', true],
-      ["a\r\n" * 15_000 + 'a', '<p>body_markdown is too long even after converting newlines to \n</p>', false]
+      ["#{"a\r\n" * 15_000}a", '<p>body_markdown is too long even after converting newlines to \n</p>', false]
     ].each do |test_case|
       post = Post.new(shared_params.merge({ body_markdown: test_case.first,
                                             body: test_case.second }))

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -100,7 +100,9 @@ class PostTest < ActiveSupport::TestCase
       ['# Heading', '<h1>Heading</h1>', true],
       ['a' * 30_000, 'a' * 65_535, true],
       ['a' * 30_001, '<p>body_markdown is too long</p>', false],
-      ['body is too long', 'a' * 65_536, false]
+      ['body is too long', 'a' * 65_536, false],
+      ["a\r\n" * 15_000, '<p>body_markdown is too long before converting newlines to \n</p>', true],
+      ["a\r\n" * 15_000 + 'a', '<p>body_markdown is too long even after converting newlines to \n</p>', false]
     ].each do |test_case|
       post = Post.new(shared_params.merge({ body_markdown: test_case.first,
                                             body: test_case.second }))


### PR DESCRIPTION
Fixes #2115 

Normalizes the `body_markdown` field in the post model so that newlines are all `\n`.

Applied only to this one field that was raised in #2115 for now, but let me know any other places you would also like to see this normalization, or if there's a preferred general approach. Provided your suggested approach doesn't clash with this, I'm hoping to get the specific fix merged and deployed first, then apply anything further separately once the bug is no longer holding up a question being posted.