### PR TITLE
Advertisement helper improvements

### DIFF
--- a/app/helpers/advertisement_helper.rb
+++ b/app/helpers/advertisement_helper.rb
@@ -91,7 +91,7 @@ module AdvertisementHelper
       icon = Magick::ImageList.new("./app/assets/images/#{File.basename(expanded_path)}")
     else
       icon = Magick::ImageList.new
-      icon_path_content = URI.open(icon_path).read # rubocop:disable Security/Open
+      icon_path_content = URI.parse(icon_path).open.read
       icon.from_blob(icon_path_content)
     end
 

--- a/test/helpers/advertisement_helper_test.rb
+++ b/test/helpers/advertisement_helper_test.rb
@@ -7,6 +7,8 @@ class AdvertisementHelperTest < ActionView::TestCase
   setup do
     @external_png = File.open(Rails.root.join('app/assets/images/logo.png'))
     stub_request(:get, 'https://example.com/external.png').to_return(body: @external_png)
+
+    FileUtils.rm_f(command_execution_test_filepath)
   end
 
   teardown do
@@ -23,5 +25,17 @@ class AdvertisementHelperTest < ActionView::TestCase
   test ':community_icon should correctly handle external URLs' do
     icon = community_icon('https://example.com/external.png')
     assert icon.is_a?(Magick::ImageList)
+  end
+
+  test ':community_icon should not allow system command execution' do
+    community_icon('| touch "tmp/oops.txt"')
+
+    assert_not File.exist?(command_execution_test_filepath)
+  end
+
+  private
+
+  def command_execution_test_filepath
+    Rails.root.join('tmp/oops.txt')
   end
 end


### PR DESCRIPTION
- [ ] Prevent malicious icon_path from executing system commands - See [Security/Open](https://docs.rubocop.org/rubocop/latest/cops_security.html#securityopen) cop for details;
- [ ] Only allow safe URIs (HTTP, HTTP(S), or relative) for `icon_path`;