### PR TITLE
Manually exclude line ending changes from diffs

### DIFF
--- a/app/models/concerns/line_ending_normalization.rb
+++ b/app/models/concerns/line_ending_normalization.rb
@@ -4,5 +4,4 @@ module LineEndingNormalization
   def normalize_newlines(text)
     text.encode(text.encoding, universal_newline: true).strip
   end
-
 end

--- a/app/models/concerns/line_ending_normalization.rb
+++ b/app/models/concerns/line_ending_normalization.rb
@@ -1,0 +1,8 @@
+module LineEndingNormalization
+  extend ActiveSupport::Concern
+
+  def normalize_newlines(text)
+    text.encode(text.encoding, universal_newline: true).strip
+  end
+
+end

--- a/app/models/concerns/post_normalizations.rb
+++ b/app/models/concerns/post_normalizations.rb
@@ -1,10 +1,6 @@
 module PostNormalizations
   extend ActiveSupport::Concern
 
-  included do
-    normalizes :before_state, :after_state, with: ->(text) { normalize_newlines(text) }
-  end
-
   class_methods do
     def normalize_newlines(text)
       text.encode(text.encoding, universal_newline: true).strip

--- a/app/models/concerns/post_normalizations.rb
+++ b/app/models/concerns/post_normalizations.rb
@@ -1,4 +1,4 @@
-module LineEndingNormalization
+module PostNormalizations
   extend ActiveSupport::Concern
 
   def normalize_newlines(text)

--- a/app/models/concerns/post_normalizations.rb
+++ b/app/models/concerns/post_normalizations.rb
@@ -2,7 +2,7 @@ module PostNormalizations
   extend ActiveSupport::Concern
 
   included do
-    normalizes :before_state, :after_state, with: -> text { normalize_newlines(text) }
+    normalizes :before_state, :after_state, with: ->(text) { normalize_newlines(text) }
   end
 
   class_methods do

--- a/app/models/concerns/post_normalizations.rb
+++ b/app/models/concerns/post_normalizations.rb
@@ -1,7 +1,13 @@
 module PostNormalizations
   extend ActiveSupport::Concern
 
-  def normalize_newlines(text)
-    text.encode(text.encoding, universal_newline: true).strip
+  included do
+    normalizes :before_state, :after_state, with: -> text { normalize_newlines(text) }
+  end
+
+  class_methods do
+    def normalize_newlines(text)
+      text.encode(text.encoding, universal_newline: true).strip
+    end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,7 @@
 class Post < ApplicationRecord
   include CommunityRelated
-  include LineEndingNormalization
   include Lockable
+  include PostNormalizations
   include PostValidations
   include SoftDeletable
   include Timestamped

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,6 @@
 class Post < ApplicationRecord
   include CommunityRelated
+  include LineEndingNormalization
   include Lockable
   include PostValidations
   include SoftDeletable

--- a/app/models/post_history.rb
+++ b/app/models/post_history.rb
@@ -12,9 +12,6 @@ class PostHistory < ApplicationRecord
   scope :of_type, ->(name) { joins(:post_history_type).where(post_history_types: { name: name }) }
   scope :on_undeleted, -> { joins(:post).where(posts: { deleted: false }) }
 
-  normalizes :before_state, with: :normalize_newlines
-  normalizes :after_state, with: :normalize_newlines
-
   def before_tags
     tags.where(post_history_tags: { relationship: 'before' })
   end

--- a/app/models/post_history.rb
+++ b/app/models/post_history.rb
@@ -1,4 +1,5 @@
 class PostHistory < ApplicationRecord
+  include LineEndingNormalization
   include PostRelated
   include EditsValidations
 
@@ -11,11 +12,8 @@ class PostHistory < ApplicationRecord
   scope :of_type, ->(name) { joins(:post_history_type).where(post_history_types: { name: name }) }
   scope :on_undeleted, -> { joins(:post).where(posts: { deleted: false }) }
 
