### PR TITLE
Fix system test not uploading screenshots on failure

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -149,7 +149,7 @@ jobs:
       - run: bundle exec rails test:system
       - name: Upload screenshots
         uses: actions/upload-artifact@v4
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         with:
           name: screenshots-${{ matrix.ruby_version }}
           path: tmp/screenshots

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -149,6 +149,7 @@ jobs:
       - run: bundle exec rails test:system
       - name: Upload screenshots
         uses: actions/upload-artifact@v4
+        if: ${{ always() }}
         with:
           name: screenshots-${{ matrix.ruby_version }}
           path: tmp/screenshots


### PR DESCRIPTION
When system tests fail, the step that is supposed to upload screenshots is cancelled

Testing the change is too much work for little to no benefit given the flaky nature of the failing tests - I'll keep an eye on failing actions (as usual) to see if the step starts to succeed - it should, but you never know.

[Reference](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#always) for those interested in how it works