### PR TITLE
Add test to fail when an edit is only line ending style changes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -446,7 +446,7 @@ class ApplicationController < ActionController::Base
   end
 
   def normalize_if_string(maybe_string)
-    return maybe_string unless maybe_string.is_a? String
+    return maybe_string unless maybe_string.is_a?(String)
 
     maybe_string.encode(maybe_string.encoding, universal_newline: true).strip
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -444,4 +444,12 @@ class ApplicationController < ActionController::Base
   def request_authenticity_tokens
     super << csrf_token_storage_strategy.fetch(request)
   end
+
+  def normalize_if_string(potential_string)
+    if potential_string.is_a? String
+      potential_string.encode(potential_string.encoding, universal_newline: true).strip
+    else
+      potential_string
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -446,10 +446,8 @@ class ApplicationController < ActionController::Base
   end
 
   def normalize_if_string(maybe_string)
-    if maybe_string.is_a? String
-      maybe_string.encode(maybe_string.encoding, universal_newline: true).strip
-    else
-      maybe_string
-    end
+    return maybe_string unless maybe_string.is_a? String
+
+    maybe_string.encode(maybe_string.encoding, universal_newline: true).strip
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -445,11 +445,11 @@ class ApplicationController < ActionController::Base
     super << csrf_token_storage_strategy.fetch(request)
   end
 
-  def normalize_if_string(potential_string)
-    if potential_string.is_a? String
-      potential_string.encode(potential_string.encoding, universal_newline: true).strip
+  def normalize_if_string(maybe_string)
+    if maybe_string.is_a? String
+      maybe_string.encode(maybe_string.encoding, universal_newline: true).strip
     else
-      potential_string
+      maybe_string
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -445,7 +445,7 @@ class ApplicationController < ActionController::Base
     super << csrf_token_storage_strategy.fetch(request)
   end
 
-  def normalize_if_string(maybe_string)
+  def normalize(maybe_string)
     return maybe_string unless maybe_string.is_a?(String)
 
     maybe_string.encode(maybe_string.encoding, universal_newline: true).strip

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -219,7 +219,7 @@ class PostsController < ApplicationController
     body_rendered = helpers.rendered_post(:post, :body_markdown)
     new_tags_cache = params[:post][:tags_cache]&.reject(&:empty?)
 
-    if edit_post_params.to_h.all? { |k, v| normalize_if_string(@post.send(k)) == normalize_if_string(v) }
+    if edit_post_params.to_h.all? { |k, v| normalize(@post.send(k)) == normalize(v) }
       flash[:danger] = helpers.i18ns('posts.no_edit_changes')
       return redirect_to post_path(@post)
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -714,7 +714,7 @@ class PostsController < ApplicationController
 
   def normalize_if_string(potential_string)
     if potential_string.is_a? String
-      potential_string.encode(potential_string.encoding, universal_newline: true).strip()
+      potential_string.encode(potential_string.encoding, universal_newline: true).strip
     else
       potential_string
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -219,7 +219,7 @@ class PostsController < ApplicationController
     body_rendered = helpers.rendered_post(:post, :body_markdown)
     new_tags_cache = params[:post][:tags_cache]&.reject(&:empty?)
 
-    if edit_post_params.to_h.all? { |k, v| @post.send(k) == v }
+    if edit_post_params.to_h.all? { |k, v| normalize_if_string(@post.send(k)) == normalize_if_string(v) }
       flash[:danger] = helpers.i18ns('posts.no_edit_changes')
       return redirect_to post_path(@post)
     end
@@ -711,6 +711,14 @@ class PostsController < ApplicationController
   end
 
   private