-  normalize_newlines = lambda { |text|
-    text.encode(text.encoding, universal_newline: true)
-  }
-  normalizes :before_state, with: normalize_newlines
-  normalizes :after_state, with: normalize_newlines
+  normalizes :before_state, with: :normalize_newlines
+  normalizes :after_state, with: :normalize_newlines
 
   def before_tags
     tags.where(post_history_tags: { relationship: 'before' })

--- a/app/models/post_history.rb
+++ b/app/models/post_history.rb
@@ -1,5 +1,5 @@
 class PostHistory < ApplicationRecord
-  include LineEndingNormalization
+  include PostNormalizations
   include PostRelated
   include EditsValidations
 

--- a/app/models/post_history.rb
+++ b/app/models/post_history.rb
@@ -12,6 +12,8 @@ class PostHistory < ApplicationRecord
   scope :of_type, ->(name) { joins(:post_history_type).where(post_history_types: { name: name }) }
   scope :on_undeleted, -> { joins(:post).where(posts: { deleted: false }) }
 
+  normalizes :before_state, :after_state, with: ->(text) { normalize_newlines(text) }
+
   def before_tags
     tags.where(post_history_tags: { relationship: 'before' })
   end

--- a/app/views/post_history/_diff.html.erb
+++ b/app/views/post_history/_diff.html.erb
@@ -1,8 +1,8 @@
 <div class="diff">
   <% if before.present? && after.present? %>
     <% if before.is_a?(String) && after.is_a?(String) %>
-      <% before = post.normalize_newlines(before) %>
-      <% after = post.normalize_newlines(after) %>
+      <% before = Post.normalize_newlines(before) %>
+      <% after = Post.normalize_newlines(after) %>
       <% diff = Diffy::SplitDiff.new(before, after, format: :html) %>
       <div class="diff-section">
         <div class="diff-old is-changed raw-markdown">

--- a/app/views/post_history/_diff.html.erb
+++ b/app/views/post_history/_diff.html.erb
@@ -1,7 +1,9 @@
 <div class="diff">
   <% if before.present? && after.present? %>
     <% if before.is_a?(String) && after.is_a?(String) %>
-      <% diff = Diffy::SplitDiff.new(before, after, format: :html, ignore_crlf: true) %>
+      <% before = before.encode(before.encoding, universal_newline: true).strip %>
+      <% after = after.encode(after.encoding, universal_newline: true).strip %>
+      <% diff = Diffy::SplitDiff.new(before, after, format: :html) %>
       <div class="diff-section">
         <div class="diff-old is-changed raw-markdown">
           <%= raw(diff.left) %>

--- a/app/views/post_history/_diff.html.erb
+++ b/app/views/post_history/_diff.html.erb
@@ -1,8 +1,8 @@
 <div class="diff">
   <% if before.present? && after.present? %>
     <% if before.is_a?(String) && after.is_a?(String) %>
-      <% before = before.encode(before.encoding, universal_newline: true).strip %>
-      <% after = after.encode(after.encoding, universal_newline: true).strip %>
+      <% before = post.normalize_newlines(before) %>
+      <% after = post.normalize_newlines(after) %>
       <% diff = Diffy::SplitDiff.new(before, after, format: :html) %>
       <div class="diff-section">
         <div class="diff-old is-changed raw-markdown">

--- a/test/controllers/posts/update_test.rb
+++ b/test/controllers/posts/update_test.rb
@@ -77,7 +77,7 @@ class PostsControllerTest < ActionController::TestCase
     post = posts(:question_three)
     before_history = PostHistory.where(post: post).count
     bm = post.body_markdown
-    body_markdown_with_crlf = bm.encode(bm.encoding, normalize_newlines: true).split("\n").join("\r\n")
+    body_markdown_with_crlf = bm.encode(bm.encoding, universal_newline: true).split("\n").join("\r\n")
     patch :update, params: { id: post.id,
                              post: { title: post.title,
                                      body_markdown: body_markdown_with_crlf,


### PR DESCRIPTION
It seems Diffy's `ignore_crlf` option does not work consistently so this removes its use and instead passes normalized `before` and `after` strings to Diffy, removing the need for the option.