### PR TITLE
Add an editor button to insert `<details>` element for spoilers

### DIFF
--- a/app/assets/javascripts/markdown.js
+++ b/app/assets/javascripts/markdown.js
@@ -102,6 +102,7 @@ $(() => {
     hr: new InlineAction('\n\n-----\n\n'),
     table: new InlineAction('\n\n| Title1 | Title2 |\n|- | - |\n| row1_1 | row1_2 |\n\n'),
     mathjax: new InlineAction('$', '$'),
+    spoiler: new InlineAction('\n\n<details>\n<summary>Spoiler</summary>\n', '\n</details>\n\n'),
   };
 
   $(document).on('click', '.js-markdown-tool', (ev) => {

--- a/app/views/shared/_markdown_tools.html.erb
+++ b/app/views/shared/_markdown_tools.html.erb
@@ -77,6 +77,9 @@
         <%= md_list_item action: 'hr', label: 'Horizontal line' do %>
           <i class="fas fa-fw fa-level-down-alt"></i> Horizontal line
         <% end %>
+        <%= md_list_item action: 'spoiler', label: 'Spoiler' do %>
+          <i class="fas fa-fw fa-eye-slash"></i> Spoiler
+        <% end %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Closes #418 

Since it seems we've settled on using the `<details>` element for spoiler text, this adds an editor button to automatically insert the HTML for it. I put the button in the "miscellaneous" tooling, with the header and table tools since it doesn't really seem like something most people will need often.

<img width="788" height="485" alt="image" src="https://github.com/user-attachments/assets/ee6a9638-38c8-4179-9767-65619f8bd5ab" />

Highlighting "This is some spoiler text" and clicking the button results in the following HTML.

```md


<details>
<summary>Spoiler</summary>
This is some spoiler text
</details>


```

Note: I copied the "table" button behavior of adding two newlines before and after the inserted HTML. We don't have inline spoiler text, so if a user attempts to do so, they will get the following result.

```md
This is some 

<details>
<summary>Spoiler</summary>
spoiler
</details>

 text
```