### PR TITLE
add entry in audit log for automatic ability grants

### DIFF
--- a/app/models/community_user.rb
+++ b/app/models/community_user.rb
@@ -124,6 +124,10 @@ class CommunityUser < ApplicationRecord
     # If not sandbox mode, create new privilege entry
     grant_privilege!(internal_id) unless sandbox
     recalc_trust_level unless sandbox
+
+    AuditLog.admin_audit(event_type: 'ability_grant', related: user,
+                         user: User.system,
+                         comment: priv.name)
     true
   end
 


### PR DESCRIPTION
Fixes https://github.com/codidact/qpixel/issues/2132.

If moderators grant or revoke abilities manually, we add entries in the audit log.  With this change we also create entries when the system does it, i.e. when abilities are recalculated.  Sample entry:

<img width="1239" height="256" alt="screenshot" src="https://github.com/user-attachments/assets/207371ea-4c33-4c00-a864-20a5fbbfb515" />

This does create entries for new users too.  Should I exclude Participate to cut down on log clutter, or keep it for consistency and as an easy way to see new signups?  Only admins can see these entries.
