### PR TITLE
Change editor controls to properly edit block markdown

### DIFF
--- a/app/assets/javascripts/markdown.js
+++ b/app/assets/javascripts/markdown.js
@@ -1,7 +1,5 @@
 $(() => {
-  /** @typedef {{apply: function(JQuery<HTMLTextAreaElement | HTMLInputElement>): void}} Action */
-
-  /** @implements {Action} */
+  /** @implements {MarkdownAction} */
   class InlineAction {
     constructor(start, end = '') {
       this.start = start;
@@ -20,7 +18,7 @@ $(() => {
     }
   }
 
-  /** @implements {Action} */
+  /** @implements {MarkdownAction} */
   class BlockAction {
     /**
      * @param {function(string, number): string} callback
@@ -78,7 +76,7 @@ $(() => {
   }
 
   /**
-   * @type {{[key: string]: Action}}
+   * @type {{[key: string]: MarkdownAction}}
    */
   const actions = {
     bold: new InlineAction('**', '**'),

--- a/app/assets/javascripts/markdown.js
+++ b/app/assets/javascripts/markdown.js
@@ -64,10 +64,12 @@ $(() => {
       for (const line of val.split('\n')) {
         const begin = idx;
         const end = begin + line.length;
-        if (begin <= preSelectionStart && preSelectionStart <= end)
+        if (begin <= preSelectionStart && preSelectionStart <= end) {
           startPos = begin;
-        if (begin <= preSelectionEnd && preSelectionEnd <= end)
+        }
+        if (begin <= preSelectionEnd && preSelectionEnd <= end) {
           endPos = end;
+        }
         // include newline
         idx = end + 1;
       }

--- a/app/assets/javascripts/markdown.js
+++ b/app/assets/javascripts/markdown.js
@@ -107,15 +107,13 @@ $(() => {
   $(document).on('click', '.js-markdown-tool', (ev) => {
     const $tgt = $(ev.target);
     const $button = $tgt.is('a') ? $tgt : $tgt.parents('a');
-    const action = $button.attr('data-action');
+    const action = /** @type {string} */ ($button.attr('data-action'));
 
     /** @type {JQuery<HTMLTextAreaElement | HTMLInputElement>} */
     const $field = $('.js-post-field');
 
-    if (action && action in actions) {
-      actions[action].apply($field);
-      $field.trigger("focus");
-    }
+    actions[action].apply($field);
+    $field.trigger("focus");
   });
 
   QPixel.DOM?.addSelectorListener('keypress', '#markdown-link-name, #markdown-link-url', (ev) => {

--- a/app/assets/javascripts/markdown.js
+++ b/app/assets/javascripts/markdown.js
@@ -1,6 +1,13 @@
 $(() => {
-  /** @implements {MarkdownAction} */
+  /**
+   * A markdown action which places markings before and after the current selection
+   * @implements {MarkdownAction}
+   */
   class InlineAction {
+    /**
+     * @param {string} start Text to place before the selection
+     * @param {string} end Text to place after the selection
+     */
     constructor(start, end = '') {
       this.start = start;
       this.end = end;
@@ -18,11 +25,14 @@ $(() => {
     }
   }
 
-  /** @implements {MarkdownAction} */
+  /**
+   * A markdown action which edits a range of complete lines
+   * @implements {MarkdownAction}
+   */
   class BlockAction {
     /**
-     * @param {function(string, number): string} callback
-     * @param {boolean} skip_blanks
+     * @param {function(string, number): string} callback Function to map each line
+     * @param {boolean} skip_blanks Whether to skip blank lines (this affects indexing)
      */
     constructor(callback, skip_blanks) {
       this.callback = callback;
@@ -49,8 +59,11 @@ $(() => {
 
 
     /**
+     * Returns the range covering all lines touched by the field's selection.
+     * The returned range is an expansion of the initial selection, snapped to
+     * the line start of the initial line and line end of the final line.
      * @param {JQuery<HTMLTextAreaElement | HTMLInputElement>} $field 
-     * @returns {[number, number]} 
+     * @returns {[start: number, end: number]} Start and end offsets of the block.
      */
     #getBlockSelection($field) {
       const preSelectionStart = $field[0].selectionStart;

--- a/app/assets/javascripts/markdown.js
+++ b/app/assets/javascripts/markdown.js
@@ -1,4 +1,96 @@
 $(() => {
+  /** @typedef {{apply: function(JQuery<HTMLTextAreaElement | HTMLInputElement>): void}} Action */
+
+  /** @implements {Action} */
+  class InlineAction {
+    constructor(start, end = '') {
+      this.start = start;
+      this.end = end;
+    }
+
+    /**
+     * @param {JQuery<HTMLTextAreaElement | HTMLInputElement>} $field 
+     */
+    apply($field) {
+      const preSelectionStart = $field[0].selectionStart;
+      const preSelectionEnd = $field[0].selectionEnd;
+      QPixel.MD.insertIntoField($field, this.start, this.end);
+      $field[0].selectionStart = preSelectionStart + this.start.length;
+      $field[0].selectionEnd = preSelectionEnd + this.end.length;
+    }
+  }
+
+  /** @implements {Action} */
+  class BlockAction {
+    /**
+     * @param {function(string, number): string} callback
+     * @param {boolean} skip_blanks
+     */
+    constructor(callback, skip_blanks) {
+      this.callback = callback;
+      this.skip_blanks = skip_blanks;
+    }
+
+    /**
+     * @param {JQuery<HTMLTextAreaElement | HTMLInputElement>} $field 
+     */
+    apply($field) {
+      // Override the selection range so it encompasses full lines
+      const [startPos, endPos] = this.#getBlockSelection($field);
+      $field[0].setSelectionRange(startPos, endPos);
+      const lines = $field.val().substring(startPos, endPos).split('\n');
+      let jdx = 0;
+      for (let idx = 0; idx < lines.length; ++idx) {
+        if (lines[idx] != '' || !this.skip_blanks) {
+          lines[idx] = this.callback(lines[idx], jdx);
+          ++jdx;
+        }
+      }
+      $field[0].setRangeText(lines.join('\n'));
+    }
+
+
+    /**
+     * @param {JQuery<HTMLTextAreaElement | HTMLInputElement>} $field 
+     * @returns {[number, number]} 
+     */
+    #getBlockSelection($field) {
+      const preSelectionStart = $field[0].selectionStart;
+      const preSelectionEnd = $field[0].selectionEnd;
+      const val = $field.val();
+      // Not particularly efficient, but seems to work fine
+      let startPos, endPos;
+      let idx = 0;
+      for (const line of val.split('\n')) {
+        const begin = idx;
+        const end = begin + line.length;
+        if (begin <= preSelectionStart && preSelectionStart <= end)
+          startPos = begin;
+        if (begin <= preSelectionEnd && preSelectionEnd <= end)
+          endPos = end;
+        // include newline
+        idx = end + 1;
+      }
+      return [startPos, endPos];
+    }
+  }
+
+  /**
+   * @type {{[key: string]: Action}}
+   */
+  const actions = {
+    bold: new InlineAction('**', '**'),
+    italic: new InlineAction('_', '_'),
+    code: new InlineAction('`', '`'),
+    quote: new BlockAction(l => `> ${l}`, false),
+    bullet: new BlockAction(l => `* ${l}`, true),
+    numbered: new BlockAction((l, i) => `${i + 1}. ${l}`, true),
+    heading: new BlockAction(l => `# ${l}`, true),
+    hr: new InlineAction('\n\n-----\n\n'),
+    table: new InlineAction('\n\n| Title1 | Title2 |\n|- | - |\n| row1_1 | row1_2 |\n\n'),
+    mathjax: new InlineAction('$', '$'),
+  };
+
   $(document).on('click', '.js-markdown-tool', (ev) => {
     const $tgt = $(ev.target);
     const $button = $tgt.is('a') ? $tgt : $tgt.parents('a');
@@ -7,25 +99,9 @@ $(() => {
     /** @type {JQuery<HTMLTextAreaElement | HTMLInputElement>} */
     const $field = $('.js-post-field');
 
-    const actions = {
-      bold: ['**', '**'],
-      italic: ['_', '_'],
-      code: ['`', '`'],
-      quote: ['\n > ', null],
-      bullet: ['\n * ', null],
-      numbered: ['\n 1. ', null],
-      heading: ['\n# ', null],
-      hr: ['\n\n-----\n\n', null],
-      table: ['\n\n| Title1 | Title2 |\n|- | - |\n| row1_1 | row1_2 |\n\n', null],
-      mathjax: ['$', '$'],
-    };
-
-    if (Object.keys(actions).indexOf(action) !== -1) {
-      const preSelection = [$field[0].selectionStart, $field[0].selectionEnd];
-      QPixel.MD.insertIntoField($field, actions[action][0], actions[action][1]);
-      $field.focus();
-      $field[0].selectionStart = preSelection[0] + actions[action][0].length;
-      $field[0].selectionEnd = preSelection[1] + actions[action][0].length;
+    if (action && action in actions) {
+      actions[action].apply($field);
+      $field.trigger("focus");
     }
   });
 

--- a/global.d.ts
+++ b/global.d.ts
@@ -32,6 +32,10 @@ interface DelegatedListener {
 
 type ClassWatcherCallback = (element: HTMLElement) => void;
 
+interface MarkdownAction {
+  apply($field: JQuery<HTMLTextAreaElement | HTMLInputElement>): void
+}
+
 interface QPixelDOM {
   // private properties
   _delegatedListeners?: DelegatedListener[];


### PR DESCRIPTION
Fixes #2051

Block markdown should place the markdown symbols at the start of each line, rather than in the middle, even if that's where the selection is.

```md
line 1

line 2

line 3
```

Blockquoted

```md
> line 1
> 
> line 2
> 
> line 3
```

Numbered list

```md
1. line 1

2. line 2

3. line 3
```