+
+  def normalize_if_string(potential_string)
+    if potential_string.is_a? String
+      potential_string.encode(potential_string.encoding, universal_newline: true).strip()
+    else
+      potential_string
+    end
+  end
 
   def permitted
     [:post_type_id, :category_id, :parent_id, :title, :body_markdown, :license_id,

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -712,14 +712,6 @@ class PostsController < ApplicationController
 
   private
 
-  def normalize_if_string(potential_string)
-    if potential_string.is_a? String
-      potential_string.encode(potential_string.encoding, universal_newline: true).strip
-    else
-      potential_string
-    end
-  end
-
   def permitted
     [:post_type_id, :category_id, :parent_id, :title, :body_markdown, :license_id,
      :doc_slug, :help_category, :help_ordering]

--- a/test/controllers/posts/update_test.rb
+++ b/test/controllers/posts/update_test.rb
@@ -77,10 +77,10 @@ class PostsControllerTest < ActionController::TestCase
     post = posts(:question_three)
     before_history = PostHistory.where(post: post).count
     bm = post.body_markdown
-    body_markdown_with_CRLF = bm.encode(bm.encoding, normalize_newlines: true).split("\n").join("\r\n")
+    body_markdown_with_crlf = bm.encode(bm.encoding, normalize_newlines: true).split("\n").join("\r\n")
     patch :update, params: { id: post.id,
                              post: { title: post.title,
-                                     body_markdown: body_markdown_with_CRLF,
+                                     body_markdown: body_markdown_with_crlf,
                                      tags_cache: post.tags_cache } }
     after_history = PostHistory.where(post: post).count
     assert_response(:found)

--- a/test/controllers/posts/update_test.rb
+++ b/test/controllers/posts/update_test.rb
@@ -76,16 +76,20 @@ class PostsControllerTest < ActionController::TestCase
     sign_in users(:standard_user)
     post = posts(:question_three)
     before_history = PostHistory.where(post: post).count
+    bm = post.body_markdown
+    body_markdown_with_CRLF = bm.encode(bm.encoding, normalize_newlines: true).split("\n").join("\r\n")
     patch :update, params: { id: post.id,
-                              post: { title: post.title,
-                                      body_markdown: post.body_markdown.split("\n").join("\r\n"),
-                                      tags_cache: post.tags_cache } }
+                             post: { title: post.title,
+                                     body_markdown: body_markdown_with_CRLF,
+                                     tags_cache: post.tags_cache } }
     after_history = PostHistory.where(post: post).count
     assert_response(:found)
     assert_redirected_to post_path(post)
     assert_not_nil assigns(:post)
     assert_not_nil flash[:danger]
-    assert_equal before_history, after_history, 'PostHistory event incorrectly created on no-change update'
+    assert_equal before_history,
+                 after_history,
+                 'PostHistory event incorrectly created on line-ending-change-only update'
   end
 
   test 'cannot update locked post' do

--- a/test/controllers/posts/update_test.rb
+++ b/test/controllers/posts/update_test.rb
@@ -72,6 +72,22 @@ class PostsControllerTest < ActionController::TestCase
     assert_equal before_history, after_history, 'PostHistory event incorrectly created on no-change update'
   end
 
+  test 'update rejects edit with no change apart from line ending style' do
+    sign_in users(:standard_user)
+    post = posts(:question_three)
+    before_history = PostHistory.where(post: post).count
+    patch :update, params: { id: post.id,
+                              post: { title: post.title,
+                                      body_markdown: post.body_markdown.split("\n").join("\r\n"),
+                                      tags_cache: post.tags_cache } }
+    after_history = PostHistory.where(post: post).count
+    assert_response(:found)
+    assert_redirected_to post_path(post)
+    assert_not_nil assigns(:post)
+    assert_not_nil flash[:danger]
+    assert_equal before_history, after_history, 'PostHistory event incorrectly created on no-change update'
+  end
+
   test 'cannot update locked post' do
     sign_in users(:standard_user)
     before_history = PostHistory.where(post: posts(:locked)).count

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -40,6 +40,35 @@ question_two:
   upvote_count: 0
   downvote_count: 0
 
+question_three:
+  post_type: question
+  title: Q3 - This is test question number three
+  body: |
+      <p>This is the body of test question three.</p>
+      <p>Note that there are newlines for testing purposes.</p>
+      <p>This is important.</p>
+  body_markdown: |
+      This is the body of test question three.
+
+      Note that there are newlines for testing purposes.
+
+      This is important.
+  tags_cache:
+    - discussion
+    - support
+    - bug
+  tags:
+    - discussion
+    - support
+    - bug
+  score: 0.5
+  user: standard_user
+  community: sample
+  category: main
+  license: cc_by_sa
+  upvote_count: 0
+  downvote_count: 0
+
 new_user_question:
   post_type: question
   title: Q1 - This is test question number one


### PR DESCRIPTION
Fixes #2126 

A post edit that only changes line endings will now be rejected. I've aimed to make this compatible with existing posts that may have `body_markdown` using any type of line endings, and newer posts that will have exclusively normalized `\n` (LF) line endings.